### PR TITLE
fix(oauth): usar UUID en JWT subject y agregar fallback

### DIFF
--- a/backend/api/app/core/dependencies.py
+++ b/backend/api/app/core/dependencies.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+from uuid import UUID
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError
@@ -28,7 +29,16 @@ async def get_current_user(
     except JWTError:
         raise credentials_exception
     
-    user = db.query(User).filter(User.id == token_data.sub).first()
+    user = None
+    
+    # Intentar buscar por UUID (caso normal: sub = user.id)
+    try:
+        subject_as_uuid = UUID(token_data.sub)
+        user = db.query(User).filter(User.id == subject_as_uuid).first()
+    except (ValueError, TypeError):
+        # Fallback: buscar por email (tokens antiguos con sub = email)
+        user = db.query(User).filter(User.email == token_data.sub).first()
+    
     if user is None:
         raise credentials_exception
     

--- a/backend/api/app/services/google_oauth_service.py
+++ b/backend/api/app/services/google_oauth_service.py
@@ -196,8 +196,8 @@ class GoogleOAuthService:
         # 3. Crear/actualizar usuario en DB
         user = self.get_or_create_user(google_user)
         
-        # 4. Generar nuestro propio JWT
-        jwt_token = create_access_token(subject=user.email)
+        # 4. Generar nuestro propio JWT (usar UUID como subject)
+        jwt_token = create_access_token(subject=str(user.id))
         
         return {
             "access_token": jwt_token,


### PR DESCRIPTION
Cambiar subject=user.email a subject=str(user.id) en OAuth
- Agregar try/except en get_current_user para buscar por UUID o email
- Fixes error 500 en /auth/me después de login con Google