### PR TITLE
Feature/frontend backend timeline library flow integration

### DIFF
--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     gcc \
     postgresql-client \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Copiar requirements y instalar dependencias Python

--- a/backend/api/app/api/v1/endpoints/job.py
+++ b/backend/api/app/api/v1/endpoints/job.py
@@ -45,6 +45,10 @@ async def reframe_video(
         user_id=current_user.id,
         start_sec=body.start_sec,
         end_sec=body.end_sec,
+        crop_to_vertical=body.crop_to_vertical,
+        subtitles=body.subtitles,
+        face_tracking=body.face_tracking,
+        color_filter=body.color_filter,
     )
 
 

--- a/backend/api/app/api/v1/endpoints/job.py
+++ b/backend/api/app/api/v1/endpoints/job.py
@@ -107,5 +107,8 @@ async def get_my_clips(
     service: Annotated[JobService, Depends(get_job_service)],
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
     offset: Annotated[int, Query(ge=0)] = 0,
+    q: Annotated[
+        str | None, Query(description="Busqueda por nombre de archivo o id de job")
+    ] = None,
 ) -> UserClipsResponse:
-    return service.list_user_clips(current_user.id, limit=limit, offset=offset)
+    return service.list_user_clips(current_user.id, limit=limit, offset=offset, query=q)

--- a/backend/api/app/api/v1/endpoints/job.py
+++ b/backend/api/app/api/v1/endpoints/job.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 from uuid import UUID
-from fastapi import APIRouter, Depends, status, Path, Query
+from fastapi import APIRouter, Depends, Response, status, Path, Query
 from sqlalchemy.orm import Session
 from app.core.dependencies import get_current_active_user
 from app.database.session import get_db
@@ -9,6 +9,7 @@ from app.models.user import User
 from app.services.job_service import JobService
 from app.services.dependencies import get_job_service
 from app.schemas.job import (
+    UserClipDetailResponse,
     JobReframeResponse,
     JobStatusResponse,
     JobReframeRequest,
@@ -116,3 +117,33 @@ async def get_my_clips(
     ] = None,
 ) -> UserClipsResponse:
     return service.list_user_clips(current_user.id, limit=limit, offset=offset, query=q)
+
+
+@router.get(
+    "/{job_id}",
+    response_model=UserClipDetailResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Obtener clip propio",
+    description="Devuelve el detalle de un clip (job reframe) del usuario autenticado",
+)
+async def get_my_clip_by_id(
+    job_id: Annotated[UUID, Path(description="ID del clip/job")],
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[JobService, Depends(get_job_service)],
+) -> UserClipDetailResponse:
+    return service.get_user_clip(job_id, current_user.id)
+
+
+@router.delete(
+    "/{job_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Eliminar clip propio",
+    description="Elimina un clip generado (job reframe) del usuario autenticado",
+)
+async def delete_my_clip(
+    job_id: Annotated[UUID, Path(description="ID del clip/job")],
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[JobService, Depends(get_job_service)],
+) -> Response:
+    service.delete_user_clip(job_id, current_user.id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/api/app/api/v1/endpoints/job.py
+++ b/backend/api/app/api/v1/endpoints/job.py
@@ -1,15 +1,21 @@
 from typing import Annotated
 from uuid import UUID
-from fastapi import APIRouter, Depends, status, Path
+from fastapi import APIRouter, Depends, status, Path, Query
 from sqlalchemy.orm import Session
 from app.core.dependencies import get_current_active_user
 from app.database.session import get_db
 
-from app.services.queue_service import QueueService
 from app.models.user import User
 from app.services.job_service import JobService
 from app.services.dependencies import get_job_service
-from app.schemas.job import JobReframeResponse, JobStatusResponse, JobReframeRequest
+from app.schemas.job import (
+    JobReframeResponse,
+    JobStatusResponse,
+    JobReframeRequest,
+    JobAutoReframeRequest,
+    JobAutoReframeResponse,
+    UserClipsResponse,
+)
 
 router = APIRouter(prefix="/jobs", tags=["Jobs"])
 
@@ -24,22 +30,50 @@ router = APIRouter(prefix="/jobs", tags=["Jobs"])
         201: {"description": "Job creado"},
         400: {"description": "Archivo inválido"},
         401: {"description": "No autenticado"},
-        404: {"description": "Video no encontrado"}
-    }
+        404: {"description": "Video no encontrado"},
+    },
 )
 async def reframe_video(
     video_id: Annotated[UUID, Path(description="ID del Video")],
     body: JobReframeRequest,
     current_user: Annotated[User, Depends(get_current_active_user)],
-    service: Annotated[JobService, Depends(get_job_service)]
+    service: Annotated[JobService, Depends(get_job_service)],
 ) -> JobReframeResponse:
     """Crea un nuevo Job de REFRAME para el video subido (requiere autenticación)"""
     return service.reframe_video(
         video_id=video_id,
         user_id=current_user.id,
         start_sec=body.start_sec,
-        end_sec=body.end_sec
+        end_sec=body.end_sec,
     )
+
+
+@router.post(
+    "/reframe/{video_id}/auto",
+    response_model=JobAutoReframeResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Generar clips automáticos",
+    description="Genera varios jobs REFRAME para clips automáticos de un video",
+    responses={
+        201: {"description": "Jobs automáticos creados"},
+        401: {"description": "No autenticado"},
+        404: {"description": "Video no encontrado"},
+    },
+)
+async def auto_reframe_video(
+    video_id: Annotated[UUID, Path(description="ID del Video")],
+    body: JobAutoReframeRequest,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[JobService, Depends(get_job_service)],
+) -> JobAutoReframeResponse:
+    """Crea N jobs automáticos con segmentos sugeridos para shorts"""
+    return service.auto_reframe_video(
+        video_id=video_id,
+        user_id=current_user.id,
+        clips_count=body.clips_count,
+        clip_duration_sec=body.clip_duration_sec,
+    )
+
 
 @router.get(
     "/status/{job_id}",
@@ -50,12 +84,28 @@ async def reframe_video(
     responses={
         200: {"description": "Estado del Job devuelto exitosamente"},
         404: {"description": "Job no encontrado"},
-    }
+    },
 )
 async def get_job_status(
     job_id: Annotated[UUID, Path(description="ID del Job")],
     current_user: Annotated[User, Depends(get_current_active_user)],
-    service: Annotated[JobService, Depends(get_job_service)]
+    service: Annotated[JobService, Depends(get_job_service)],
 ) -> JobStatusResponse:
     """Devuelve el estado del Job (requiere autenticación)"""
     return service.get_job_status(job_id, current_user.id)
+
+
+@router.get(
+    "/my-clips",
+    response_model=UserClipsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Listar mis clips generados",
+    description="Devuelve los clips generados por el usuario autenticado",
+)
+async def get_my_clips(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[JobService, Depends(get_job_service)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> UserClipsResponse:
+    return service.list_user_clips(current_user.id, limit=limit, offset=offset)

--- a/backend/api/app/api/v1/endpoints/job.py
+++ b/backend/api/app/api/v1/endpoints/job.py
@@ -51,6 +51,7 @@ async def reframe_video(
         face_tracking=body.face_tracking,
         color_filter=body.color_filter,
         output_style=body.output_style,
+        content_profile=body.content_profile,
     )
 
 
@@ -79,6 +80,7 @@ async def auto_reframe_video(
         clips_count=body.clips_count,
         clip_duration_sec=body.clip_duration_sec,
         output_style=body.output_style,
+        content_profile=body.content_profile,
     )
 
 

--- a/backend/api/app/api/v1/endpoints/job.py
+++ b/backend/api/app/api/v1/endpoints/job.py
@@ -50,6 +50,7 @@ async def reframe_video(
         subtitles=body.subtitles,
         face_tracking=body.face_tracking,
         color_filter=body.color_filter,
+        output_style=body.output_style,
     )
 
 
@@ -77,6 +78,7 @@ async def auto_reframe_video(
         user_id=current_user.id,
         clips_count=body.clips_count,
         clip_duration_sec=body.clip_duration_sec,
+        output_style=body.output_style,
     )
 
 

--- a/backend/api/app/api/v1/endpoints/video.py
+++ b/backend/api/app/api/v1/endpoints/video.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from app.core.dependencies import get_current_active_user
 from app.database.session import get_db
 from app.models.user import User
-from app.schemas.video import VideoUploadResponse, VideoURLResponse
+from app.schemas.video import VideoUploadResponse, VideoURLResponse, UserVideosResponse
 from app.services.video_service import VideoService
 
 router = APIRouter(prefix="/videos", tags=["Videos"])
@@ -22,13 +22,13 @@ router = APIRouter(prefix="/videos", tags=["Videos"])
     responses={
         201: {"description": "Video subido exitosamente"},
         400: {"description": "Archivo inválido"},
-        401: {"description": "No autenticado"}
-    }
+        401: {"description": "No autenticado"},
+    },
 )
 async def upload_video(
     file: Annotated[UploadFile, File(...)],
     current_user: Annotated[User, Depends(get_current_active_user)],
-    db: Annotated[Session, Depends(get_db)]
+    db: Annotated[Session, Depends(get_db)],
 ) -> VideoUploadResponse:
     """Sube un video con autenticación (asociado a usuario)"""
     service = VideoService(db)
@@ -44,14 +44,43 @@ async def upload_video(
     responses={
         200: {"description": "URL generada exitosamente"},
         404: {"description": "Video no encontrado"},
-        400: {"description": "Video sin ruta de almacenamiento"}
-    }
+        400: {"description": "Video sin ruta de almacenamiento"},
+    },
 )
 async def get_video_url(
     video_id: UUID,
     db: Annotated[Session, Depends(get_db)],
-    expires_in: Annotated[int, Query(ge=60, le=86400, description="Tiempo de expiración en segundos (1 min - 24 horas)")] = 3600
+    expires_in: Annotated[
+        int,
+        Query(
+            ge=60,
+            le=86400,
+            description="Tiempo de expiración en segundos (1 min - 24 horas)",
+        ),
+    ] = 3600,
 ) -> VideoURLResponse:
     """Obtiene una URL presignada temporal para descargar el video (expira en 1 hora por defecto)"""
     service = VideoService(db)
     return service.get_video_url(video_id, expires_in)
+
+
+@router.get(
+    "/my-videos",
+    response_model=UserVideosResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Listar mis videos originales",
+    description="Devuelve los videos originales subidos por el usuario autenticado",
+)
+async def get_my_videos(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    db: Annotated[Session, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    q: Annotated[
+        str | None, Query(description="Busqueda por nombre de archivo o id de video")
+    ] = None,
+) -> UserVideosResponse:
+    service = VideoService(db)
+    return service.list_user_videos(
+        current_user.id, limit=limit, offset=offset, query=q
+    )

--- a/backend/api/app/api/v1/endpoints/video.py
+++ b/backend/api/app/api/v1/endpoints/video.py
@@ -1,13 +1,20 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, UploadFile, Query, status
+from fastapi import APIRouter, Depends, File, UploadFile, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.core.dependencies import get_current_active_user
 from app.database.session import get_db
 from app.models.user import User
-from app.schemas.video import VideoUploadResponse, VideoURLResponse, UserVideosResponse
+from app.schemas.video import (
+    UpdateVideoRequest,
+    UserVideoDetailResponse,
+    UserVideoItem,
+    UserVideosResponse,
+    VideoUploadResponse,
+    VideoURLResponse,
+)
 from app.services.video_service import VideoService
 
 router = APIRouter(prefix="/videos", tags=["Videos"])
@@ -84,3 +91,52 @@ async def get_my_videos(
     return service.list_user_videos(
         current_user.id, limit=limit, offset=offset, query=q
     )
+
+
+@router.get(
+    "/{video_id}",
+    response_model=UserVideoDetailResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Obtener un video propio",
+    description="Devuelve metadata y preview del video autenticado",
+)
+async def get_my_video_by_id(
+    video_id: UUID,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> UserVideoDetailResponse:
+    service = VideoService(db)
+    return service.get_user_video(video_id, current_user.id)
+
+
+@router.patch(
+    "/{video_id}",
+    response_model=UserVideoItem,
+    status_code=status.HTTP_200_OK,
+    summary="Actualizar metadata de video",
+    description="Permite renombrar un video propio",
+)
+async def update_my_video(
+    video_id: UUID,
+    body: UpdateVideoRequest,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> UserVideoItem:
+    service = VideoService(db)
+    return service.update_user_video(video_id, current_user.id, body)
+
+
+@router.delete(
+    "/{video_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Eliminar video propio",
+    description="Elimina video y metadata asociada del usuario autenticado",
+)
+async def delete_my_video(
+    video_id: UUID,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> Response:
+    service = VideoService(db)
+    service.delete_user_video(video_id, current_user.id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/api/app/core/config.py
+++ b/backend/api/app/core/config.py
@@ -2,31 +2,34 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field, field_validator
 import secrets
 
+
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", case_sensitive=True, env_file_encoding="utf-8")
-    
+    model_config = SettingsConfigDict(
+        env_file=".env", case_sensitive=True, env_file_encoding="utf-8"
+    )
+
     APP_NAME: str = "NoCountry Video API"
     APP_VERSION: str = "1.0.0"
     DEBUG: bool = Field(default=False)
     ENVIRONMENT: str = Field(default="development")
-    
+
     DATABASE_URL: str = Field(...)
     DB_POOL_SIZE: int = Field(default=10)
     DB_MAX_OVERFLOW: int = Field(default=20)
     DB_ECHO: bool = Field(default=False)
-    
+
     @field_validator("DATABASE_URL")
     @classmethod
     def validate_database_url(cls, v):
         if not v.startswith("postgresql://"):
             raise ValueError("DATABASE_URL debe comenzar con postgresql://")
         return v
-    
+
     REDIS_HOST: str = Field(default="redis")
     REDIS_PORT: int = Field(default=6379)
     REDIS_DB: int = Field(default=0)
     REDIS_PASSWORD: str | None = Field(default=None)
-    
+
     MINIO_ENDPOINT: str = Field(default="minio:9000")
     MINIO_ACCESS_KEY: str = Field(default="minio")
     MINIO_SECRET_KEY: str = Field(default="miniopass")
@@ -35,43 +38,48 @@ class Settings(BaseSettings):
     # Endpoint público para URLs presignadas (accesible desde navegador)
     MINIO_PUBLIC_ENDPOINT: str | None = Field(default=None)
     MINIO_PUBLIC_SECURE: bool | None = Field(default=None)
-    
+
     SECRET_KEY: str = Field(default_factory=lambda: secrets.token_urlsafe(32))
     ALGORITHM: str = Field(default="HS256")
     ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(default=60 * 24 * 7)
-    
+
     @field_validator("SECRET_KEY")
     @classmethod
     def validate_secret_key(cls, v, info):
         if info.data.get("ENVIRONMENT") == "production" and len(v) < 32:
-            raise ValueError("SECRET_KEY debe tener al menos 32 caracteres en producción")
+            raise ValueError(
+                "SECRET_KEY debe tener al menos 32 caracteres en producción"
+            )
         return v
-    
+
     # === GOOGLE OAUTH ===
-    GOOGLE_CLIENT_ID: str = Field(...)
-    GOOGLE_CLIENT_SECRET: str = Field(...)
+    GOOGLE_CLIENT_ID: str = Field(default="")
+    GOOGLE_CLIENT_SECRET: str = Field(default="")
     GOOGLE_REDIRECT_URI: str = Field(default="http://localhost:3000/auth/callback")
-    
+
     @field_validator("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET")
     @classmethod
     def validate_google_credentials(cls, v, info):
         if info.data.get("ENVIRONMENT") == "production" and not v:
             raise ValueError(f"{info.field_name} is required in production")
         return v
-    
-    ALLOWED_ORIGINS: list[str] = Field(default=["http://localhost:3000", "http://localhost:5173"])
-    
+
+    ALLOWED_ORIGINS: list[str] = Field(
+        default=["http://localhost:3000", "http://localhost:5173"]
+    )
+
     @field_validator("ALLOWED_ORIGINS", mode="before")
     @classmethod
     def parse_cors_origins(cls, v):
         if isinstance(v, str):
             return [origin.strip() for origin in v.split(",")]
         return v
-    
+
     RATE_LIMIT_ENABLED: bool = Field(default=False)
     RATE_LIMIT_PER_MINUTE: int = Field(default=60)
-    
+
     LOG_LEVEL: str = Field(default="INFO")
     LOG_FORMAT: str = Field(default="json")
+
 
 settings = Settings()

--- a/backend/api/app/core/dependencies.py
+++ b/backend/api/app/core/dependencies.py
@@ -11,16 +11,17 @@ from app.schemas.token import TokenPayload
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
 
+
 async def get_current_user(
     token: Annotated[str, Depends(oauth2_scheme)],
-    db: Annotated[Session, Depends(get_db)]
+    db: Annotated[Session, Depends(get_db)],
 ) -> User:
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
-    
+
     try:
         payload = decode_access_token(token)
         token_data = TokenPayload(**payload)
@@ -28,24 +29,24 @@ async def get_current_user(
             raise credentials_exception
     except JWTError:
         raise credentials_exception
-    
+
     user = None
-    
+
     # Intentar buscar por UUID (caso normal: sub = user.id)
     try:
         subject_as_uuid = UUID(token_data.sub)
         user = db.query(User).filter(User.id == subject_as_uuid).first()
     except (ValueError, TypeError):
-        # Fallback: buscar por email (tokens antiguos con sub = email)
         user = db.query(User).filter(User.email == token_data.sub).first()
-    
+
     if user is None:
         raise credentials_exception
-    
+
     return user
 
+
 async def get_current_active_user(
-    current_user: Annotated[User, Depends(get_current_user)]
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> User:
     if not current_user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")

--- a/backend/api/app/schemas/job.py
+++ b/backend/api/app/schemas/job.py
@@ -4,6 +4,7 @@ from pydantic import Field
 from app.schemas.base import BaseSchema
 from app.models.job import JobStatus, JobType
 
+
 class JobReframeResponse(BaseSchema):
     job_id: UUID
     job_type: JobType
@@ -13,12 +14,60 @@ class JobReframeResponse(BaseSchema):
     end_sec: int
     created_at: datetime
 
+
 class JobStatusResponse(BaseSchema):
     job_id: UUID
     status: JobStatus
     output_path: str | None = None
-    
+
 
 class JobReframeRequest(BaseSchema):
     start_sec: int = Field(..., description="Inicio de recorte en Segundo")
     end_sec: int = Field(..., description="Final del recorte en Segundos")
+
+
+class AutoClipSegment(BaseSchema):
+    start_sec: int
+    end_sec: int
+
+
+class JobAutoReframeRequest(BaseSchema):
+    clips_count: int = Field(
+        default=3, ge=1, le=20, description="Cantidad de clips a generar"
+    )
+    clip_duration_sec: int = Field(
+        default=15, ge=5, le=120, description="Duracion por clip"
+    )
+
+
+class JobAutoReframeItem(BaseSchema):
+    job_id: UUID
+    job_type: JobType
+    status: JobStatus
+    start_sec: int
+    end_sec: int
+    created_at: datetime
+
+
+class JobAutoReframeResponse(BaseSchema):
+    video_id: UUID
+    total_jobs: int
+    clip_duration_sec: int
+    used_video_duration_sec: int | None = None
+    jobs: list[JobAutoReframeItem]
+
+
+class UserClipItem(BaseSchema):
+    job_id: UUID
+    video_id: UUID
+    status: JobStatus
+    output_path: str | None = None
+    source_filename: str
+    created_at: datetime
+
+
+class UserClipsResponse(BaseSchema):
+    total: int
+    limit: int
+    offset: int
+    clips: list[UserClipItem]

--- a/backend/api/app/schemas/job.py
+++ b/backend/api/app/schemas/job.py
@@ -87,3 +87,7 @@ class UserClipsResponse(BaseSchema):
     limit: int
     offset: int
     clips: list[UserClipItem]
+
+
+class UserClipDetailResponse(BaseSchema):
+    clip: UserClipItem

--- a/backend/api/app/schemas/job.py
+++ b/backend/api/app/schemas/job.py
@@ -24,6 +24,22 @@ class JobStatusResponse(BaseSchema):
 class JobReframeRequest(BaseSchema):
     start_sec: int = Field(..., description="Inicio de recorte en Segundo")
     end_sec: int = Field(..., description="Final del recorte en Segundos")
+    crop_to_vertical: bool | None = Field(
+        default=None,
+        description="Opcional: forzar salida vertical",
+    )
+    subtitles: bool | None = Field(
+        default=None,
+        description="Opcional: habilitar subtitulos",
+    )
+    face_tracking: bool | None = Field(
+        default=None,
+        description="Opcional: seguimiento facial",
+    )
+    color_filter: bool | None = Field(
+        default=None,
+        description="Opcional: aplicar filtro de color",
+    )
 
 
 class AutoClipSegment(BaseSchema):

--- a/backend/api/app/schemas/job.py
+++ b/backend/api/app/schemas/job.py
@@ -45,6 +45,10 @@ class JobReframeRequest(BaseSchema):
         default="vertical",
         description="Estilo de salida: vertical clasico o split speaker",
     )
+    content_profile: Literal["auto", "interview", "sports", "music"] = Field(
+        default="auto",
+        description="Perfil de contenido para ajustar framing (auto/entrevista/deportes/musica)",
+    )
 
 
 class AutoClipSegment(BaseSchema):
@@ -53,15 +57,25 @@ class AutoClipSegment(BaseSchema):
 
 
 class JobAutoReframeRequest(BaseSchema):
-    clips_count: int = Field(
-        default=3, ge=1, le=20, description="Cantidad de clips a generar"
+    clips_count: int | None = Field(
+        default=None,
+        ge=1,
+        le=20,
+        description="Cantidad de clips a generar (opcional, backend decide si no se envia)",
     )
-    clip_duration_sec: int = Field(
-        default=15, ge=5, le=120, description="Duracion por clip"
+    clip_duration_sec: int | None = Field(
+        default=None,
+        ge=5,
+        le=120,
+        description="Duracion por clip (opcional, backend decide si no se envia)",
     )
     output_style: Literal["vertical", "speaker_split"] = Field(
         default="vertical",
         description="Estilo de salida para los clips automaticos",
+    )
+    content_profile: Literal["auto", "interview", "sports", "music"] = Field(
+        default="auto",
+        description="Perfil de contenido para ajustar framing (auto/entrevista/deportes/musica)",
     )
 
 

--- a/backend/api/app/schemas/job.py
+++ b/backend/api/app/schemas/job.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from datetime import datetime
+from typing import Literal
 from pydantic import Field
 from app.schemas.base import BaseSchema
 from app.models.job import JobStatus, JobType
@@ -40,6 +41,10 @@ class JobReframeRequest(BaseSchema):
         default=None,
         description="Opcional: aplicar filtro de color",
     )
+    output_style: Literal["vertical", "speaker_split"] = Field(
+        default="vertical",
+        description="Estilo de salida: vertical clasico o split speaker",
+    )
 
 
 class AutoClipSegment(BaseSchema):
@@ -53,6 +58,10 @@ class JobAutoReframeRequest(BaseSchema):
     )
     clip_duration_sec: int = Field(
         default=15, ge=5, le=120, description="Duracion por clip"
+    )
+    output_style: Literal["vertical", "speaker_split"] = Field(
+        default="vertical",
+        description="Estilo de salida para los clips automaticos",
     )
 
 

--- a/backend/api/app/schemas/video.py
+++ b/backend/api/app/schemas/video.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from uuid import UUID
+from pydantic import Field
 from app.schemas.base import BaseSchema
 
 
@@ -28,6 +29,20 @@ class UserVideoItem(BaseSchema):
     status: str | None = None
     uploaded_at: datetime
     preview_url: str | None = None
+
+
+class UserVideoDetailResponse(BaseSchema):
+    video_id: UUID
+    filename: str
+    status: str | None = None
+    uploaded_at: datetime
+    updated_at: datetime
+    storage_path: str | None = None
+    preview_url: str | None = None
+
+
+class UpdateVideoRequest(BaseSchema):
+    filename: str = Field(min_length=1, max_length=255)
 
 
 class UserVideosResponse(BaseSchema):

--- a/backend/api/app/schemas/video.py
+++ b/backend/api/app/schemas/video.py
@@ -20,3 +20,18 @@ class VideoURLResponse(BaseSchema):
     url: str
     expires_in_seconds: int
     filename: str
+
+
+class UserVideoItem(BaseSchema):
+    video_id: UUID
+    filename: str
+    status: str | None = None
+    uploaded_at: datetime
+    preview_url: str | None = None
+
+
+class UserVideosResponse(BaseSchema):
+    total: int
+    limit: int
+    offset: int
+    videos: list[UserVideoItem]

--- a/backend/api/app/services/google_oauth_service.py
+++ b/backend/api/app/services/google_oauth_service.py
@@ -1,4 +1,5 @@
 """Servicio de autenticación con Google OAuth 2.0"""
+
 import secrets
 import logging
 from typing import Dict, Any
@@ -17,29 +18,29 @@ logger = logging.getLogger(__name__)
 
 class GoogleOAuthService:
     """Servicio para manejar el flujo completo de Google OAuth"""
-    
+
     GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
     GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
     GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
     SCOPES = [
         "openid",
         "https://www.googleapis.com/auth/userinfo.email",
-        "https://www.googleapis.com/auth/userinfo.profile"
+        "https://www.googleapis.com/auth/userinfo.profile",
     ]
-    
+
     def __init__(self, db: Session):
         self.db = db
-    
+
     def get_authorization_url(self) -> GoogleAuthURL:
         """
         Genera la URL de autorización de Google + state token para CSRF protection.
-        
+
         Returns:
             GoogleAuthURL: URL donde redirigir al usuario + state token
         """
         # Generar state token aleatorio para CSRF protection
         state = secrets.token_urlsafe(32)
-        
+
         # Construir URL de autorización
         params = {
             "client_id": settings.GOOGLE_CLIENT_ID,
@@ -50,25 +51,22 @@ class GoogleOAuthService:
             "access_type": "offline",  # Para refresh token
             "prompt": "select_account",  # Forzar selección de cuenta
         }
-        
+
         # Construir query string manualmente
         query_string = "&".join([f"{k}={v}" for k, v in params.items()])
         authorization_url = f"{self.GOOGLE_AUTH_URL}?{query_string}"
-        
-        return GoogleAuthURL(
-            authorization_url=authorization_url,
-            state=state
-        )
-    
+
+        return GoogleAuthURL(authorization_url=authorization_url, state=state)
+
     async def exchange_code_for_token(self, code: str) -> Dict[str, Any]:
         """
         Intercambia el authorization code por un access token.
-        
+
         Este paso se hace server-to-server, el client_secret NUNCA se expone al frontend.
-        
+
         Args:
             code: Authorization code recibido de Google
-            
+
         Returns:
             Dict con access_token, refresh_token, etc.
         """
@@ -77,7 +75,7 @@ class GoogleOAuthService:
         logger.debug(f"📍 Redirect URI: {settings.GOOGLE_REDIRECT_URI}")
         logger.debug(f"🔑 Client ID: {settings.GOOGLE_CLIENT_ID[:20]}...")
         logger.debug(f"📝 Code length: {len(code)} chars")
-        
+
         async with httpx.AsyncClient() as client:
             token_data = {
                 "code": code,
@@ -86,54 +84,51 @@ class GoogleOAuthService:
                 "redirect_uri": settings.GOOGLE_REDIRECT_URI,
                 "grant_type": "authorization_code",
             }
-            
-            response = await client.post(
-                self.GOOGLE_TOKEN_URL,
-                data=token_data
-            )
-            
+
+            response = await client.post(self.GOOGLE_TOKEN_URL, data=token_data)
+
             # Si hay error, loguear respuesta de Google
             if response.status_code != 200:
                 error_detail = response.text
                 logger.error(f"❌ Google OAuth error: {response.status_code}")
                 logger.error(f"📄 Response: {error_detail}")
-            
+
             response.raise_for_status()
             return response.json()
-    
+
     async def get_user_info(self, access_token: str) -> GoogleUserInfo:
         """
         Obtiene la información del usuario desde Google.
-        
+
         Args:
             access_token: Token de acceso obtenido en el paso anterior
-            
+
         Returns:
             GoogleUserInfo: Datos del usuario (email, nombre, foto, etc.)
         """
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 self.GOOGLE_USERINFO_URL,
-                headers={"Authorization": f"Bearer {access_token}"}
+                headers={"Authorization": f"Bearer {access_token}"},
             )
             response.raise_for_status()
             data = response.json()
-            
+
             return GoogleUserInfo(**data)
-    
+
     def get_or_create_user(self, google_user: GoogleUserInfo) -> User:
         """
         Busca o crea un usuario basado en la info de Google.
-        
+
         Args:
             google_user: Información del usuario desde Google
-            
+
         Returns:
             User: Usuario creado o encontrado
         """
         # Buscar usuario existente por email
         user = self.db.query(User).filter(User.email == google_user.email).first()
-        
+
         if user:
             # Usuario existe - actualizar provider si era de email
             if user.provider == "email":
@@ -143,7 +138,7 @@ class GoogleOAuthService:
                 self.db.commit()
                 self.db.refresh(user)
             return user
-        
+
         # Usuario NO existe - crear nuevo
         new_user = User(
             email=google_user.email,
@@ -152,11 +147,11 @@ class GoogleOAuthService:
             role=UserRole.USER,
             is_active=True,
             is_verified=True,  # Google ya verificó el email
-            hashed_password=None  # No tiene password (OAuth)
+            hashed_password=None,  # No tiene password (OAuth)
         )
         self.db.add(new_user)
         self.db.flush()  # Generar el ID sin hacer commit
-        
+
         # Crear perfil automático con datos de Google
         profile = Profile(
             user_id=new_user.id,
@@ -168,46 +163,47 @@ class GoogleOAuthService:
         self.db.add(profile)
         self.db.commit()
         self.db.refresh(new_user)
-        
+
         return new_user
-    
+
     async def authenticate_with_google(self, code: str) -> Dict[str, Any]:
         """
         Flujo completo de autenticación con Google.
-        
+
         1. Intercambia code por access_token
         2. Obtiene info del usuario
         3. Crea/actualiza usuario en DB
         4. Genera JWT propio
-        
+
         Args:
             code: Authorization code desde Google
-            
+
         Returns:
             Dict con access_token (JWT propio) y datos del usuario
         """
         # 1. Intercambiar code por token
         token_data = await self.exchange_code_for_token(code)
         access_token = token_data["access_token"]
-        
+
         # 2. Obtener info del usuario
         google_user = await self.get_user_info(access_token)
-        
+
         # 3. Crear/actualizar usuario en DB
         user = self.get_or_create_user(google_user)
-        
-        # 4. Generar nuestro propio JWT (usar UUID como subject)
+
+        # 4. Generar nuestro propio JWT
         jwt_token = create_access_token(subject=str(user.id))
-        
+
         return {
             "access_token": jwt_token,
             "token_type": "bearer",
-            "expires_in": settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # Convertir a segundos
+            "expires_in": settings.ACCESS_TOKEN_EXPIRE_MINUTES
+            * 60,  # Convertir a segundos
             "user": {
                 "id": str(user.id),
                 "email": user.email,
                 "role": user.role,
                 "is_active": user.is_active,
                 "is_verified": user.is_verified,
-            }
+            },
         }

--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -341,9 +341,26 @@ class JobService:
             return []
 
     def reframe_video(
-        self, video_id: UUID, user_id: UUID, start_sec: int, end_sec: int
+        self,
+        video_id: UUID,
+        user_id: UUID,
+        start_sec: int,
+        end_sec: int,
+        crop_to_vertical: bool | None = None,
+        subtitles: bool | None = None,
+        face_tracking: bool | None = None,
+        color_filter: bool | None = None,
     ) -> JobReframeResponse:
         video = self._get_user_video(video_id, user_id)
+
+        logger.info(
+            "Reframe options for video %s: crop_to_vertical=%s subtitles=%s face_tracking=%s color_filter=%s",
+            video_id,
+            crop_to_vertical,
+            subtitles,
+            face_tracking,
+            color_filter,
+        )
 
         return self._create_reframe_job(
             video=video,

--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 import re
 import subprocess
+from urllib.parse import unquote, urlparse
 from sqlalchemy.orm import Session
 from app.models.job import Job, JobStatus, JobType
 from app.models.video import Video
@@ -30,6 +31,37 @@ class JobService:
         self.db = db
         self.queue = queue
 
+    def _extract_storage_path(self, output_path: str | None) -> str | None:
+        if not output_path:
+            return None
+
+        if output_path.startswith("s3://"):
+            return output_path
+
+        parsed = urlparse(output_path)
+        normalized_path = parsed.path.lstrip("/")
+
+        if not normalized_path:
+            return None
+
+        return f"s3://{unquote(normalized_path)}"
+
+    def _resolve_output_url(self, output_path: str | None) -> str | None:
+        if not output_path:
+            return None
+
+        storage_path = self._extract_storage_path(output_path)
+        if not storage_path:
+            return output_path
+
+        try:
+            return VideoWorkerService().get_video_public_url(
+                storage_path, expires_in=3600
+            )
+        except Exception as exc:
+            logger.warning(f"No se pudo regenerar URL de salida para clip: {exc}")
+            return output_path
+
     def get_job_status(self, job_id: UUID, user_id: UUID) -> JobStatusResponse:
         job = (
             self.db.query(Job).filter(Job.id == job_id, Job.user_id == user_id).first()
@@ -39,7 +71,9 @@ class JobService:
             raise NotFoundException("Job Not found")
 
         return JobStatusResponse(
-            job_id=job.id, status=job.status, output_path=job.output_path
+            job_id=job.id,
+            status=job.status,
+            output_path=self._resolve_output_url(job.output_path),
         )
 
     def _get_user_video(self, video_id: UUID, user_id: UUID) -> Video:
@@ -381,7 +415,7 @@ class JobService:
                 job_id=job.id,
                 video_id=job.video_id,
                 status=job.status,
-                output_path=job.output_path,
+                output_path=self._resolve_output_url(job.output_path),
                 source_filename=video.original_filename,
                 created_at=job.created_at,
             )

--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -11,6 +11,7 @@ from app.schemas.job import (
     JobStatusResponse,
     JobAutoReframeResponse,
     JobAutoReframeItem,
+    UserClipDetailResponse,
     UserClipsResponse,
     UserClipItem,
 )
@@ -20,6 +21,7 @@ from app.core.logging import setup_logging
 from app.utils.exceptions import (
     JobParameterException,
     NotFoundException,
+    VideoDBException,
 )
 
 logger = setup_logging()
@@ -449,3 +451,55 @@ class JobService:
         ]
 
         return UserClipsResponse(total=total, limit=limit, offset=offset, clips=clips)
+
+    def get_user_clip(self, job_id: UUID, user_id: UUID) -> UserClipDetailResponse:
+        row = (
+            self.db.query(Job, Video)
+            .join(Video, Video.id == Job.video_id)
+            .filter(
+                Job.id == job_id,
+                Job.user_id == user_id,
+                Job.job_type == JobType.REFRAME,
+            )
+            .first()
+        )
+
+        if not row:
+            raise NotFoundException("Clip no encontrado")
+
+        job, video = row
+        clip = UserClipItem(
+            job_id=job.id,
+            video_id=job.video_id,
+            status=job.status,
+            output_path=self._resolve_output_url(job.output_path),
+            source_filename=video.original_filename,
+            created_at=job.created_at,
+        )
+        return UserClipDetailResponse(clip=clip)
+
+    def delete_user_clip(self, job_id: UUID, user_id: UUID) -> None:
+        job = (
+            self.db.query(Job)
+            .filter(
+                Job.id == job_id,
+                Job.user_id == user_id,
+                Job.job_type == JobType.REFRAME,
+            )
+            .first()
+        )
+
+        if not job:
+            raise NotFoundException("Clip no encontrado")
+
+        if job.output_path:
+            storage_path = self._extract_storage_path(job.output_path)
+            if storage_path:
+                VideoWorkerService().delete_video_from_storage(storage_path)
+
+        try:
+            self.db.delete(job)
+            self.db.commit()
+        except Exception as exc:
+            self.db.rollback()
+            raise VideoDBException("Error eliminando clip", str(exc))

--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -1,111 +1,91 @@
-from uuid import UUID, uuid4
-from datetime import datetime
-from venv import logger
-from app.core.config import settings
+from uuid import UUID
+import re
+import subprocess
 from sqlalchemy.orm import Session
 from app.models.job import Job, JobStatus, JobType
 from app.models.video import Video
-from app.schemas.job import JobReframeResponse, JobStatusResponse
+from app.schemas.job import (
+    JobReframeResponse,
+    JobStatusResponse,
+    JobAutoReframeResponse,
+    JobAutoReframeItem,
+    UserClipsResponse,
+    UserClipItem,
+)
 from app.services.queue_service import QueueService
+from app.services.video_worker_service import VideoWorkerService
+from app.core.logging import setup_logging
 from app.utils.exceptions import (
     JobParameterException,
     NotFoundException,
 )
 
+logger = setup_logging()
+
 
 class JobService:
     """Servicio de Jobs - Persiste un Job, luego envia mensaje a Redis"""
-    
+
     def __init__(self, db: Session, queue: QueueService):
         self.db = db
         self.queue = queue
-    
 
     def get_job_status(self, job_id: UUID, user_id: UUID) -> JobStatusResponse:
         job = (
-        self.db.query(Job)
-        .filter(
-            Job.id == job_id,
-            Job.user_id == user_id
-        )
-        .first()
+            self.db.query(Job).filter(Job.id == job_id, Job.user_id == user_id).first()
         )
 
         if not job:
             raise NotFoundException("Job Not found")
 
         return JobStatusResponse(
-            job_id=job.id,
-            status=job.status,
-            output_path=job.output_path
+            job_id=job.id, status=job.status, output_path=job.output_path
         )
-    
-    
-    def reframe_video(self, video_id: UUID, user_id: UUID, start_sec: int, end_sec: int) -> JobReframeResponse:
+
+    def _get_user_video(self, video_id: UUID, user_id: UUID) -> Video:
         video = (
             self.db.query(Video)
-            .filter(
-                Video.id == video_id,
-                Video.user_id == user_id
-            )
+            .filter(Video.id == video_id, Video.user_id == user_id)
             .first()
         )
 
         if not video:
-            raise NotFoundException("Video not found"
-            )
-        
-        # ...TODO, tabla videos no guarda duracion?
-        # validar que start y end sec sean coherentes con la duracion del video
-        #video_total_sec = video.duration_seconds
-        #if video_total_sec is None:
-        #    raise JobParameterException("Video duration not available")
-        #if start_sec < 0 or start_sec > video_total_sec or end_sec > video_total_sec:
-        #    raise JobParameterException()
+            raise NotFoundException("Video not found")
+
+        return video
+
+    def _validate_time_range(self, start_sec: int, end_sec: int) -> None:
         if start_sec < 0 or start_sec > end_sec:
             raise JobParameterException()
 
-        # validar que no exista ya un job PENDING/RUNNING/FAILED para ese video_id
-        existing_job = (
-            self.db.query(Job)
-            .filter(
-                Job.video_id == video_id,
-                Job.status.in_([JobStatus.PENDING, JobStatus.RUNNING, JobStatus.FAILED])
+    def _create_reframe_job(
+        self,
+        *,
+        video: Video,
+        user_id: UUID,
+        start_sec: int,
+        end_sec: int,
+        allow_reuse: bool,
+    ) -> JobReframeResponse:
+        self._validate_time_range(start_sec, end_sec)
+
+        existing_job = None
+        if allow_reuse:
+            existing_job = (
+                self.db.query(Job)
+                .filter(
+                    Job.video_id == video.id,
+                    Job.status.in_(
+                        [JobStatus.PENDING, JobStatus.RUNNING, JobStatus.FAILED]
+                    ),
+                )
+                .first()
             )
-            .first()
-        )
 
-        if existing_job:
-            if existing_job.status == JobStatus.RUNNING:
-                logger.info(f"Existing job {existing_job.id} is already {existing_job.status}")
-                return JobReframeResponse(
-                    job_id=existing_job.id,
-                    job_type=existing_job.job_type,
-                    status=existing_job.status,
-                    filename=video.original_filename,
-                    start_sec=start_sec,
-                    end_sec=end_sec,
-                    created_at=existing_job.created_at
-                )
-
-        if existing_job:
-            logger.info(f"Existing job {existing_job.id} found for video {video_id} with status {existing_job.status}, reusing it")
-            # republicar a Redis
-            try:
-                self.queue.publish_reframe_job(
-                    job_id=str(existing_job.id),
-                    video_id=str(video_id),
-                    user_id=str(user_id),
-                    start_sec=start_sec,
-                    end_sec=end_sec,
-                )
-            except Exception as e:
-                # Si falla Redis, dejamos el job en FAILED
-                existing_job.status = JobStatus.FAILED
-                existing_job.error_message = "Error enviando job a la cola"
-                self.db.commit()
-                raise e
-    
+        if existing_job and existing_job.status == JobStatus.RUNNING:
+            logger.info(
+                f"Existing job {existing_job.id} is already {existing_job.status}"
+            )
             return JobReframeResponse(
                 job_id=existing_job.id,
                 job_type=existing_job.job_type,
@@ -113,32 +93,57 @@ class JobService:
                 filename=video.original_filename,
                 start_sec=start_sec,
                 end_sec=end_sec,
-                created_at=existing_job.created_at
+                created_at=existing_job.created_at,
             )
 
-        # crear Job en DB
+        if existing_job:
+            logger.info(
+                f"Existing job {existing_job.id} found for video {video.id} with status {existing_job.status}, reusing it"
+            )
+            try:
+                self.queue.publish_reframe_job(
+                    job_id=str(existing_job.id),
+                    video_id=str(video.id),
+                    user_id=str(user_id),
+                    start_sec=start_sec,
+                    end_sec=end_sec,
+                )
+            except Exception as e:
+                existing_job.status = JobStatus.FAILED
+                existing_job.error_message = "Error enviando job a la cola"
+                self.db.commit()
+                raise e
+
+            return JobReframeResponse(
+                job_id=existing_job.id,
+                job_type=existing_job.job_type,
+                status=existing_job.status,
+                filename=video.original_filename,
+                start_sec=start_sec,
+                end_sec=end_sec,
+                created_at=existing_job.created_at,
+            )
+
         job = Job(
             user_id=user_id,
-            video_id=video_id,
+            video_id=video.id,
             job_type=JobType.REFRAME,
-            status=JobStatus.PENDING
+            status=JobStatus.PENDING,
         )
 
         self.db.add(job)
-        self.db.commit()        # persistir primero
-        self.db.refresh(job)    # refresh para obtener ID generado
+        self.db.commit()
+        self.db.refresh(job)
 
-        # enviar a Redis (después del commit) ! Idealmente solo enviariamos el jobId
         try:
             self.queue.publish_reframe_job(
                 job_id=str(job.id),
-                video_id=str(video_id),
+                video_id=str(video.id),
                 user_id=str(user_id),
                 start_sec=start_sec,
                 end_sec=end_sec,
             )
         except Exception as e:
-            # Si falla Redis, dejamos el job en FAILED
             job.status = JobStatus.FAILED
             job.error_message = "Error enviando job a la cola"
             self.db.commit()
@@ -151,5 +156,236 @@ class JobService:
             filename=video.original_filename,
             start_sec=start_sec,
             end_sec=end_sec,
-            created_at=job.created_at
+            created_at=job.created_at,
         )
+
+    def _build_auto_clip_ranges(
+        self, video: Video, clips_count: int, clip_duration_sec: int
+    ) -> tuple[list[tuple[int, int]], int | None]:
+        duration = self._resolve_video_duration(video)
+
+        if not duration or duration <= 0:
+            starts = [i * clip_duration_sec for i in range(clips_count)]
+            return ([(start, start + clip_duration_sec) for start in starts], None)
+
+        safe_clip_duration = min(clip_duration_sec, max(5, duration))
+        max_start = max(duration - safe_clip_duration, 0)
+        source_url = self._get_source_url(video)
+
+        if not source_url:
+            starts = self._distributed_starts(max_start, clips_count)
+            ranges = [
+                (start, min(start + safe_clip_duration, duration)) for start in starts
+            ]
+            return (ranges, duration)
+
+        highlights = self._extract_nonsilent_segments(source_url, duration)
+        starts: list[int] = []
+        min_gap = max(1, safe_clip_duration // 2)
+
+        if highlights:
+            scored = sorted(highlights, key=lambda seg: seg[1] - seg[0], reverse=True)
+            for start_h, end_h in scored:
+                center = (start_h + end_h) / 2
+                start = int(round(center - (safe_clip_duration / 2)))
+                start = max(0, min(max_start, start))
+                if all(abs(start - existing) >= min_gap for existing in starts):
+                    starts.append(start)
+                if len(starts) >= clips_count:
+                    break
+
+        if len(starts) < clips_count:
+            for extra in self._distributed_starts(max_start, clips_count):
+                if all(abs(extra - existing) >= min_gap for existing in starts):
+                    starts.append(extra)
+                if len(starts) >= clips_count:
+                    break
+
+        unique_sorted = sorted(set(starts))[:clips_count]
+        ranges = [
+            (start, min(start + safe_clip_duration, duration))
+            for start in unique_sorted
+        ]
+        return (ranges, duration)
+
+    def _distributed_starts(self, max_start: int, clips_count: int) -> list[int]:
+        if clips_count <= 1:
+            return [max_start // 2]
+        if max_start <= 0:
+            return [0 for _ in range(clips_count)]
+        intro_offset = int(max_start * 0.08)
+        usable_max = max(int(max_start * 0.92), intro_offset)
+        return [
+            round(intro_offset + ((usable_max - intro_offset) * i) / (clips_count - 1))
+            for i in range(clips_count)
+        ]
+
+    def _get_source_url(self, video: Video) -> str | None:
+        if not video.storage_path:
+            return None
+        try:
+            return VideoWorkerService().get_video_url(
+                video.storage_path, expires_in=600
+            )
+        except Exception as exc:
+            logger.warning(f"No se pudo generar URL temporal para analisis: {exc}")
+            return None
+
+    def _resolve_video_duration(self, video: Video) -> int | None:
+        if video.duration_seconds and video.duration_seconds > 0:
+            return int(video.duration_seconds)
+        source_url = self._get_source_url(video)
+        if not source_url:
+            return None
+        return self._probe_duration_seconds(source_url)
+
+    def _probe_duration_seconds(self, source_url: str) -> int | None:
+        try:
+            cmd = [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                source_url,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            raw = result.stdout.strip()
+            if not raw:
+                return None
+            return max(1, int(float(raw)))
+        except Exception as exc:
+            logger.warning(f"No se pudo obtener duracion con ffprobe: {exc}")
+            return None
+
+    def _extract_nonsilent_segments(
+        self, source_url: str, duration_sec: int
+    ) -> list[tuple[int, int]]:
+        try:
+            cmd = [
+                "ffmpeg",
+                "-hide_banner",
+                "-i",
+                source_url,
+                "-af",
+                "silencedetect=noise=-30dB:d=0.35",
+                "-f",
+                "null",
+                "-",
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            output = f"{result.stdout}\n{result.stderr}"
+
+            nonsilent_segments: list[tuple[int, int]] = []
+            active_start = 0.0
+            min_segment_len = 1.5
+
+            for line in output.splitlines():
+                match_start = re.search(r"silence_start:\s*([0-9]+(?:\.[0-9]+)?)", line)
+                if match_start:
+                    silence_start = float(match_start.group(1))
+                    if silence_start - active_start >= min_segment_len:
+                        nonsilent_segments.append(
+                            (int(active_start), int(min(silence_start, duration_sec)))
+                        )
+                    continue
+
+                match_end = re.search(r"silence_end:\s*([0-9]+(?:\.[0-9]+)?)", line)
+                if match_end:
+                    active_start = float(match_end.group(1))
+
+            if duration_sec - active_start >= min_segment_len:
+                nonsilent_segments.append((int(active_start), int(duration_sec)))
+
+            cleaned = [seg for seg in nonsilent_segments if seg[1] > seg[0]]
+            return cleaned
+        except Exception as exc:
+            logger.warning(f"No se pudo analizar silencios para highlights: {exc}")
+            return []
+
+    def reframe_video(
+        self, video_id: UUID, user_id: UUID, start_sec: int, end_sec: int
+    ) -> JobReframeResponse:
+        video = self._get_user_video(video_id, user_id)
+
+        return self._create_reframe_job(
+            video=video,
+            user_id=user_id,
+            start_sec=start_sec,
+            end_sec=end_sec,
+            allow_reuse=True,
+        )
+
+    def auto_reframe_video(
+        self,
+        video_id: UUID,
+        user_id: UUID,
+        clips_count: int,
+        clip_duration_sec: int,
+    ) -> JobAutoReframeResponse:
+        video = self._get_user_video(video_id, user_id)
+        clip_ranges, used_duration = self._build_auto_clip_ranges(
+            video, clips_count, clip_duration_sec
+        )
+
+        created_jobs: list[JobAutoReframeItem] = []
+        for start_sec, end_sec in clip_ranges:
+            job_response = self._create_reframe_job(
+                video=video,
+                user_id=user_id,
+                start_sec=start_sec,
+                end_sec=end_sec,
+                allow_reuse=False,
+            )
+            created_jobs.append(
+                JobAutoReframeItem(
+                    job_id=job_response.job_id,
+                    job_type=job_response.job_type,
+                    status=job_response.status,
+                    start_sec=job_response.start_sec,
+                    end_sec=job_response.end_sec,
+                    created_at=job_response.created_at,
+                )
+            )
+
+        return JobAutoReframeResponse(
+            video_id=video.id,
+            total_jobs=len(created_jobs),
+            clip_duration_sec=clip_duration_sec,
+            used_video_duration_sec=used_duration,
+            jobs=created_jobs,
+        )
+
+    def list_user_clips(
+        self, user_id: UUID, limit: int = 20, offset: int = 0
+    ) -> UserClipsResponse:
+        base_query = (
+            self.db.query(Job, Video)
+            .join(Video, Video.id == Job.video_id)
+            .filter(
+                Job.user_id == user_id,
+                Job.job_type == JobType.REFRAME,
+                Job.output_path.isnot(None),
+            )
+        )
+
+        total = base_query.count()
+        rows = (
+            base_query.order_by(Job.created_at.desc()).offset(offset).limit(limit).all()
+        )
+
+        clips = [
+            UserClipItem(
+                job_id=job.id,
+                video_id=job.video_id,
+                status=job.status,
+                output_path=job.output_path,
+                source_filename=video.original_filename,
+                created_at=job.created_at,
+            )
+            for job, video in rows
+        ]
+
+        return UserClipsResponse(total=total, limit=limit, offset=offset, clips=clips)

--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -2,6 +2,7 @@ from uuid import UUID
 import re
 import subprocess
 from typing import Literal
+from statistics import median
 from urllib.parse import unquote, urlparse
 from sqlalchemy import String, cast
 from sqlalchemy.orm import Session
@@ -105,6 +106,7 @@ class JobService:
         end_sec: int,
         allow_reuse: bool,
         output_style: Literal["vertical", "speaker_split"] = "vertical",
+        content_profile: Literal["auto", "interview", "sports", "music"] = "auto",
     ) -> JobReframeResponse:
         self._validate_time_range(start_sec, end_sec)
 
@@ -147,6 +149,7 @@ class JobService:
                     start_sec=start_sec,
                     end_sec=end_sec,
                     output_style=output_style,
+                    content_profile=content_profile,
                 )
             except Exception as e:
                 existing_job.status = JobStatus.FAILED
@@ -183,6 +186,7 @@ class JobService:
                 start_sec=start_sec,
                 end_sec=end_sec,
                 output_style=output_style,
+                content_profile=content_profile,
             )
         except Exception as e:
             job.status = JobStatus.FAILED
@@ -201,53 +205,257 @@ class JobService:
         )
 
     def _build_auto_clip_ranges(
-        self, video: Video, clips_count: int, clip_duration_sec: int
-    ) -> tuple[list[tuple[int, int]], int | None]:
+        self,
+        video: Video,
+        clips_count: int | None,
+        clip_duration_sec: int | None,
+        requested_profile: Literal["auto", "interview", "sports", "music"],
+    ) -> tuple[
+        list[tuple[int, int]], int | None, Literal["interview", "sports", "music"]
+    ]:
         duration = self._resolve_video_duration(video)
 
-        if not duration or duration <= 0:
-            starts = [i * clip_duration_sec for i in range(clips_count)]
-            return ([(start, start + clip_duration_sec) for start in starts], None)
-
-        safe_clip_duration = min(clip_duration_sec, max(5, duration))
-        max_start = max(duration - safe_clip_duration, 0)
         source_url = self._get_source_url(video)
+        highlights: list[tuple[int, int]] = []
+        scene_changes: list[int] = []
+        if source_url and duration and duration > 0:
+            highlights = self._extract_nonsilent_segments(source_url, duration)
+            scene_changes = self._extract_scene_change_timestamps(source_url, duration)
+
+        resolved_profile = self._resolve_content_profile(
+            video=video,
+            requested_profile=requested_profile,
+            duration=duration,
+            highlights=highlights,
+            scene_changes=scene_changes,
+        )
+
+        effective_count = self._resolve_auto_clips_count(duration, clips_count)
+        min_len, max_len, default_len = self._profile_duration_policy(resolved_profile)
+        preferred_duration = clip_duration_sec or default_len
+
+        if not duration or duration <= 0:
+            safe_fallback = max(min_len, min(max_len, preferred_duration))
+            starts = [i * safe_fallback for i in range(effective_count)]
+            return (
+                [(start, start + safe_fallback) for start in starts],
+                None,
+                resolved_profile,
+            )
+
+        safe_clip_duration = min(
+            max(min_len, preferred_duration), min(max_len, duration)
+        )
+        max_start = max(duration - safe_clip_duration, 0)
 
         if not source_url:
-            starts = self._distributed_starts(max_start, clips_count)
+            starts = self._distributed_starts(max_start, effective_count)
             ranges = [
                 (start, min(start + safe_clip_duration, duration)) for start in starts
             ]
-            return (ranges, duration)
+            return (ranges, duration, resolved_profile)
 
-        highlights = self._extract_nonsilent_segments(source_url, duration)
         starts: list[int] = []
+        candidate_ranges: dict[int, tuple[int, int]] = {}
         min_gap = max(1, safe_clip_duration // 2)
 
         if highlights:
             scored = sorted(highlights, key=lambda seg: seg[1] - seg[0], reverse=True)
             for start_h, end_h in scored:
+                segment_len = max(1, end_h - start_h)
                 center = (start_h + end_h) / 2
                 start = int(round(center - (safe_clip_duration / 2)))
                 start = max(0, min(max_start, start))
                 if all(abs(start - existing) >= min_gap for existing in starts):
+                    dynamic_len = int(round(segment_len * 0.9))
+                    dynamic_len = max(min_len, min(max_len, dynamic_len))
+                    if resolved_profile == "sports":
+                        start, end = self._sports_context_window(
+                            anchor=int(round(center)),
+                            duration_sec=duration,
+                            base_duration=max(dynamic_len, safe_clip_duration),
+                            min_len=min_len,
+                            max_len=max_len,
+                        )
+                    else:
+                        end = min(start + dynamic_len, duration)
+
                     starts.append(start)
-                if len(starts) >= clips_count:
+                    candidate_ranges[start] = (start, end)
+                if len(starts) >= effective_count:
                     break
 
-        if len(starts) < clips_count:
-            for extra in self._distributed_starts(max_start, clips_count):
+        if len(starts) < effective_count and scene_changes:
+            for ts in scene_changes:
+                start = int(round(ts - (safe_clip_duration / 2)))
+                start = max(0, min(max_start, start))
+                if all(abs(start - existing) >= min_gap for existing in starts):
+                    if resolved_profile == "sports":
+                        start, end = self._sports_context_window(
+                            anchor=ts,
+                            duration_sec=duration,
+                            base_duration=max(safe_clip_duration, 16),
+                            min_len=min_len,
+                            max_len=max_len,
+                        )
+                    else:
+                        end = min(start + safe_clip_duration, duration)
+
+                    starts.append(start)
+                    candidate_ranges[start] = (start, end)
+                if len(starts) >= effective_count:
+                    break
+
+        if len(starts) < effective_count:
+            for extra in self._distributed_starts(max_start, effective_count):
                 if all(abs(extra - existing) >= min_gap for existing in starts):
                     starts.append(extra)
-                if len(starts) >= clips_count:
+                    candidate_ranges[extra] = (
+                        extra,
+                        min(extra + safe_clip_duration, duration),
+                    )
+                if len(starts) >= effective_count:
                     break
 
-        unique_sorted = sorted(set(starts))[:clips_count]
-        ranges = [
-            (start, min(start + safe_clip_duration, duration))
-            for start in unique_sorted
+        unique_sorted = sorted(set(starts))[:effective_count]
+        ranges: list[tuple[int, int]] = []
+        for start in unique_sorted:
+            stored = candidate_ranges.get(start)
+            if stored:
+                start, end = stored
+            else:
+                end = min(start + safe_clip_duration, duration)
+            if end <= start:
+                end = min(duration, start + min_len)
+            ranges.append((start, end))
+
+        return (ranges, duration, resolved_profile)
+
+    def _sports_context_window(
+        self,
+        *,
+        anchor: int,
+        duration_sec: int,
+        base_duration: int,
+        min_len: int,
+        max_len: int,
+    ) -> tuple[int, int]:
+        # En deportes priorizamos contexto previo a la accion (pre-jugada + gol/reaccion).
+        target_len = max(min_len, min(max_len, max(base_duration, 16)))
+        pre_ratio = 0.62
+        pre = int(round(target_len * pre_ratio))
+        post = max(1, target_len - pre)
+
+        start = max(0, anchor - pre)
+        end = min(duration_sec, anchor + post)
+
+        current_len = end - start
+        if current_len < min_len:
+            missing = min_len - current_len
+            extend_right = min(missing, max(0, duration_sec - end))
+            end += extend_right
+            missing -= extend_right
+            if missing > 0:
+                start = max(0, start - missing)
+
+        return (start, end)
+
+    def _resolve_auto_clips_count(
+        self, duration: int | None, requested: int | None
+    ) -> int:
+        if requested is not None:
+            return requested
+        if not duration:
+            return 3
+        if duration < 90:
+            return 2
+        if duration < 300:
+            return 3
+        if duration < 900:
+            return 4
+        return 5
+
+    def _profile_duration_policy(
+        self, profile: Literal["interview", "sports", "music"]
+    ) -> tuple[int, int, int]:
+        if profile == "sports":
+            return (8, 22, 14)
+        if profile == "music":
+            return (12, 32, 20)
+        return (8, 20, 14)
+
+    def _resolve_content_profile(
+        self,
+        *,
+        video: Video,
+        requested_profile: Literal["auto", "interview", "sports", "music"],
+        duration: int | None,
+        highlights: list[tuple[int, int]],
+        scene_changes: list[int],
+    ) -> Literal["interview", "sports", "music"]:
+        if requested_profile != "auto":
+            return requested_profile
+
+        filename = (video.original_filename or "").lower()
+        sports_keywords = ["gol", "football", "futbol", "soccer", "liga", "vs", "match"]
+        music_keywords = [
+            "music",
+            "musica",
+            "song",
+            "live",
+            "lyrics",
+            "concierto",
+            "karaoke",
         ]
-        return (ranges, duration)
+
+        if any(key in filename for key in sports_keywords):
+            return "sports"
+        if any(key in filename for key in music_keywords):
+            return "music"
+
+        if not duration or duration <= 0:
+            return "interview"
+
+        nonsilent_seconds = sum(max(0, end - start) for start, end in highlights)
+        nonsilent_ratio = nonsilent_seconds / duration if duration > 0 else 0
+        scenes_per_min = (len(scene_changes) / max(duration, 1)) * 60
+
+        if scenes_per_min >= 18 and nonsilent_ratio >= 0.45:
+            return "sports"
+        if nonsilent_ratio >= 0.8 and scenes_per_min <= 12:
+            return "music"
+        return "interview"
+
+    def _extract_scene_change_timestamps(
+        self, source_url: str, duration_sec: int
+    ) -> list[int]:
+        try:
+            cmd = [
+                "ffmpeg",
+                "-hide_banner",
+                "-i",
+                source_url,
+                "-vf",
+                "select='gt(scene,0.35)',showinfo",
+                "-an",
+                "-f",
+                "null",
+                "-",
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            output = f"{result.stdout}\n{result.stderr}"
+            timestamps: list[int] = []
+            for line in output.splitlines():
+                match = re.search(r"pts_time:([0-9]+(?:\.[0-9]+)?)", line)
+                if not match:
+                    continue
+                ts = int(float(match.group(1)))
+                if 0 <= ts <= duration_sec:
+                    timestamps.append(ts)
+            return sorted(set(timestamps))
+        except Exception as exc:
+            logger.warning(f"No se pudo detectar cambios de escena: {exc}")
+            return []
 
     def _distributed_starts(self, max_start: int, clips_count: int) -> list[int]:
         if clips_count <= 1:
@@ -357,17 +565,19 @@ class JobService:
         face_tracking: bool | None = None,
         color_filter: bool | None = None,
         output_style: Literal["vertical", "speaker_split"] = "vertical",
+        content_profile: Literal["auto", "interview", "sports", "music"] = "auto",
     ) -> JobReframeResponse:
         video = self._get_user_video(video_id, user_id)
 
         logger.info(
-            "Reframe options for video %s: crop_to_vertical=%s subtitles=%s face_tracking=%s color_filter=%s output_style=%s",
+            "Reframe options for video %s: crop_to_vertical=%s subtitles=%s face_tracking=%s color_filter=%s output_style=%s content_profile=%s",
             video_id,
             crop_to_vertical,
             subtitles,
             face_tracking,
             color_filter,
             output_style,
+            content_profile,
         )
 
         return self._create_reframe_job(
@@ -375,21 +585,26 @@ class JobService:
             user_id=user_id,
             start_sec=start_sec,
             end_sec=end_sec,
-            allow_reuse=True,
+            allow_reuse=False,
             output_style=output_style,
+            content_profile=content_profile,
         )
 
     def auto_reframe_video(
         self,
         video_id: UUID,
         user_id: UUID,
-        clips_count: int,
-        clip_duration_sec: int,
+        clips_count: int | None,
+        clip_duration_sec: int | None,
         output_style: Literal["vertical", "speaker_split"] = "vertical",
+        content_profile: Literal["auto", "interview", "sports", "music"] = "auto",
     ) -> JobAutoReframeResponse:
         video = self._get_user_video(video_id, user_id)
-        clip_ranges, used_duration = self._build_auto_clip_ranges(
-            video, clips_count, clip_duration_sec
+        clip_ranges, used_duration, resolved_profile = self._build_auto_clip_ranges(
+            video,
+            clips_count,
+            clip_duration_sec,
+            content_profile,
         )
 
         created_jobs: list[JobAutoReframeItem] = []
@@ -401,6 +616,7 @@ class JobService:
                 end_sec=end_sec,
                 allow_reuse=False,
                 output_style=output_style,
+                content_profile=resolved_profile,
             )
             created_jobs.append(
                 JobAutoReframeItem(
@@ -413,10 +629,16 @@ class JobService:
                 )
             )
 
+        effective_duration = (
+            int(round(median([max(1, end - start) for start, end in clip_ranges])))
+            if clip_ranges
+            else (clip_duration_sec or 15)
+        )
+
         return JobAutoReframeResponse(
             video_id=video.id,
             total_jobs=len(created_jobs),
-            clip_duration_sec=clip_duration_sec,
+            clip_duration_sec=effective_duration,
             used_video_duration_sec=used_duration,
             jobs=created_jobs,
         )

--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -2,6 +2,7 @@ from uuid import UUID
 import re
 import subprocess
 from urllib.parse import unquote, urlparse
+from sqlalchemy import String, cast
 from sqlalchemy.orm import Session
 from app.models.job import Job, JobStatus, JobType
 from app.models.video import Video
@@ -393,7 +394,7 @@ class JobService:
         )
 
     def list_user_clips(
-        self, user_id: UUID, limit: int = 20, offset: int = 0
+        self, user_id: UUID, limit: int = 20, offset: int = 0, query: str | None = None
     ) -> UserClipsResponse:
         base_query = (
             self.db.query(Job, Video)
@@ -404,6 +405,14 @@ class JobService:
                 Job.output_path.isnot(None),
             )
         )
+
+        cleaned_query = (query or "").strip()
+        if cleaned_query:
+            like_term = f"%{cleaned_query}%"
+            base_query = base_query.filter(
+                (Video.original_filename.ilike(like_term))
+                | (cast(Job.id, String).ilike(like_term))
+            )
 
         total = base_query.count()
         rows = (

--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 import re
 import subprocess
+from typing import Literal
 from urllib.parse import unquote, urlparse
 from sqlalchemy import String, cast
 from sqlalchemy.orm import Session
@@ -103,6 +104,7 @@ class JobService:
         start_sec: int,
         end_sec: int,
         allow_reuse: bool,
+        output_style: Literal["vertical", "speaker_split"] = "vertical",
     ) -> JobReframeResponse:
         self._validate_time_range(start_sec, end_sec)
 
@@ -144,6 +146,7 @@ class JobService:
                     user_id=str(user_id),
                     start_sec=start_sec,
                     end_sec=end_sec,
+                    output_style=output_style,
                 )
             except Exception as e:
                 existing_job.status = JobStatus.FAILED
@@ -179,6 +182,7 @@ class JobService:
                 user_id=str(user_id),
                 start_sec=start_sec,
                 end_sec=end_sec,
+                output_style=output_style,
             )
         except Exception as e:
             job.status = JobStatus.FAILED
@@ -352,16 +356,18 @@ class JobService:
         subtitles: bool | None = None,
         face_tracking: bool | None = None,
         color_filter: bool | None = None,
+        output_style: Literal["vertical", "speaker_split"] = "vertical",
     ) -> JobReframeResponse:
         video = self._get_user_video(video_id, user_id)
 
         logger.info(
-            "Reframe options for video %s: crop_to_vertical=%s subtitles=%s face_tracking=%s color_filter=%s",
+            "Reframe options for video %s: crop_to_vertical=%s subtitles=%s face_tracking=%s color_filter=%s output_style=%s",
             video_id,
             crop_to_vertical,
             subtitles,
             face_tracking,
             color_filter,
+            output_style,
         )
 
         return self._create_reframe_job(
@@ -370,6 +376,7 @@ class JobService:
             start_sec=start_sec,
             end_sec=end_sec,
             allow_reuse=True,
+            output_style=output_style,
         )
 
     def auto_reframe_video(
@@ -378,6 +385,7 @@ class JobService:
         user_id: UUID,
         clips_count: int,
         clip_duration_sec: int,
+        output_style: Literal["vertical", "speaker_split"] = "vertical",
     ) -> JobAutoReframeResponse:
         video = self._get_user_video(video_id, user_id)
         clip_ranges, used_duration = self._build_auto_clip_ranges(
@@ -392,6 +400,7 @@ class JobService:
                 start_sec=start_sec,
                 end_sec=end_sec,
                 allow_reuse=False,
+                output_style=output_style,
             )
             created_jobs.append(
                 JobAutoReframeItem(

--- a/backend/api/app/services/queue_service.py
+++ b/backend/api/app/services/queue_service.py
@@ -3,19 +3,29 @@ from app.core.logging import setup_logging
 
 logger = setup_logging()
 
+
 class QueueService:
     def __init__(self, redis_client):
         self.redis = redis_client
 
-    def publish_reframe_job(self, job_id: str, video_id: str, user_id: str, start_sec: int, end_sec: int):
-        # idealmente, solo enviamos job_id y que el worker consulte tabla Jobs; 
+    def publish_reframe_job(
+        self,
+        job_id: str,
+        video_id: str,
+        user_id: str,
+        start_sec: int,
+        end_sec: int,
+        output_style: str = "vertical",
+    ):
+        # idealmente, solo enviamos job_id y que el worker consulte tabla Jobs;
         payload = {
             "job_id": job_id,
             "video_id": video_id,
             "user_id": user_id,
             "start_sec": start_sec,
             "end_sec": end_sec,
-            "type": "REFRAME"
+            "output_style": output_style,
+            "type": "REFRAME",
         }
         self.redis.push_to_queue("reframe_queue", payload)
 

--- a/backend/api/app/services/queue_service.py
+++ b/backend/api/app/services/queue_service.py
@@ -16,6 +16,7 @@ class QueueService:
         start_sec: int,
         end_sec: int,
         output_style: str = "vertical",
+        content_profile: str = "interview",
     ):
         # idealmente, solo enviamos job_id y que el worker consulte tabla Jobs;
         payload = {
@@ -25,6 +26,7 @@ class QueueService:
             "start_sec": start_sec,
             "end_sec": end_sec,
             "output_style": output_style,
+            "content_profile": content_profile,
             "type": "REFRAME",
         }
         self.redis.push_to_queue("reframe_queue", payload)

--- a/backend/api/app/services/video_service.py
+++ b/backend/api/app/services/video_service.py
@@ -12,6 +12,8 @@ from botocore.exceptions import ClientError
 from app.core.config import settings
 from app.models.video import Video
 from app.schemas.video import (
+    UpdateVideoRequest,
+    UserVideoDetailResponse,
     VideoUploadResponse,
     VideoURLResponse,
     UserVideoItem,
@@ -21,6 +23,7 @@ from app.utils.exceptions import (
     BadRequestException,
     MinIOStorageException,
     NotFoundException,
+    ForbiddenException,
     VideoDBException,
     VideoValidationException,
 )
@@ -131,13 +134,15 @@ class VideoService:
 
         return size_bytes
 
-    def _create_video_record(self, original_filename: str, user_id: UUID) -> Video:
+    def _create_video_record(
+        self, original_filename: str, user_id: UUID | None
+    ) -> Video:
         """
         Crea un registro de video en la base de datos.
 
         Args:
             original_filename: Nombre original del archivo
-            user_id: ID del usuario autenticado
+            user_id: ID del usuario (None para uploads públicos)
 
         Returns:
             Video creado
@@ -161,34 +166,14 @@ class VideoService:
             raise VideoDBException("Error creando registro de video", str(exc))
 
     def _extract_metadata(self, storage_path: str) -> dict:
-        """
-        Extrae metadata del video en MinIO usando ffprobe.
-
-        Args:
-            storage_path: Ruta del video en formato s3://bucket/key
-
-        Returns:
-            Dict con la metadata extraída (vacío si falla)
-        """
         try:
-            # Extraer bucket y object_key del storage_path
-            storage_path_clean = storage_path.replace("s3://", "")
-            parts = storage_path_clean.split("/", 1)
-            if len(parts) != 2:
-                print(f"Formato de storage_path inválido: {storage_path}")
-                return {}
-
-            bucket, object_key = parts
-
-            # Generar URL presignada para que ffprobe pueda acceder
+            bucket, object_key = self._extract_bucket_and_key(storage_path)
             s3_client = self._get_s3_client()
             presigned_url = s3_client.generate_presigned_url(
                 "get_object",
                 Params={"Bucket": bucket, "Key": object_key},
                 ExpiresIn=3600,
             )
-
-            # Usar ffprobe con la URL presignada
             cmd = [
                 "ffprobe",
                 "-v",
@@ -201,24 +186,12 @@ class VideoService:
             ]
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
             if result.returncode != 0:
-                print(f"ffprobe error: {result.stderr}")
                 return {}
             return json.loads(result.stdout) if result.stdout else {}
-        except Exception as e:
-            print(f"Error extrayendo metadata: {e}")
-            import traceback
-
-            traceback.print_exc()
+        except Exception:
             return {}
 
     def _save_metadata_to_video(self, video: Video, metadata: dict) -> None:
-        """
-        Actualiza el registro del video con metadata extraída.
-
-        Args:
-            video: Objeto Video a actualizar
-            metadata: Dict con metadata extraída por ffprobe
-        """
         try:
             if metadata.get("format"):
                 video.duration_seconds = int(
@@ -226,7 +199,7 @@ class VideoService:
                 )
 
             for stream in metadata.get("streams", []):
-                if stream["codec_type"] == "video":
+                if stream.get("codec_type") == "video":
                     fps_str = stream.get("r_frame_rate", "0")
                     if fps_str and "/" in str(fps_str):
                         fps_value = float(fps_str.split("/")[0])
@@ -235,14 +208,160 @@ class VideoService:
                     video.height = stream.get("height")
                     video.codec = stream.get("codec_name")
                     video.bitrate = stream.get("bit_rate")
-                elif stream["codec_type"] == "audio":
+                elif stream.get("codec_type") == "audio":
                     video.has_audio = True
                     video.audio_codec = stream.get("codec_name")
 
             self.db.commit()
-        except Exception as e:
-            print(f"Error guardando metadata: {e}")
+        except Exception:
             self.db.rollback()
+
+    def _extract_bucket_and_key(self, storage_path: str) -> tuple[str, str]:
+        cleaned_path = storage_path.replace("s3://", "")
+        parts = cleaned_path.split("/", 1)
+        if len(parts) != 2:
+            raise BadRequestException("Formato de storage_path inválido")
+        return (parts[0], parts[1])
+
+    def _build_preview_url(self, video: Video, expires_in: int = 3600) -> str | None:
+        if not video.storage_path:
+            return None
+        try:
+            return self.get_video_url(video.id, expires_in=expires_in).url
+        except Exception:
+            return None
+
+    def _get_user_video(self, video_id: UUID, user_id: UUID) -> Video:
+        video = self.db.query(Video).filter(Video.id == video_id).first()
+        if not video:
+            raise NotFoundException(f"Video con ID {video_id} no encontrado")
+        if video.user_id != user_id:
+            raise ForbiddenException("No tienes permisos para acceder a este video")
+        return video
+
+    def _to_user_video_item(self, video: Video) -> UserVideoItem:
+        return UserVideoItem(
+            video_id=video.id,
+            filename=video.original_filename,
+            status=video.status,
+            uploaded_at=video.created_at,
+            preview_url=self._build_preview_url(video),
+        )
+
+    def get_user_video(self, video_id: UUID, user_id: UUID) -> UserVideoDetailResponse:
+        video = self._get_user_video(video_id, user_id)
+        return UserVideoDetailResponse(
+            video_id=video.id,
+            filename=video.original_filename,
+            status=video.status,
+            uploaded_at=video.created_at,
+            updated_at=video.updated_at,
+            storage_path=video.storage_path,
+            preview_url=self._build_preview_url(video),
+        )
+
+    def update_user_video(
+        self, video_id: UUID, user_id: UUID, payload: UpdateVideoRequest
+    ) -> UserVideoItem:
+        video = self._get_user_video(video_id, user_id)
+        cleaned_filename = payload.filename.strip()
+        if not cleaned_filename:
+            raise BadRequestException("El nombre de archivo no puede estar vacío")
+
+        try:
+            video.original_filename = cleaned_filename
+            self.db.commit()
+            self.db.refresh(video)
+        except Exception as exc:
+            self.db.rollback()
+            raise VideoDBException("Error actualizando metadata del video", str(exc))
+
+        return self._to_user_video_item(video)
+
+    def delete_user_video(self, video_id: UUID, user_id: UUID) -> None:
+        video = self._get_user_video(video_id, user_id)
+
+        if video.storage_path:
+            bucket, object_key = self._extract_bucket_and_key(video.storage_path)
+            s3_client = self._get_s3_client()
+            try:
+                s3_client.delete_object(Bucket=bucket, Key=object_key)
+            except ClientError as exc:
+                error_code = exc.response.get("Error", {}).get("Code")
+                if error_code not in {"NoSuchKey", "404"}:
+                    raise MinIOStorageException(
+                        "Error eliminando archivo de MinIO", str(exc)
+                    )
+
+        try:
+            self.db.delete(video)
+            self.db.commit()
+        except Exception as exc:
+            self.db.rollback()
+            raise VideoDBException("Error eliminando video", str(exc))
+
+    def upload_video_public(self, file: UploadFile) -> VideoUploadResponse:
+        """
+        Sube un video públicamente (sin autenticación) - Solo para desarrollo.
+
+        Args:
+            file: Archivo subido
+
+        Returns:
+            VideoUploadResponse con información del video subido
+
+        Raises:
+            VideoValidationException: Si el archivo no es válido
+            MinIOStorageException: Si falla la subida a MinIO
+            VideoDBException: Si falla guardar en base de datos
+        """
+        size_bytes = self._validate_file(file)
+
+        bucket = settings.MINIO_BUCKET_VIDEOS
+        object_key = f"public/{uuid4()}_{file.filename}"
+
+        s3_client = self._get_s3_client()
+        try:
+            self._ensure_bucket_exists(s3_client, bucket)
+            file.file.seek(0)
+            extra_args = (
+                {"ContentType": file.content_type} if file.content_type else None
+            )
+            if extra_args:
+                s3_client.upload_fileobj(
+                    file.file, bucket, object_key, ExtraArgs=extra_args
+                )
+            else:
+                s3_client.upload_fileobj(file.file, bucket, object_key)
+        except ClientError as exc:
+            raise MinIOStorageException("Error subiendo archivo a MinIO", str(exc))
+        except Exception as exc:
+            raise MinIOStorageException("Error inesperado durante subida", str(exc))
+
+        # Crear registro en DB
+        video = self._create_video_record(file.filename, None)
+
+        # Actualizar storage_path
+        try:
+            video.storage_path = f"s3://{bucket}/{object_key}"
+            self.db.commit()
+        except Exception as exc:
+            raise VideoDBException("Error actualizando storage_path", str(exc))
+
+        metadata = self._extract_metadata(video.storage_path)
+        self._save_metadata_to_video(video, metadata)
+
+        return VideoUploadResponse(
+            video_id=video.id,
+            bucket=bucket,
+            object_key=object_key,
+            filename=file.filename,
+            content_type=file.content_type,
+            size_bytes=size_bytes,
+            user_id=None,
+            storage_path=video.storage_path,
+            uploaded_at=datetime.utcnow(),
+        )
 
     def upload_video_authenticated(
         self, file: UploadFile, user_id: UUID
@@ -295,7 +414,6 @@ class VideoService:
         except Exception as exc:
             raise VideoDBException("Error actualizando storage_path", str(exc))
 
-        # Extraer y guardar metadata
         metadata = self._extract_metadata(video.storage_path)
         self._save_metadata_to_video(video, metadata)
 
@@ -338,11 +456,7 @@ class VideoService:
 
         # Extraer bucket y object_key del storage_path (formato: s3://bucket/key)
         try:
-            storage_path = video.storage_path.replace("s3://", "")
-            parts = storage_path.split("/", 1)
-            if len(parts) != 2:
-                raise ValueError("Formato de storage_path inválido")
-            bucket, object_key = parts
+            bucket, object_key = self._extract_bucket_and_key(video.storage_path)
         except Exception as exc:
             raise BadRequestException(f"Error procesando storage_path: {str(exc)}")
 
@@ -397,26 +511,8 @@ class VideoService:
 
         videos: list[UserVideoItem] = []
         for video in rows:
-            preview_url = None
-            if video.storage_path:
-                try:
-                    preview_url = self.get_video_url(video.id, expires_in=3600).url
-                except Exception:
-                    preview_url = None
-
-            videos.append(
-                UserVideoItem(
-                    video_id=video.id,
-                    filename=video.original_filename,
-                    status=video.status,
-                    uploaded_at=video.created_at,
-                    preview_url=preview_url,
-                )
-            )
+            videos.append(self._to_user_video_item(video))
 
         return UserVideosResponse(
-            total=total,
-            limit=limit,
-            offset=offset,
-            videos=videos,
+            total=total, limit=limit, offset=offset, videos=videos
         )

--- a/backend/api/app/services/video_service.py
+++ b/backend/api/app/services/video_service.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 from fastapi import UploadFile
+from sqlalchemy import String, cast
 from sqlalchemy.orm import Session
 import boto3
 import subprocess
@@ -10,7 +11,12 @@ from botocore.exceptions import ClientError
 
 from app.core.config import settings
 from app.models.video import Video
-from app.schemas.video import VideoUploadResponse, VideoURLResponse
+from app.schemas.video import (
+    VideoUploadResponse,
+    VideoURLResponse,
+    UserVideoItem,
+    UserVideosResponse,
+)
 from app.utils.exceptions import (
     BadRequestException,
     MinIOStorageException,
@@ -22,9 +28,9 @@ from app.utils.exceptions import (
 
 class VideoService:
     """Servicio de videos - Maneja validación, almacenamiento y metadata"""
-    
+
     # Configuración de validación
-    MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024  
+    MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024
     ALLOWED_EXTENSIONS = {"mp4", "mkv", "avi", "mov", "flv", "wmv", "webm", "m4v"}
     ALLOWED_MIME_TYPES = {
         "video/mp4",
@@ -33,12 +39,12 @@ class VideoService:
         "video/quicktime",
         "video/x-flv",
         "video/x-ms-wmv",
-        "video/webm"
+        "video/webm",
     }
-    
+
     def __init__(self, db: Session):
         self.db = db
-    
+
     def _get_s3_client(self, endpoint: str | None = None, secure: bool | None = None):
         """Obtiene cliente S3 configurado para MinIO"""
         selected_endpoint = endpoint or settings.MINIO_ENDPOINT
@@ -51,13 +57,13 @@ class VideoService:
             aws_access_key_id=settings.MINIO_ACCESS_KEY,
             aws_secret_access_key=settings.MINIO_SECRET_KEY,
             region_name="us-east-1",
-            config=Config(signature_version="s3v4", s3={"addressing_style": "path"})
+            config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
         )
-    
+
     def _ensure_bucket_exists(self, s3_client, bucket: str) -> None:
         """
         Crea el bucket si no existe.
-        
+
         Raises:
             MinIOStorageException: Si no se puede verificar/crear el bucket
         """
@@ -68,77 +74,74 @@ class VideoService:
                 s3_client.create_bucket(Bucket=bucket)
             except ClientError as create_exc:
                 raise MinIOStorageException(
-                    f"Error creando bucket '{bucket}'",
-                    str(create_exc)
+                    f"Error creando bucket '{bucket}'", str(create_exc)
                 )
-    
+
     def _validate_file(self, file: UploadFile) -> int:
         """
         Valida el archivo subido.
-        
+
         Args:
             file: Archivo subido
-            
+
         Returns:
             Tamaño del archivo en bytes
-            
+
         Raises:
             VideoValidationException: Si el archivo no cumple los requisitos
         """
         # Validar nombre
         if not file.filename:
             raise VideoValidationException("El archivo debe tener un nombre")
-        
+
         # Validar extensión
         ext = file.filename.rsplit(".", 1)[-1].lower() if "." in file.filename else ""
         if ext not in self.ALLOWED_EXTENSIONS:
             raise VideoValidationException(
                 f"Extensión no permitida. Extensiones válidas: {', '.join(sorted(self.ALLOWED_EXTENSIONS))}"
             )
-        
+
         # Validar MIME type
         if file.content_type:
             if file.content_type not in self.ALLOWED_MIME_TYPES:
                 raise VideoValidationException(
                     f"Tipo de archivo no válido. MIME type: {file.content_type}"
                 )
-        
+
         # Obtener tamaño
         try:
             file.file.seek(0, 2)
             size_bytes = file.file.tell()
             file.file.seek(0)
         except Exception:
-            raise VideoValidationException("No se pudo determinar el tamaño del archivo")
-        
+            raise VideoValidationException(
+                "No se pudo determinar el tamaño del archivo"
+            )
+
         # Validar tamaño no vacío
         if size_bytes == 0:
             raise VideoValidationException("El archivo está vacío")
-        
+
         # Validar tamaño máximo
         if size_bytes > self.MAX_FILE_SIZE_BYTES:
             max_mb = self.MAX_FILE_SIZE_BYTES / (1024 * 1024)
             raise VideoValidationException(
                 f"El archivo excede el tamaño máximo permitido ({max_mb}MB)"
             )
-        
+
         return size_bytes
-    
-    def _create_video_record(
-        self,
-        original_filename: str,
-        user_id: UUID
-    ) -> Video:
+
+    def _create_video_record(self, original_filename: str, user_id: UUID) -> Video:
         """
         Crea un registro de video en la base de datos.
-        
+
         Args:
             original_filename: Nombre original del archivo
             user_id: ID del usuario autenticado
-            
+
         Returns:
             Video creado
-            
+
         Raises:
             VideoDBException: Si falla la creación del registro
         """
@@ -147,7 +150,7 @@ class VideoService:
                 user_id=user_id,
                 original_filename=original_filename,
                 storage_path=None,
-                status="uploaded"
+                status="uploaded",
             )
             self.db.add(video)
             self.db.commit()
@@ -156,14 +159,14 @@ class VideoService:
         except Exception as exc:
             self.db.rollback()
             raise VideoDBException("Error creando registro de video", str(exc))
-    
+
     def _extract_metadata(self, storage_path: str) -> dict:
         """
         Extrae metadata del video en MinIO usando ffprobe.
-        
+
         Args:
             storage_path: Ruta del video en formato s3://bucket/key
-            
+
         Returns:
             Dict con la metadata extraída (vacío si falla)
         """
@@ -174,23 +177,27 @@ class VideoService:
             if len(parts) != 2:
                 print(f"Formato de storage_path inválido: {storage_path}")
                 return {}
-            
+
             bucket, object_key = parts
-            
+
             # Generar URL presignada para que ffprobe pueda acceder
             s3_client = self._get_s3_client()
             presigned_url = s3_client.generate_presigned_url(
-                'get_object',
-                Params={'Bucket': bucket, 'Key': object_key},
-                ExpiresIn=3600
+                "get_object",
+                Params={"Bucket": bucket, "Key": object_key},
+                ExpiresIn=3600,
             )
-            
+
             # Usar ffprobe con la URL presignada
             cmd = [
-                "ffprobe", "-v", "quiet",
-                "-print_format", "json",
-                "-show_format", "-show_streams",
-                presigned_url
+                "ffprobe",
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_format",
+                "-show_streams",
+                presigned_url,
             ]
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
             if result.returncode != 0:
@@ -200,21 +207,24 @@ class VideoService:
         except Exception as e:
             print(f"Error extrayendo metadata: {e}")
             import traceback
+
             traceback.print_exc()
             return {}
-    
+
     def _save_metadata_to_video(self, video: Video, metadata: dict) -> None:
         """
         Actualiza el registro del video con metadata extraída.
-        
+
         Args:
             video: Objeto Video a actualizar
             metadata: Dict con metadata extraída por ffprobe
         """
         try:
             if metadata.get("format"):
-                video.duration_seconds = int(float(metadata["format"].get("duration", 0)))
-            
+                video.duration_seconds = int(
+                    float(metadata["format"].get("duration", 0))
+                )
+
             for stream in metadata.get("streams", []):
                 if stream["codec_type"] == "video":
                     fps_str = stream.get("r_frame_rate", "0")
@@ -228,65 +238,67 @@ class VideoService:
                 elif stream["codec_type"] == "audio":
                     video.has_audio = True
                     video.audio_codec = stream.get("codec_name")
-            
+
             self.db.commit()
         except Exception as e:
             print(f"Error guardando metadata: {e}")
             self.db.rollback()
-    
+
     def upload_video_authenticated(
-        self,
-        file: UploadFile,
-        user_id: UUID
+        self, file: UploadFile, user_id: UUID
     ) -> VideoUploadResponse:
         """
         Sube un video asociado a un usuario autenticado.
-        
+
         Args:
             file: Archivo subido
             user_id: ID del usuario
-            
+
         Returns:
             VideoUploadResponse con información del video subido
-            
+
         Raises:
             VideoValidationException: Si el archivo no es válido
             MinIOStorageException: Si falla la subida a MinIO
             VideoDBException: Si falla guardar en base de datos
         """
         size_bytes = self._validate_file(file)
-        
+
         bucket = settings.MINIO_BUCKET_VIDEOS
         object_key = f"{user_id}/{uuid4()}_{file.filename}"
-        
+
         s3_client = self._get_s3_client()
         try:
             self._ensure_bucket_exists(s3_client, bucket)
             file.file.seek(0)
-            extra_args = {"ContentType": file.content_type} if file.content_type else None
+            extra_args = (
+                {"ContentType": file.content_type} if file.content_type else None
+            )
             if extra_args:
-                s3_client.upload_fileobj(file.file, bucket, object_key, ExtraArgs=extra_args)
+                s3_client.upload_fileobj(
+                    file.file, bucket, object_key, ExtraArgs=extra_args
+                )
             else:
                 s3_client.upload_fileobj(file.file, bucket, object_key)
         except ClientError as exc:
             raise MinIOStorageException("Error subiendo archivo a MinIO", str(exc))
         except Exception as exc:
             raise MinIOStorageException("Error inesperado durante subida", str(exc))
-        
+
         # Crear registro en DB
         video = self._create_video_record(file.filename, user_id)
-        
+
         # Actualizar storage_path
         try:
             video.storage_path = f"s3://{bucket}/{object_key}"
             self.db.commit()
         except Exception as exc:
             raise VideoDBException("Error actualizando storage_path", str(exc))
-        
+
         # Extraer y guardar metadata
         metadata = self._extract_metadata(video.storage_path)
         self._save_metadata_to_video(video, metadata)
-        
+
         return VideoUploadResponse(
             video_id=video.id,
             bucket=bucket,
@@ -296,20 +308,20 @@ class VideoService:
             size_bytes=size_bytes,
             user_id=user_id,
             storage_path=video.storage_path,
-            uploaded_at=datetime.utcnow()
+            uploaded_at=datetime.utcnow(),
         )
-    
+
     def get_video_url(self, video_id: UUID, expires_in: int = 3600) -> VideoURLResponse:
         """
         Genera una URL presignada para descargar el video.
-        
+
         Args:
             video_id: ID del video
             expires_in: Tiempo de expiración en segundos (default: 1 hora)
-            
+
         Returns:
             VideoURLResponse con la URL presignada
-            
+
         Raises:
             HTTPException: Si el video no existe o no tiene storage_path
             MinIOStorageException: Si falla la generación de URL
@@ -318,10 +330,12 @@ class VideoService:
         video = self.db.query(Video).filter(Video.id == video_id).first()
         if not video:
             raise NotFoundException(f"Video con ID {video_id} no encontrado")
-        
+
         if not video.storage_path:
-            raise BadRequestException("El video no tiene una ruta de almacenamiento válida")
-        
+            raise BadRequestException(
+                "El video no tiene una ruta de almacenamiento válida"
+            )
+
         # Extraer bucket y object_key del storage_path (formato: s3://bucket/key)
         try:
             storage_path = video.storage_path.replace("s3://", "")
@@ -331,23 +345,78 @@ class VideoService:
             bucket, object_key = parts
         except Exception as exc:
             raise BadRequestException(f"Error procesando storage_path: {str(exc)}")
-        
+
         # Generar URL presignada usando endpoint público
         public_endpoint = settings.MINIO_PUBLIC_ENDPOINT or settings.MINIO_ENDPOINT
-        public_secure = settings.MINIO_SECURE if settings.MINIO_PUBLIC_SECURE is None else settings.MINIO_PUBLIC_SECURE
+        public_secure = (
+            settings.MINIO_SECURE
+            if settings.MINIO_PUBLIC_SECURE is None
+            else settings.MINIO_PUBLIC_SECURE
+        )
         s3_client = self._get_s3_client(endpoint=public_endpoint, secure=public_secure)
         try:
             url = s3_client.generate_presigned_url(
-                'get_object',
-                Params={'Bucket': bucket, 'Key': object_key},
-                ExpiresIn=expires_in
+                "get_object",
+                Params={"Bucket": bucket, "Key": object_key},
+                ExpiresIn=expires_in,
             )
         except ClientError as exc:
             raise MinIOStorageException("Error generando URL presignada", str(exc))
-        
+
         return VideoURLResponse(
             video_id=video.id,
             url=url,
             expires_in_seconds=expires_in,
-            filename=video.original_filename
+            filename=video.original_filename,
+        )
+
+    def list_user_videos(
+        self,
+        user_id: UUID,
+        limit: int = 20,
+        offset: int = 0,
+        query: str | None = None,
+    ) -> UserVideosResponse:
+        base_query = self.db.query(Video).filter(Video.user_id == user_id)
+
+        cleaned_query = (query or "").strip()
+        if cleaned_query:
+            like_term = f"%{cleaned_query}%"
+            base_query = base_query.filter(
+                (Video.original_filename.ilike(like_term))
+                | (cast(Video.id, String).ilike(like_term))
+            )
+
+        total = base_query.count()
+        rows = (
+            base_query.order_by(Video.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+
+        videos: list[UserVideoItem] = []
+        for video in rows:
+            preview_url = None
+            if video.storage_path:
+                try:
+                    preview_url = self.get_video_url(video.id, expires_in=3600).url
+                except Exception:
+                    preview_url = None
+
+            videos.append(
+                UserVideoItem(
+                    video_id=video.id,
+                    filename=video.original_filename,
+                    status=video.status,
+                    uploaded_at=video.created_at,
+                    preview_url=preview_url,
+                )
+            )
+
+        return UserVideosResponse(
+            total=total,
+            limit=limit,
+            offset=offset,
+            videos=videos,
         )

--- a/backend/api/app/services/video_worker_service.py
+++ b/backend/api/app/services/video_worker_service.py
@@ -4,11 +4,14 @@ from uuid import UUID, uuid4
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from app.core.config import settings
-from app.utils.exceptions import BadRequestException, MinIOStorageException, VideoDBException
+from app.utils.exceptions import (
+    BadRequestException,
+    MinIOStorageException,
+    VideoDBException,
+)
 
 
 class VideoWorkerService:
-
     def __init__(self):
         self.client = boto3.client(
             "s3",
@@ -16,7 +19,7 @@ class VideoWorkerService:
             aws_access_key_id=settings.MINIO_ACCESS_KEY,
             aws_secret_access_key=settings.MINIO_SECRET_KEY,
             region_name="us-east-1",
-            config=Config(signature_version="s3v4", s3={"addressing_style": "path"})
+            config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
         )
 
     def _get_s3_client(self, endpoint: str | None = None, secure: bool | None = None):
@@ -31,14 +34,13 @@ class VideoWorkerService:
             aws_access_key_id=settings.MINIO_ACCESS_KEY,
             aws_secret_access_key=settings.MINIO_SECRET_KEY,
             region_name="us-east-1",
-            config=Config(signature_version="s3v4", s3={"addressing_style": "path"})
+            config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
         )
-
 
     def _ensure_bucket_exists(self, s3_client, bucket: str) -> None:
         """
         Crea el bucket si no existe.
-        
+
         Raises:
             MinIOStorageException: Si no se puede verificar/crear el bucket
         """
@@ -49,19 +51,14 @@ class VideoWorkerService:
                 s3_client.create_bucket(Bucket=bucket)
             except ClientError as create_exc:
                 raise MinIOStorageException(
-                    f"Error creando bucket '{bucket}'",
-                    str(create_exc)
+                    f"Error creando bucket '{bucket}'", str(create_exc)
                 )
-
 
     def get_video_url(self, storage_path: str, expires_in: int = 3600) -> str:
         bucket, key = storage_path.replace("s3://", "").split("/", 1)
         return self.client.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": bucket, "Key": key},
-            ExpiresIn=expires_in
+            "get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=expires_in
         )
-    
 
     def get_video_public_url(self, storage_path: str, expires_in: int = 3600) -> str:
         try:
@@ -72,18 +69,24 @@ class VideoWorkerService:
             bucket, object_key = parts
         except Exception as exc:
             raise BadRequestException(f"Error procesando storage_path: {str(exc)}")
-        
+
         # Generar URL presignada usando endpoint público
         public_endpoint = settings.MINIO_PUBLIC_ENDPOINT or settings.MINIO_ENDPOINT
-        public_secure = settings.MINIO_SECURE if settings.MINIO_PUBLIC_SECURE is None else settings.MINIO_PUBLIC_SECURE
-        print(f"Generando URL pública con endpoint {public_endpoint} (secure={public_secure})")
+        public_secure = (
+            settings.MINIO_SECURE
+            if settings.MINIO_PUBLIC_SECURE is None
+            else settings.MINIO_PUBLIC_SECURE
+        )
+        print(
+            f"Generando URL pública con endpoint {public_endpoint} (secure={public_secure})"
+        )
         print(f"MINIO_PUBLIC_ENDPOINT: {settings.MINIO_PUBLIC_ENDPOINT}")
         s3_client = self._get_s3_client(endpoint=public_endpoint, secure=public_secure)
         try:
             url = s3_client.generate_presigned_url(
-                'get_object',
-                Params={'Bucket': bucket, 'Key': object_key},
-                ExpiresIn=expires_in
+                "get_object",
+                Params={"Bucket": bucket, "Key": object_key},
+                ExpiresIn=expires_in,
             )
         except ClientError as exc:
             raise MinIOStorageException("Error generando URL presignada", str(exc))
@@ -111,7 +114,9 @@ class VideoWorkerService:
 
         try:
             with open(local_path, "rb") as f:
-                s3_client.upload_fileobj(f, bucket, object_key, ExtraArgs={"ContentType": "video/mp4"})
+                s3_client.upload_fileobj(
+                    f, bucket, object_key, ExtraArgs={"ContentType": "video/mp4"}
+                )
         except ClientError as exc:
             raise MinIOStorageException("Error subiendo archivo a MinIO", str(exc))
         except Exception as exc:
@@ -119,3 +124,20 @@ class VideoWorkerService:
 
         storage_path = f"s3://{bucket}/{object_key}"
         return storage_path
+
+    def delete_video_from_storage(self, storage_path: str) -> None:
+        try:
+            cleaned_path = storage_path.replace("s3://", "")
+            bucket, object_key = cleaned_path.split("/", 1)
+        except ValueError as exc:
+            raise BadRequestException(f"Error procesando storage_path: {str(exc)}")
+
+        s3_client = self._get_s3_client()
+        try:
+            s3_client.delete_object(Bucket=bucket, Key=object_key)
+        except ClientError as exc:
+            error_code = exc.response.get("Error", {}).get("Code")
+            if error_code not in {"NoSuchKey", "404"}:
+                raise MinIOStorageException(
+                    "Error eliminando archivo de MinIO", str(exc)
+                )

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - REDIS_HOST=redis
       - MINIO_ENDPOINT=minio:9000
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/fastapi_db
+      - WORKER_PIPELINE_DEBUG=false
     depends_on:
       - redis
       - minio

--- a/backend/docs/backend-pr-log.md
+++ b/backend/docs/backend-pr-log.md
@@ -1,0 +1,116 @@
+# Backend PR Log
+
+## Branch
+- `fix/jobs-endpoints-debug`
+
+## Objetivo
+- Restaurar y estabilizar autenticacion OAuth.
+- Diagnosticar endpoints de jobs.
+- Asegurar que el worker produzca salida final recortada (sin overlay de debug).
+- Agregar generacion automatica de clips shorts desde un video fuente.
+
+## Cambios aplicados
+
+### 1) OAuth y autenticacion
+- `api/app/core/dependencies.py`
+  - `get_current_user` ahora admite `sub` como UUID y como email (fallback).
+  - Evita rechazos de token cuando el `sub` no coincide con un formato unico.
+- `api/app/services/google_oauth_service.py`
+  - JWT emitido con `subject=str(user.id)` para alinear con el login tradicional.
+
+### 2) Configuracion para arranque del worker
+- `api/app/core/config.py`
+  - `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET` pasan a tener default vacio.
+  - Evita que el worker falle al iniciar por credenciales OAuth faltantes cuando no son necesarias para jobs.
+
+### 3) Endpoints/jobs y robustez del worker
+- `worker/app/worker.py`
+  - Se agregaron `continue` en rutas de error para cortar el flujo correctamente.
+  - Evita errores encadenados cuando falla el pipeline (variables no definidas en pasos siguientes).
+
+### 4) Pipeline de video (reframe/crop)
+- `worker/app/pipeline.py`
+  - `DEBUG` ahora se controla por variable de entorno `WORKER_PIPELINE_DEBUG` (default `false`).
+  - Se corrige inicializacion de `CameraDirector`: se pasa `FINAL_W` (ancho de recorte) en lugar de `FINAL_H`.
+  - Se fuerza `crop_w` par para compatibilidad con encoder H.264.
+  - En videos ya normalizados, el segmento se re-encodea (en vez de `copy`) para evitar cortes inestables sin stream de video.
+  - Se estandariza salida a `.mp4` para `normalized_`, `processed_` y `result_` (evita errores de muxer WebM con `libx264/aac`).
+  - Se agrega fallback cuando no hay stream de audio: exporta video-only en vez de fallar.
+  - Fix de audio en normalizacion con scale: ahora preserva/inyecta audio usando `input_stream.audio` al re-encodear.
+  - Resultado esperado: salida final recortada vertical (9:16) sin overlays cuando debug esta apagado.
+
+### 5) Docker Compose
+- `docker-compose.yml`
+  - Se agrega en `worker.environment`: `WORKER_PIPELINE_DEBUG=false`.
+
+### 6) Worker upload naming
+- `worker/app/worker.py`
+  - El upload a MinIO usa el nombre real del archivo generado por pipeline (`os.path.basename(video_local_path)`).
+  - Evita inconsistencias de extension cuando el input original es `.webm` y el output final es `.mp4`.
+
+### 7) Endpoint auto-clips
+- `api/app/schemas/job.py`
+  - Se agregan schemas para auto clips:
+    - `JobAutoReframeRequest`
+    - `JobAutoReframeItem`
+    - `JobAutoReframeResponse`
+- `api/app/services/job_service.py`
+  - Se refactoriza creacion de jobs con helper interno reutilizable.
+  - Nuevo metodo `auto_reframe_video(...)` para generar multiples jobs en lote.
+  - Estrategia de segmentos v2:
+    - deteccion de tramos no silenciosos con `ffmpeg silencedetect` sobre URL temporal del video,
+    - ranking de highlights por duracion,
+    - seleccion de clips con separacion minima para evitar solapamientos,
+    - fallback a distribucion temporal uniforme si no hay señal util.
+  - Si la duracion no esta en DB, se obtiene con `ffprobe` (usando URL temporal MinIO).
+- `api/app/api/v1/endpoints/job.py`
+  - Nuevo endpoint `POST /api/v1/jobs/reframe/{video_id}/auto`.
+  - Permite pedir 1..20 clips con duracion configurable (5..120s).
+  - Nuevo endpoint `GET /api/v1/jobs/my-clips` con paginado (`limit`, `offset`) para listar clips generados del usuario.
+
+- `api/app/schemas/job.py`
+  - Nuevos schemas para listados de clips del usuario:
+    - `UserClipItem`
+    - `UserClipsResponse`
+
+### 8) API runtime para analisis de highlights
+- `api/Dockerfile`
+  - Se instala `ffmpeg` para habilitar `ffprobe` + `silencedetect` en API.
+
+## Validaciones ejecutadas
+- Salud API:
+  - `GET /api/v1/health` -> `healthy`.
+- Endpoints jobs (smoke tests):
+  - `POST /api/v1/jobs/reframe/{video_id}` -> `201`.
+  - `POST /api/v1/jobs/reframe/{video_id}/auto` -> `201` (crea multiples jobs).
+  - `GET /api/v1/jobs/status/{job_id}` -> `200`.
+  - Parametros invalidos -> `400`.
+  - Job de otro usuario -> `404`.
+  - Video inexistente -> `404`.
+- Worker:
+  - Arranque correcto y escucha de cola confirmado por logs.
+  - `docker exec worker python -c "from worker.app.pipeline import DEBUG; print(DEBUG)"` -> `False`.
+  - Prueba directa del pipeline dentro de contenedor devuelve path de salida: `tmp/result/result_reframe_valid_input.mp4`.
+  - `ffprobe` sobre salida final: `h264`, `404x720` (formato vertical).
+  - Flujo completo por endpoint con video valido: job finaliza `DONE` con `output_path`.
+- Flujo completo con video `.webm` real (`/home/guillenec/Vídeos/Videomatch - José María Listorti Bailando Chayanne (HD) [hg2G__cvrz0].webm`) finaliza `DONE` y genera output `.mp4`.
+- Flujo auto clips probado con 3 segmentos (`clips_count=3`, `clip_duration_sec=7`) y los 3 jobs completados en `DONE`.
+- Flujo auto clips v2 probado con 5 segmentos (`clips_count=5`, `clip_duration_sec=8`):
+  - respuesta incluye `used_video_duration_sec=131`,
+  - clips generados en offsets distintos (ej: `2-10`, `24-32`, `41-49`, `82-90`, `117-125`).
+- Validacion de audio en clip generado:
+  - job finaliza `DONE` y `ffprobe` sobre `output_path` devuelve stream de audio `aac`.
+- Validacion endpoint de listado:
+  - `GET /api/v1/jobs/my-clips?limit=5&offset=0` devuelve clips del usuario autenticado.
+
+## Evidencia funcional
+- Se verifico al menos un job en estado `DONE` con `output_path` presente en DB.
+- Los jobs con input invalido quedan en `FAILED` sin cascada de errores secundarios.
+- Se verifico salida vertical sin overlay de debug al procesar un video valido.
+
+## Pendientes recomendados
+- Correr reframe con video real y validar visualmente:
+  - seguimiento de rostro,
+  - recorte vertical final,
+  - ausencia de overlays en output.
+- Ajustar threshold/logica de seguimiento si en ciertos clips el encuadre no acompana como se espera.

--- a/backend/worker/app/pipeline.py
+++ b/backend/worker/app/pipeline.py
@@ -587,6 +587,25 @@ def reframe_vertical(frame, camera_x, final_w, final_h):
     return crop  # 👈 tamaño fijo
 
 
+def compose_speaker_split(frame, camera_x, final_w, final_h):
+    """
+    Genera layout vertical en dos paneles:
+      - Arriba: seguimiento facial (crop vertical guiado por camera_x)
+      - Abajo: video completo horizontal con letterbox
+    """
+    top_ratio = 0.56
+    top_h = int(final_h * top_ratio)
+    bottom_h = max(1, final_h - top_h)
+
+    top_focus = reframe_vertical(frame, camera_x, final_w, final_h)
+    top_panel = cv2.resize(top_focus, (final_w, top_h), interpolation=cv2.INTER_AREA)
+    bottom_panel = resize_with_letterbox(frame, final_w, bottom_h)
+
+    stacked = np.vstack((top_panel, bottom_panel))
+    cv2.line(stacked, (0, top_h), (final_w, top_h), (0, 0, 0), 2)
+    return stacked
+
+
 def close_streams(decoder, encoder):
     """Properly closes FFmpeg pipes."""
     decoder.stdout.close()
@@ -835,7 +854,7 @@ def analyze_speech_activity(video_segment_path):
     return speech_mask
 
 
-def stream_processing(video_path, filename):
+def stream_processing(video_path, filename, output_style="vertical"):
     """
     Main video processing pipeline.
     Reads video frames via FFmpeg pipe, tracks active speaker,
@@ -971,6 +990,8 @@ def stream_processing(video_path, filename):
 
         if DEBUG:
             out_frame = frame.copy()
+        elif output_style == "speaker_split":
+            out_frame = compose_speaker_split(frame, camera_x, FINAL_W, FINAL_H)
         else:
             out_frame = reframe_vertical(frame, camera_x, FINAL_W, FINAL_H)
 
@@ -985,7 +1006,7 @@ def stream_processing(video_path, filename):
     return output_path
 
 
-def generate_video(video_path, filename):
+def generate_video(video_path, filename, output_style="vertical"):
     """
     Executes the full visual processing pipeline on a normalized segment
     and merges the original audio track at the end.
@@ -1002,7 +1023,7 @@ def generate_video(video_path, filename):
     """
 
     # 1. Reframe / crop / camera logic
-    no_audio_out = stream_processing(video_path, filename)
+    no_audio_out = stream_processing(video_path, filename, output_style=output_style)
 
     # 2. Merge original audio track
     result_video_path = merge_audio_track(no_audio_out, video_path, filename)
@@ -1012,12 +1033,14 @@ def generate_video(video_path, filename):
 
 
 # ================= PIPELINE MAIN =================
-def process(video_path, filename, start, end):
+def process(video_path, filename, start, end, output_style="vertical"):
     """
     Returns local path of generated video
         /tmp/result_{filename}
     """
     normalized_video_path = normalize_video_segment(video_path, filename, start, end)
-    result_video_path = generate_video(normalized_video_path, filename)
+    result_video_path = generate_video(
+        normalized_video_path, filename, output_style=output_style
+    )
     logger.info(f"🎉 GENERATED VIDEO PATH: {result_video_path}")
     return result_video_path

--- a/backend/worker/app/pipeline.py
+++ b/backend/worker/app/pipeline.py
@@ -40,7 +40,12 @@ previsualizar en el front y ofrecer micro ajustes y sus resultados ??
 ========================================================================
 """
 
-DEBUG = True
+DEBUG = os.getenv("WORKER_PIPELINE_DEBUG", "false").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 # output routes and dirs
 OUTPUT_DIR = Path("tmp")
@@ -58,8 +63,8 @@ RESULT_VIDEO.mkdir(exist_ok=True)
 EDGE_MARGIN_RATIO = 0.10
 SUBJECT_LOST_TIMEOUT_SEC = 2.0
 MIN_FACE_RATIO = 0.003  # 0.3% shows / escenario
-#MIN_FACE_RATIO = 0.0015 # si la cámara está lejos:
-#MIN_FACE_RATIO = 0.01 # si está cerca
+# MIN_FACE_RATIO = 0.0015 # si la cámara está lejos:
+# MIN_FACE_RATIO = 0.01 # si está cerca
 
 
 # camera direction parameters
@@ -89,7 +94,11 @@ if face_cascade.empty():
 # logger
 logger = logging.getLogger("pipeline")
 logger.propagate = True
-#========================================================================   
+# ========================================================================
+
+
+def _mp4_filename(filename: str) -> str:
+    return f"{Path(filename).stem}.mp4"
 
 
 class CameraDirector:
@@ -132,6 +141,7 @@ class CameraDirector:
 
     It ONLY decides *where the camera should point*.
     """
+
     def __init__(self, frame_width, final_w, fps):
         self.w = frame_width
         self.crop_w = final_w
@@ -205,19 +215,18 @@ class CameraDirector:
             # No subject detected → hold position
             logger.info(f"🔔 NO SUBJECT DETECTED, CURRENT POSITION: {self.current_x}")
             return self.current_x
-        
-        #Eso hace que:
+
+        # Eso hace que:
         # espere estabilidad del activo
         # ignore cambios efímeros
         # evite cortes nerviosos
         if self.detected_persistence < self.MIN_DETECTED_PERSISTENCE:
             return self.current_x
-        
-        # ================= HARD CUT ================= 
+
+        # ================= HARD CUT =================
         if is_voice and abs(detected_x - self.current_x) > self.HARD_CUT_THRESHOLD:
             self.current_x = max(
-                self.crop_w // 2,
-                min(self.w - self.crop_w // 2, detected_x)
+                self.crop_w // 2, min(self.w - self.crop_w // 2, detected_x)
             )
             self.mode = "HOLD"
             self.hold_frames = 0
@@ -225,12 +234,12 @@ class CameraDirector:
             return self.current_x
 
         # ================= SAFE ZONE CHECK =================
-        left  = self.current_x - self.crop_w // 2
+        left = self.current_x - self.crop_w // 2
         right = self.current_x + self.crop_w // 2
 
         margin = int(self.crop_w * 0.25)
 
-        safe_left  = left + margin
+        safe_left = left + margin
         safe_right = right - margin
 
         if detected_x < safe_left or detected_x > safe_right:
@@ -251,12 +260,11 @@ class CameraDirector:
 
         # ================= HOLD =================
         if self.mode == "HOLD":
-
             self.hold_frames += 1
 
             if (
-                self.possible_counter > self.CONSENSUS and
-                self.hold_frames > self.HOLD_MIN
+                self.possible_counter > self.CONSENSUS
+                and self.hold_frames > self.HOLD_MIN
             ):
                 self.mode = "TRANSITION"
                 self.target_x = self.possible_target
@@ -265,22 +273,17 @@ class CameraDirector:
 
         # ================= TRANSITION =================
         elif self.mode == "TRANSITION":
-
             self.frames_in_state += 1
 
-            progress = min(
-                1.0,
-                self.frames_in_state / self.TRANSITION_MAX
-            )
+            progress = min(1.0, self.frames_in_state / self.TRANSITION_MAX)
 
             self.current_x = int(
-                self.current_x +
-                (self.target_x - self.current_x) * progress
+                self.current_x + (self.target_x - self.current_x) * progress
             )
 
             if (
-                self.frames_in_state > self.TRANSITION_MIN and
-                abs(self.current_x - self.target_x) < 5
+                self.frames_in_state > self.TRANSITION_MIN
+                and abs(self.current_x - self.target_x) < 5
             ):
                 self.mode = "HOLD"
                 self.current_x = self.target_x
@@ -288,7 +291,9 @@ class CameraDirector:
                 self.frames_in_state = 0
 
         return self.current_x
-#========================================================================
+
+
+# ========================================================================
 
 
 def get_video_metadata(video_path):
@@ -329,34 +334,38 @@ def get_video_metadata(video_path):
 def init_stream_decoder(video_path):
     """Opens FFmpeg process that streams raw BGR frames."""
     return (
-        ffmpeg
-        .input(video_path)
-        .output('pipe:', format='rawvideo', pix_fmt='bgr24')
-        .global_args('-loglevel', 'error')
+        ffmpeg.input(video_path)
+        .output("pipe:", format="rawvideo", pix_fmt="bgr24")
+        .global_args("-loglevel", "error")
         .run_async(pipe_stdout=True)
     )
+
 
 def init_stream_encoder(output_path, actual_w, actual_h, fps):
     """Opens FFmpeg encoder process receiving raw frames via stdin."""
     return (
-        ffmpeg
-        .input('pipe:', format='rawvideo', pix_fmt='bgr24',
-               s=f"{actual_w}x{actual_h}", framerate=fps)
-        .output(
-            output_path,
-            vcodec='libx264',
-            pix_fmt='yuv420p',
-            movflags='+faststart'
+        ffmpeg.input(
+            "pipe:",
+            format="rawvideo",
+            pix_fmt="bgr24",
+            s=f"{actual_w}x{actual_h}",
+            framerate=fps,
         )
+        .output(output_path, vcodec="libx264", pix_fmt="yuv420p", movflags="+faststart")
         .overwrite_output()
-        .global_args('-loglevel', 'error')  # <--- errors only
+        .global_args("-loglevel", "error")  # <--- errors only
         .run_async(pipe_stdin=True)
     )
 
 
-def normalize_video_segment(video_path, filename,start_sec, end_sec,
-                            target_fps=TARGET_FPS,
-                            target_max_width=TARGET_MAX_W):
+def normalize_video_segment(
+    video_path,
+    filename,
+    start_sec,
+    end_sec,
+    target_fps=TARGET_FPS,
+    target_max_width=TARGET_MAX_W,
+):
     """
     Cuts and conditionally normalizes a video segment for stable downstream processing.
 
@@ -416,27 +425,29 @@ def normalize_video_segment(video_path, filename,start_sec, end_sec,
     needs_scale = width > target_max_width
     needs_pixfmt = pix_fmt != "yuv420p"
 
-    output_name = f"normalized_{filename}"
+    output_name = f"normalized_{_mp4_filename(filename)}"
     output_path = str(NORMALIZED_VIDEO / output_name)
-    
-    if not any([needs_codec, needs_fps, needs_scale, needs_pixfmt]):
 
-        logger.info("⚙️  Video is already normalized. Only cutting segment.")
+    if not any([needs_codec, needs_fps, needs_scale, needs_pixfmt]):
+        logger.info(
+            "⚙️  Video is already normalized. Re-encoding trimmed segment for stability."
+        )
 
         (
-            ffmpeg
-            .input(video_path)
+            ffmpeg.input(video_path, ss=start_sec, to=end_sec)
             .output(
                 output_path,
-                ss=start_sec,
-                to=end_sec,
-                vcodec="copy",
-                acodec="copy",
-                map="0",
-                avoid_negative_ts="make_zero"
+                vcodec="libx264",
+                pix_fmt="yuv420p",
+                r=target_fps,
+                acodec="aac",
+                audio_bitrate="128k",
+                preset="fast",
+                crf=23,
+                movflags="+faststart",
             )
             .overwrite_output()
-            .global_args('-loglevel', 'error')  # <--- errors only
+            .global_args("-loglevel", "error")  # <--- errors only
             .run()
         )
         return output_path
@@ -447,13 +458,16 @@ def normalize_video_segment(video_path, filename,start_sec, end_sec,
     logger.info(f"   Resolution ok? {not needs_scale}")
     logger.info(f"   Pixel format ok? {not needs_pixfmt}")
 
-    stream = ffmpeg.input(video_path, ss=start_sec, to=end_sec)
+    input_stream = ffmpeg.input(video_path, ss=start_sec, to=end_sec)
+    video_stream = input_stream.video
 
     if needs_scale:
-        stream = stream.filter("scale", target_max_width, -2)
+        video_stream = video_stream.filter("scale", target_max_width, -2)
 
     stream = (
-        stream.output(
+        ffmpeg.output(
+            video_stream,
+            input_stream.audio,
             output_path,
             vcodec="libx264",
             pix_fmt="yuv420p",
@@ -462,10 +476,10 @@ def normalize_video_segment(video_path, filename,start_sec, end_sec,
             audio_bitrate="128k",
             preset="fast",
             crf=23,
-            movflags="+faststart"
+            movflags="+faststart",
         )
         .overwrite_output()
-        .global_args('-loglevel', 'error')  # <--- errors only
+        .global_args("-loglevel", "error")  # <--- errors only
     )
 
     logger.info("🚀 Runnig FFmpeg...")
@@ -476,8 +490,7 @@ def normalize_video_segment(video_path, filename,start_sec, end_sec,
     return output_path
 
 
-def merge_audio_track(processed_video_path,
-                      normalized_video_path, filename):
+def merge_audio_track(processed_video_path, normalized_video_path, filename):
     """
     Merges the original audio track into a processed video file.
 
@@ -505,27 +518,38 @@ def merge_audio_track(processed_video_path,
     - Audio is encoded to AAC for compatibility.
     - The output duration matches the shortest stream.
     """
-    output_name = f"result_{filename}"
+    output_name = f"result_{_mp4_filename(filename)}"
     output_path = str(RESULT_VIDEO / output_name)
 
     video_in = ffmpeg.input(processed_video_path)
-    audio_in = ffmpeg.input(normalized_video_path)
 
-    (
-        ffmpeg
-        .output(
-            video_in.video,   # video del archivo procesado
-            audio_in.audio,   # audio del original
-            output_path,
-            vcodec="copy",
-            acodec="aac",
-            shortest=None
+    try:
+        audio_in = ffmpeg.input(normalized_video_path)
+        (
+            ffmpeg.output(
+                video_in.video,
+                audio_in.audio,
+                output_path,
+                vcodec="copy",
+                acodec="aac",
+                shortest=None,
+            )
+            .overwrite_output()
+            .global_args("-loglevel", "error")
+            .run()
         )
-        .overwrite_output()
-        .global_args('-loglevel', 'error')  # <--- errors only
-        .run()
-    )
-    logger.info("🔊 Audio added")
+        logger.info("🔊 Audio added")
+    except ffmpeg.Error:
+        logger.warning(
+            "⚠️ Input segment has no audio stream; exporting video-only result"
+        )
+        (
+            ffmpeg.output(video_in.video, output_path, vcodec="copy")
+            .overwrite_output()
+            .global_args("-loglevel", "error")
+            .run()
+        )
+
     return output_path
 
 
@@ -543,7 +567,7 @@ def resize_with_letterbox(frame, final_w, final_h):
     x_offset = (final_w - new_w) // 2
     y_offset = (final_h - new_h) // 2
 
-    canvas[y_offset:y_offset+new_h, x_offset:x_offset+new_w] = resized
+    canvas[y_offset : y_offset + new_h, x_offset : x_offset + new_w] = resized
 
     return canvas
 
@@ -553,10 +577,12 @@ def reframe_vertical(frame, camera_x, final_w, final_h):
     h, w = frame.shape[:2]
 
     if h != final_h:
-        logger.warning(f"🚨 WARNING: HEIGHT MISMACHT, CURRENT H: {h}, EXCPECTED: {final_h}")
+        logger.warning(
+            f"🚨 WARNING: HEIGHT MISMACHT, CURRENT H: {h}, EXCPECTED: {final_h}"
+        )
 
     x1 = max(0, min(w - final_w, camera_x - final_w // 2))
-    crop = frame[0:final_h, x1:x1 + final_w]
+    crop = frame[0:final_h, x1 : x1 + final_w]
 
     return crop  # 👈 tamaño fijo
 
@@ -567,8 +593,9 @@ def close_streams(decoder, encoder):
     encoder.stdin.close()
     decoder.wait()
     encoder.wait()
-#========================================================================
 
+
+# ========================================================================
 
 
 def detect_face_centers(frame, gray, prev_gray):
@@ -580,13 +607,13 @@ def detect_face_centers(frame, gray, prev_gray):
 
     Returns
     -------
-    dict of 
+    dict of
         center: (x, y)
         bbox: x, y, w, h
         area: w * h
-        motion: 
+        motion:
     """
-    #gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    # gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
 
     detections = face_cascade.detectMultiScale(gray, 1.1, 5)
 
@@ -597,8 +624,7 @@ def detect_face_centers(frame, gray, prev_gray):
 
     faces = []
 
-    for (x, y, w, h) in detections:
-
+    for x, y, w, h in detections:
         area = w * h
         center_x = x + w // 2
         center_y = y + h // 2
@@ -606,14 +632,13 @@ def detect_face_centers(frame, gray, prev_gray):
 
         mouth_y1 = int(y + h * 0.6)
         mouth_y2 = int(y + h * 0.85)
-        mouth_now = gray[mouth_y1:mouth_y2, x:x+w]
-        mouth_prev = prev_gray[mouth_y1:mouth_y2, x:x+w]
+        mouth_now = gray[mouth_y1:mouth_y2, x : x + w]
+        mouth_prev = prev_gray[mouth_y1:mouth_y2, x : x + w]
         if mouth_now.shape == mouth_prev.shape:
             motion_score = np.mean(cv2.absdiff(mouth_now, mouth_prev))
         else:
             motion_score = 0
 
-        
         ## ❌ filters by min size realted to frame w/h
         if area < frame_area * MIN_FACE_RATIO:
             continue
@@ -624,22 +649,21 @@ def detect_face_centers(frame, gray, prev_gray):
         if aspect_ratio < 0.6 or aspect_ratio > 1.4:
             continue
 
-        faces.append({
-            "center": (center_x, center_y),
-            "bbox": (x, y, w, h),
-            "area": area,
-            "motion": motion_score
-        })
-
+        faces.append(
+            {
+                "center": (center_x, center_y),
+                "bbox": (x, y, w, h),
+                "area": area,
+                "motion": motion_score,
+            }
+        )
 
     return faces
 
 
-
-
-def update_active_speaker(faces, active_center, candidate_center,
-                          candidate_frames, active_lock_frames,
-                          fps, w):
+def update_active_speaker(
+    faces, active_center, candidate_center, candidate_frames, active_lock_frames, fps, w
+):
     """
     Determines which detected face should be considered the current main subject.
 
@@ -697,10 +721,10 @@ def update_active_speaker(faces, active_center, candidate_center,
 
     Behavior Summary
     ----------------
-    • Keeps the current subject if still spatially close  
-    • Starts evaluating a new subject only if far enough  
-    • Requires ~0.5 seconds of persistence before switching  
-    • Abandons subject after ~1 second of absence  
+    • Keeps the current subject if still spatially close
+    • Starts evaluating a new subject only if far enough
+    • Requires ~0.5 seconds of persistence before switching
+    • Abandons subject after ~1 second of absence
     • Prevents rapid “ping-pong” switching between faces
     """
 
@@ -709,7 +733,7 @@ def update_active_speaker(faces, active_center, candidate_center,
         active_lock_frames -= 1
 
         # Lost subject for too long → no active subject
-        if active_lock_frames < -fps * SUBJECT_LOST_TIMEOUT_SEC :
+        if active_lock_frames < -fps * SUBJECT_LOST_TIMEOUT_SEC:
             return None, None, 0, active_lock_frames
 
         return active_center, candidate_center, candidate_frames, active_lock_frames
@@ -719,23 +743,21 @@ def update_active_speaker(faces, active_center, candidate_center,
         nearest = min(
             faces,
             key=lambda f: math.hypot(
-                f["center"][0]-active_center[0],
-                f["center"][1]-active_center[1]
-            )
+                f["center"][0] - active_center[0], f["center"][1] - active_center[1]
+            ),
         )
         dist = math.hypot(
-            nearest["center"][0]-active_center[0],
-            nearest["center"][1]-active_center[1]
+            nearest["center"][0] - active_center[0],
+            nearest["center"][1] - active_center[1],
         )
     else:
-        
         # elegir la cara más grande(?)
         # nearest = max(faces, key=lambda f: f["area"])
-        
+
         # el más cerca del centrado
-        #frame_center_x = w // 2
-        #nearest = min(faces, key=lambda f: abs(f["center"][0] - frame_center_x))
-        
+        # frame_center_x = w // 2
+        # nearest = min(faces, key=lambda f: abs(f["center"][0] - frame_center_x))
+
         # elegir donde hay mayor 'movimiento'
         nearest = max(faces, key=lambda f: f["motion"])
         dist = 0
@@ -750,10 +772,13 @@ def update_active_speaker(faces, active_center, candidate_center,
     if candidate_center is None:
         return active_center, nearest["center"], 1, active_lock_frames
 
-    if math.hypot(
-        nearest["center"][0]-candidate_center[0],
-        nearest["center"][1]-candidate_center[1]
-    ) < 50:
+    if (
+        math.hypot(
+            nearest["center"][0] - candidate_center[0],
+            nearest["center"][1] - candidate_center[1],
+        )
+        < 50
+    ):
         candidate_frames += 1
     else:
         return active_center, None, 0, active_lock_frames
@@ -761,11 +786,9 @@ def update_active_speaker(faces, active_center, candidate_center,
     # Switch only if persistent
     if candidate_frames > fps * 0.5:
         return nearest["center"], None, 0, active_lock_frames
-        #return candidate_center, None, 0, active_lock_frames
+        # return candidate_center, None, 0, active_lock_frames
 
     return active_center, candidate_center, candidate_frames, active_lock_frames
-
-
 
 
 def analyze_speech_activity(video_segment_path):
@@ -781,19 +804,24 @@ def analyze_speech_activity(video_segment_path):
     # 🎧 Extraer audio RAW en memoria
     cmd = [
         "ffmpeg",
-        "-loglevel", "error",
-        "-i", video_segment_path,
-        "-ac", "1",          # mono
-        "-ar", str(AUDIO_SAMPLE_RATE),      # sample rate
-        "-f", "f32le",       # float32 PCM
-        "-"
+        "-loglevel",
+        "error",
+        "-i",
+        video_segment_path,
+        "-ac",
+        "1",  # mono
+        "-ar",
+        str(AUDIO_SAMPLE_RATE),  # sample rate
+        "-f",
+        "f32le",  # float32 PCM
+        "-",
     ]
 
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
     audio_bytes = process.stdout.read()
     audio = np.frombuffer(audio_bytes, np.float32)
 
-    sr = AUDIO_SAMPLE_RATE 
+    sr = AUDIO_SAMPLE_RATE
     hop = int(sr / TARGET_FPS)
 
     # 📈 Energía RMS por frame de video
@@ -807,8 +835,6 @@ def analyze_speech_activity(video_segment_path):
     return speech_mask
 
 
-
-
 def stream_processing(video_path, filename):
     """
     Main video processing pipeline.
@@ -819,18 +845,20 @@ def stream_processing(video_path, filename):
     logger.info("🎬 PROCESSING STREAM...")
 
     # =============== SETUP ===============
-    output_name = f"processed_{filename}"
+    output_name = f"processed_{_mp4_filename(filename)}"
     output_path = str(PROCESSED_VIDEO / output_name)
 
     w, h, fps = get_video_metadata(video_path)
     # tamaño 9:16 que entra dentro del video original
     crop_w = int(h * OUTPUT_ASPECT)
     crop_w = min(crop_w, w)
+    if crop_w % 2 != 0:
+        crop_w -= 1
 
     FINAL_W = crop_w
     FINAL_H = h
 
-    director = CameraDirector(w, FINAL_H, fps)
+    director = CameraDirector(w, FINAL_W, fps)
 
     decoder = init_stream_decoder(video_path)
     if DEBUG:
@@ -866,12 +894,18 @@ def stream_processing(video_path, filename):
         faces = detect_face_centers(frame, gray, prev_gray)
 
         # decide QUIÉN
-        active_center, candidate_center, candidate_frames, active_lock_frames = update_active_speaker(
-            faces, active_center, candidate_center,
-            candidate_frames, active_lock_frames,
-            fps, w
+        active_center, candidate_center, candidate_frames, active_lock_frames = (
+            update_active_speaker(
+                faces,
+                active_center,
+                candidate_center,
+                candidate_frames,
+                active_lock_frames,
+                fps,
+                w,
+            )
         )
-        
+
         detected_x = active_center[0] if active_center else None
 
         is_voice = frame_idx < len(voice_mask) and voice_mask[frame_idx]
@@ -891,13 +925,15 @@ def stream_processing(video_path, filename):
             # ===== FACES =====
             for f in faces:
                 x, y, w_box, h_box = f["bbox"]
-                cv2.rectangle(frame, (x, y), (x + w_box, y + h_box), (255,0,0), 2) # red
+                cv2.rectangle(
+                    frame, (x, y), (x + w_box, y + h_box), (255, 0, 0), 2
+                )  # red
 
             if active_center:
-                cv2.circle(frame, active_center, 20, (0,255,0), 2) # green
+                cv2.circle(frame, active_center, 20, (0, 255, 0), 2)  # green
 
             if candidate_center:
-                cv2.circle(frame, candidate_center, 20, (0,0,255), 2) # blue
+                cv2.circle(frame, candidate_center, 20, (0, 0, 255), 2)  # blue
             # ===== Foco del director =====
             if camera_x is not None:
                 h, w = frame.shape[:2]
@@ -905,23 +941,23 @@ def stream_processing(video_path, filename):
                 cy = h // 2  # centro vertical del frame
                 size = 20  # tamaño de la cruz
 
-                cv2.line(frame, (cx - size, cy), (cx + size, cy), (0,255,255), 2)
-                cv2.line(frame, (cx, cy - size), (cx, cy + size), (0,255,255), 2)
-                
+                cv2.line(frame, (cx - size, cy), (cx + size, cy), (0, 255, 255), 2)
+                cv2.line(frame, (cx, cy - size), (cx, cy + size), (0, 255, 255), 2)
+
                 half_w = FINAL_W // 2
                 x1 = int(max(0, camera_x - half_w))
                 x2 = int(min(width, camera_x + half_w))
                 y1 = 0
                 y2 = FINAL_H
-                cv2.rectangle(frame, (x1, y1), (x2, y2), (0,255,255), 2)  # amarillo
+                cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 255), 2)  # amarillo
 
             # ===== Texto centrado arriba =====
             if director.mode:
                 text = f"MODE: {director.mode}"
 
                 font = cv2.FONT_HERSHEY_SIMPLEX
-                font_scale = 0.6   # más chico
-                thickness = 1      # más fino
+                font_scale = 0.6  # más chico
+                thickness = 1  # más fino
 
                 text_size, _ = cv2.getTextSize(text, font, font_scale, thickness)
                 text_width = text_size[0]
@@ -929,9 +965,9 @@ def stream_processing(video_path, filename):
                 x = (width - text_width) // 2
                 y = 30  # margen superior
 
-                cv2.putText(frame, text, (x, y),
-                            font, font_scale,
-                            (255,255,255), thickness)
+                cv2.putText(
+                    frame, text, (x, y), font, font_scale, (255, 255, 255), thickness
+                )
 
         if DEBUG:
             out_frame = frame.copy()
@@ -947,8 +983,6 @@ def stream_processing(video_path, filename):
 
     logger.info(f"✅ VIDEO PROCESSED: {output_path}")
     return output_path
-
-
 
 
 def generate_video(video_path, filename):
@@ -975,8 +1009,6 @@ def generate_video(video_path, filename):
     logger.info(f"✅ RESULT VIDEO: {result_video_path}")
 
     return result_video_path
-
-
 
 
 # ================= PIPELINE MAIN =================

--- a/backend/worker/app/pipeline.py
+++ b/backend/worker/app/pipeline.py
@@ -572,6 +572,21 @@ def resize_with_letterbox(frame, final_w, final_h):
     return canvas
 
 
+def resize_with_cover(frame, final_w, final_h):
+    """Resize preserving aspect ratio and filling target area by center-cropping."""
+    h, w = frame.shape[:2]
+
+    scale = max(final_w / w, final_h / h)
+    new_w = int(w * scale)
+    new_h = int(h * scale)
+
+    resized = cv2.resize(frame, (new_w, new_h), interpolation=cv2.INTER_AREA)
+
+    x1 = max(0, (new_w - final_w) // 2)
+    y1 = max(0, (new_h - final_h) // 2)
+    return resized[y1 : y1 + final_h, x1 : x1 + final_w]
+
+
 def reframe_vertical(frame, camera_x, final_w, final_h):
     """Crops frame to vertical 9:16 region centered on camera_x."""
     h, w = frame.shape[:2]
@@ -587,19 +602,54 @@ def reframe_vertical(frame, camera_x, final_w, final_h):
     return crop  # 👈 tamaño fijo
 
 
-def compose_speaker_split(frame, camera_x, final_w, final_h):
+def compose_speaker_split(
+    frame, camera_x, final_w, final_h, content_profile="interview"
+):
     """
     Genera layout vertical en dos paneles:
       - Arriba: seguimiento facial (crop vertical guiado por camera_x)
       - Abajo: video completo horizontal con letterbox
     """
-    top_ratio = 0.56
+    is_sports = content_profile == "sports"
+    top_ratio = 0.64 if not is_sports else 0.52
     top_h = int(final_h * top_ratio)
     bottom_h = max(1, final_h - top_h)
 
-    top_focus = reframe_vertical(frame, camera_x, final_w, final_h)
+    h, w = frame.shape[:2]
+    target_aspect = final_w / top_h
+
+    crop_h = h
+    crop_w = int(crop_h * target_aspect)
+
+    if crop_w > w:
+        crop_w = w
+        crop_h = int(crop_w / target_aspect)
+
+    crop_w = max(2, crop_w - (crop_w % 2))
+    crop_h = max(2, crop_h - (crop_h % 2))
+
+    frame_center_x = w // 2
+    tracked_x = int(camera_x if camera_x is not None else frame_center_x)
+    if is_sports:
+        # En deportes reducimos paneo agresivo y privilegiamos contexto de jugada.
+        center_x = int((tracked_x * 0.35) + (frame_center_x * 0.65))
+    else:
+        center_x = tracked_x
+    half_w = crop_w // 2
+    center_x = max(half_w, min(w - half_w, center_x))
+
+    x1 = max(0, center_x - half_w)
+    x2 = min(w, x1 + crop_w)
+    y1 = max(0, (h - crop_h) // 2)
+    y2 = y1 + crop_h
+
+    top_focus = frame[y1:y2, x1:x2]
     top_panel = cv2.resize(top_focus, (final_w, top_h), interpolation=cv2.INTER_AREA)
-    bottom_panel = resize_with_letterbox(frame, final_w, bottom_h)
+    bottom_panel = (
+        resize_with_cover(frame, final_w, bottom_h)
+        if is_sports
+        else resize_with_letterbox(frame, final_w, bottom_h)
+    )
 
     stacked = np.vstack((top_panel, bottom_panel))
     cv2.line(stacked, (0, top_h), (final_w, top_h), (0, 0, 0), 2)
@@ -854,7 +904,9 @@ def analyze_speech_activity(video_segment_path):
     return speech_mask
 
 
-def stream_processing(video_path, filename, output_style="vertical"):
+def stream_processing(
+    video_path, filename, output_style="vertical", content_profile="interview"
+):
     """
     Main video processing pipeline.
     Reads video frames via FFmpeg pipe, tracks active speaker,
@@ -991,7 +1043,13 @@ def stream_processing(video_path, filename, output_style="vertical"):
         if DEBUG:
             out_frame = frame.copy()
         elif output_style == "speaker_split":
-            out_frame = compose_speaker_split(frame, camera_x, FINAL_W, FINAL_H)
+            out_frame = compose_speaker_split(
+                frame,
+                camera_x,
+                FINAL_W,
+                FINAL_H,
+                content_profile=content_profile,
+            )
         else:
             out_frame = reframe_vertical(frame, camera_x, FINAL_W, FINAL_H)
 
@@ -1006,7 +1064,9 @@ def stream_processing(video_path, filename, output_style="vertical"):
     return output_path
 
 
-def generate_video(video_path, filename, output_style="vertical"):
+def generate_video(
+    video_path, filename, output_style="vertical", content_profile="interview"
+):
     """
     Executes the full visual processing pipeline on a normalized segment
     and merges the original audio track at the end.
@@ -1023,7 +1083,12 @@ def generate_video(video_path, filename, output_style="vertical"):
     """
 
     # 1. Reframe / crop / camera logic
-    no_audio_out = stream_processing(video_path, filename, output_style=output_style)
+    no_audio_out = stream_processing(
+        video_path,
+        filename,
+        output_style=output_style,
+        content_profile=content_profile,
+    )
 
     # 2. Merge original audio track
     result_video_path = merge_audio_track(no_audio_out, video_path, filename)
@@ -1033,14 +1098,24 @@ def generate_video(video_path, filename, output_style="vertical"):
 
 
 # ================= PIPELINE MAIN =================
-def process(video_path, filename, start, end, output_style="vertical"):
+def process(
+    video_path,
+    filename,
+    start,
+    end,
+    output_style="vertical",
+    content_profile="interview",
+):
     """
     Returns local path of generated video
         /tmp/result_{filename}
     """
     normalized_video_path = normalize_video_segment(video_path, filename, start, end)
     result_video_path = generate_video(
-        normalized_video_path, filename, output_style=output_style
+        normalized_video_path,
+        filename,
+        output_style=output_style,
+        content_profile=content_profile,
     )
     logger.info(f"🎉 GENERATED VIDEO PATH: {result_video_path}")
     return result_video_path

--- a/backend/worker/app/worker.py
+++ b/backend/worker/app/worker.py
@@ -105,6 +105,7 @@ def worker_loop():
         job_id = payload.get("job_id")
         start_sec = payload.get("start_sec")
         end_sec = payload.get("end_sec")
+        output_style = payload.get("output_style", "vertical")
         logger.info(f"🎬 Job received from Redis, Job id: {job_id}")
 
         db = SessionLocal()
@@ -171,7 +172,11 @@ def worker_loop():
                     storage_path, expires_in=300
                 )
                 video_local_path = process(
-                    video_url_response, filename, start_sec, end_sec
+                    video_url_response,
+                    filename,
+                    start_sec,
+                    end_sec,
+                    output_style=output_style,
                 )
             except Exception as e:
                 logger.error(f"❌ Job {job_id} failed during pipeline execution: {e}")

--- a/backend/worker/app/worker.py
+++ b/backend/worker/app/worker.py
@@ -94,6 +94,24 @@ logger = setup_logging()
 QUEUE_NAME = "reframe_queue"
 
 
+def update_job_state(db, job_id, **fields):
+    try:
+        updated_rows = (
+            db.query(Job)
+            .filter(Job.id == job_id)
+            .update(fields, synchronize_session=False)
+        )
+        db.commit()
+        if updated_rows == 0:
+            logger.warning(f"⚠️ Job {job_id} no longer exists while updating state")
+            return False
+        return True
+    except Exception as exc:
+        db.rollback()
+        logger.error(f"❌ Could not persist state for job {job_id}: {exc}")
+        return False
+
+
 def worker_loop():
     logger.info("🎧 Worker listening for jobs...\n")
 
@@ -106,6 +124,7 @@ def worker_loop():
         start_sec = payload.get("start_sec")
         end_sec = payload.get("end_sec")
         output_style = payload.get("output_style", "vertical")
+        content_profile = payload.get("content_profile", "interview")
         logger.info(f"🎬 Job received from Redis, Job id: {job_id}")
 
         db = SessionLocal()
@@ -142,8 +161,12 @@ def worker_loop():
             )
             if not filename:
                 logger.warning(f"❌ Video {job.video_id} has no filename")
-                job.status = JobStatus.FAILED
-                db.commit()
+                update_job_state(
+                    db,
+                    job.id,
+                    status=JobStatus.FAILED,
+                    error_message="Video sin filename",
+                )
                 db.close()
                 continue
 
@@ -152,13 +175,18 @@ def worker_loop():
             )
             if not storage_path:
                 logger.warning(f"❌ Video {job.video_id} has no storage_path")
-                job.status = JobStatus.FAILED
-                db.commit()
+                update_job_state(
+                    db,
+                    job.id,
+                    status=JobStatus.FAILED,
+                    error_message="Video sin storage_path",
+                )
                 db.close()
                 continue
 
-            job.status = JobStatus.RUNNING
-            db.commit()
+            if not update_job_state(db, job.id, status=JobStatus.RUNNING):
+                db.close()
+                continue
         except Exception as e:
             logger.error(f"❌ Failed to prepare job {job_id}: {e}")
             db.close()
@@ -177,18 +205,22 @@ def worker_loop():
                     start_sec,
                     end_sec,
                     output_style=output_style,
+                    content_profile=content_profile,
                 )
             except Exception as e:
                 logger.error(f"❌ Job {job_id} failed during pipeline execution: {e}")
-                job.status = JobStatus.FAILED
-                job.error_message = str(e)
-                db.commit()
+                update_job_state(
+                    db,
+                    job.id,
+                    status=JobStatus.FAILED,
+                    error_message=str(e),
+                )
                 db.close()
                 continue
 
             # upload to minio
             try:
-                output_filename = os.path.basename(video_local_path)
+                output_filename = f"{job.id}.mp4"
                 storage_path = video_worker_service.upload_local_video_to_minio(
                     video_local_path, output_filename
                 )
@@ -199,25 +231,37 @@ def worker_loop():
                 logger.info(f"✅ Public MiniIO url: {public_storage_path}")
             except Exception as e:
                 logger.error(f"❌ Job {job_id} failed during upload to MinIO: {e}")
-                job.status = JobStatus.FAILED
-                job.error_message = str(e)
-                db.commit()
+                update_job_state(
+                    db,
+                    job.id,
+                    status=JobStatus.FAILED,
+                    error_message=str(e),
+                )
                 db.close()
                 continue
 
             # update db
             try:
-                job.output_path = public_storage_path
-                job.status = JobStatus.DONE
-                db.commit()
+                # Guardamos storage path corto; la API regenera URL firmada al consultar.
+                persisted = update_job_state(
+                    db,
+                    job.id,
+                    output_path=storage_path,
+                    status=JobStatus.DONE,
+                    error_message=None,
+                )
                 # clear /tmp service...?
-                logger.info(f"✅ Job {job_id} completed successfully")
+                if persisted:
+                    logger.info(f"✅ Job {job_id} completed successfully")
                 db.close()
             except Exception as e:
                 logger.error(f"❌ Job {job_id} failed during DB update: {e}")
-                job.status = JobStatus.FAILED
-                job.error_message = str(e)
-                db.commit()
+                update_job_state(
+                    db,
+                    job.id,
+                    status=JobStatus.FAILED,
+                    error_message=str(e),
+                )
                 db.close()
 
         elif job.job_type == JobType.CANCEL:

--- a/backend/worker/app/worker.py
+++ b/backend/worker/app/worker.py
@@ -33,6 +33,7 @@ worker.py
 
 """
 
+
 def check_ffmpeg():
     """
     Verifica que FFmpeg esté instalado en el contenedor
@@ -43,12 +44,11 @@ def check_ffmpeg():
             ["ffmpeg", "-version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True
+            text=True,
         )
         return result.stdout.split("\n")[0]
     except Exception as e:
         return f"FFmpeg error: {e}"
-
 
 
 def check_opencv():
@@ -60,7 +60,6 @@ def check_opencv():
         return f"OpenCV version {cv2.__version__}"
     except Exception as e:
         return f"OpenCV error: {e}"
-
 
 
 def check_redis():
@@ -75,29 +74,29 @@ def check_redis():
         return f"Redis error: {e}"
 
 
-
 def check_dependencies():
     """
     Ejecuta todos los chequeos de entorno al iniciar el worker.
     Sirve para validar que el contenedor está correctamente armado.
     """
     status = {
-    "redis": check_redis(),
-    "opencv": check_opencv(),
-    "ffmpeg": check_ffmpeg()
+        "redis": check_redis(),
+        "opencv": check_opencv(),
+        "ffmpeg": check_ffmpeg(),
     }
-    
+
     logger.info("🔎 Environment check:")
     for k, v in status.items():
         logger.info(f"{k}: {v}")
 
 
-
 logger = setup_logging()
 QUEUE_NAME = "reframe_queue"
+
+
 def worker_loop():
     logger.info("🎧 Worker listening for jobs...\n")
-        
+
     while True:
         payload = redis_client.pop_from_queue(QUEUE_NAME)
 
@@ -110,10 +109,10 @@ def worker_loop():
 
         db = SessionLocal()
         video_worker_service = VideoWorkerService()
-        
-        try:   
+
+        try:
             job = db.query(Job).filter(Job.id == job_id).first()
-            
+
             if not job:
                 db.close()
                 logger.warning(f"❌ Job {job_id} not found in DB")
@@ -121,18 +120,25 @@ def worker_loop():
 
             if job.status != JobStatus.PENDING and job.status != JobStatus.FAILED:
                 db.close()
-                logger.warning(f"❌Job {job_id} has invalid state {job.status}, skipping"
+                logger.warning(
+                    f"❌Job {job_id} has invalid state {job.status}, skipping"
                 )
                 continue
 
             logger.info(f"⚙️  Processing job: {job_id} of type {job.job_type}")
-        
+
         except Exception as e:
             logger.error(f"❌ Failed to fetch job {job_id} from DB: {e}")
             db.close()
+            continue
 
         try:
-            filename = db.query(Video).filter(Video.id == job.video_id).first().original_filename
+            filename = (
+                db.query(Video)
+                .filter(Video.id == job.video_id)
+                .first()
+                .original_filename
+            )
             if not filename:
                 logger.warning(f"❌ Video {job.video_id} has no filename")
                 job.status = JobStatus.FAILED
@@ -140,7 +146,9 @@ def worker_loop():
                 db.close()
                 continue
 
-            storage_path = db.query(Video).filter(Video.id == job.video_id).first().storage_path
+            storage_path = (
+                db.query(Video).filter(Video.id == job.video_id).first().storage_path
+            )
             if not storage_path:
                 logger.warning(f"❌ Video {job.video_id} has no storage_path")
                 job.status = JobStatus.FAILED
@@ -151,36 +159,48 @@ def worker_loop():
             job.status = JobStatus.RUNNING
             db.commit()
         except Exception as e:
-            logger.error(f"❌ Failed to prepare job {job_id}: {e}") 
+            logger.error(f"❌ Failed to prepare job {job_id}: {e}")
+            db.close()
+            continue
 
-        
         if job.job_type == JobType.REFRAME:
             # ejecutar pipeline
             try:
                 logger.info(f"⚙️  Processing REFRAME job {job.id}")
-                video_url_response = video_worker_service.get_video_url(storage_path, expires_in=300)
-                video_local_path = process(video_url_response, filename, start_sec, end_sec)
+                video_url_response = video_worker_service.get_video_url(
+                    storage_path, expires_in=300
+                )
+                video_local_path = process(
+                    video_url_response, filename, start_sec, end_sec
+                )
             except Exception as e:
                 logger.error(f"❌ Job {job_id} failed during pipeline execution: {e}")
-                job.status = JobStatus.FAILED   
+                job.status = JobStatus.FAILED
                 job.error_message = str(e)
                 db.commit()
                 db.close()
+                continue
 
             # upload to minio
             try:
-                storage_path = video_worker_service.upload_local_video_to_minio(video_local_path, filename)
+                output_filename = os.path.basename(video_local_path)
+                storage_path = video_worker_service.upload_local_video_to_minio(
+                    video_local_path, output_filename
+                )
                 logger.info(f"✅ Video uploaded to MinIO")
-                public_storage_path = video_worker_service.get_video_public_url(storage_path, expires_in=300)
+                public_storage_path = video_worker_service.get_video_public_url(
+                    storage_path, expires_in=300
+                )
                 logger.info(f"✅ Public MiniIO url: {public_storage_path}")
             except Exception as e:
                 logger.error(f"❌ Job {job_id} failed during upload to MinIO: {e}")
-                job.status = JobStatus.FAILED      
+                job.status = JobStatus.FAILED
                 job.error_message = str(e)
                 db.commit()
                 db.close()
+                continue
 
-           # update db
+            # update db
             try:
                 job.output_path = public_storage_path
                 job.status = JobStatus.DONE
@@ -188,7 +208,7 @@ def worker_loop():
                 # clear /tmp service...?
                 logger.info(f"✅ Job {job_id} completed successfully")
                 db.close()
-            except Exception as e: 
+            except Exception as e:
                 logger.error(f"❌ Job {job_id} failed during DB update: {e}")
                 job.status = JobStatus.FAILED
                 job.error_message = str(e)

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -71,3 +71,50 @@ Si quedan hardcodeadas en compose, pisan `.env` y Google responde `invalid_clien
 
 - Nunca commitear `client_secret` real en el repo.
 - Si un secreto se filtra en chats/capturas, rotarlo en Google Cloud inmediatamente.
+
+## Objetivo de la rama
+
+Integrar sobre `develop` actualizado los cambios de backend que habilitan flujo completo de timeline/biblioteca: jobs automaticos y manuales, busqueda/listados paginados, y CRUD autenticado de videos/clips.
+
+Rama de trabajo: `feature/integracion-timeline-library-flow`.
+
+## Cambios implementados
+
+- Se estabilizo el worker (`backend/worker/app/pipeline.py`, `backend/worker/app/worker.py`) y el flujo de procesamiento para mejorar consistencia de salida.
+- Se incorporo en jobs el flujo de autoclips y listado de clips del usuario en `backend/api/app/api/v1/endpoints/job.py` y `backend/api/app/services/job_service.py`.
+- Se agrego soporte de filtros opcionales para reframe manual en `backend/api/app/schemas/job.py`, endpoint y servicio de jobs.
+- Se mejoro `GET /api/v1/jobs/status/{job_id}` y `GET /api/v1/jobs/my-clips` para regenerar URLs presignadas al responder estados/listados.
+- Se incorporaron endpoints de videos autenticados: `GET /api/v1/videos/my-videos`, `GET /api/v1/videos/{video_id}`, `PATCH /api/v1/videos/{video_id}`, `DELETE /api/v1/videos/{video_id}` con ownership checks y serializacion unificada.
+- Se agregaron endpoints de clips por `job_id`: `GET /api/v1/jobs/{job_id}` y `DELETE /api/v1/jobs/{job_id}`, incluyendo borrado de objeto en storage cuando corresponde.
+
+## Commits realizados
+
+- `fix(worker): stabilize processing flow and media output`
+- `feat(jobs): add smart auto-clips and user clips listing`
+- `feat(api): add search to my-clips and new my-videos endpoint`
+- `feat(api): accept optional reframe filters in manual jobs`
+- `feat(api): add authenticated video CRUD endpoints`
+- `feat(api): add clip detail and delete endpoints for library actions`
+
+## Archivos clave
+
+- `backend/api/app/api/v1/endpoints/job.py`
+- `backend/api/app/api/v1/endpoints/video.py`
+- `backend/api/app/services/job_service.py`
+- `backend/api/app/services/video_service.py`
+- `backend/api/app/services/video_worker_service.py`
+- `backend/worker/app/pipeline.py`
+- `backend/worker/app/worker.py`
+- `docs/backend-pr-log.md`
+
+## Validaciones locales
+
+Intentado en `backend/api/`:
+
+- `pytest -q` -> No ejecutado (comando `pytest` no disponible en entorno local actual)
+
+## Checklist antes de PR a develop
+
+- [x] Rama creada desde `develop` actualizado
+- [x] Integracion de cambios backend/frontend de `feature/frontend-backend-timeline-library-flow`
+- [x] Documentacion actualizada

--- a/docs/front_back-pr-log.md
+++ b/docs/front_back-pr-log.md
@@ -75,3 +75,33 @@ Ejecutado en `backend/`:
 - [x] Integracion completa de `feature/frontend-backend-timeline-library-flow`
 - [x] Documentacion frontend/backend actualizada
 - [x] Log unificado frontend+backend agregado
+
+## Actualizacion de la rama (speaker split)
+
+### Objetivo
+
+Agregar una opcion de salida para generar clips en formato "speaker split": arriba enfoque al hablante (seguimiento facial) y abajo plano general horizontal completo.
+
+### Cambios realizados
+
+- Se agrego `output_style` en payloads de jobs manuales y automaticos para backend (`vertical` | `speaker_split`).
+- Se propago `output_style` desde API -> service -> cola Redis -> worker.
+- Se extendio el pipeline del worker para soportar composicion `speaker_split` apilando foco vertical en la parte superior y vista general letterbox en la inferior.
+- Se agrego selector de estilo en Home (`frontend/src/app/app/page.tsx`) antes del upload para elegir entre `Vertical clasico 9:16` y `Split speaker`.
+- Se actualizo `frontend/src/services/videoApi.ts` para enviar `output_style` al crear jobs automaticos.
+
+### Archivos clave
+
+- `backend/api/app/schemas/job.py`
+- `backend/api/app/api/v1/endpoints/job.py`
+- `backend/api/app/services/job_service.py`
+- `backend/api/app/services/queue_service.py`
+- `backend/worker/app/worker.py`
+- `backend/worker/app/pipeline.py`
+- `frontend/src/app/app/page.tsx`
+- `frontend/src/services/videoApi.ts`
+
+### Validaciones locales
+
+- `npm run lint` en `frontend/` -> OK
+- `python3 -m py_compile` sobre archivos backend modificados -> OK

--- a/docs/front_back-pr-log.md
+++ b/docs/front_back-pr-log.md
@@ -1,0 +1,77 @@
+# Frontend + Backend PR Worklog
+
+## Objetivo de la rama
+
+Integrar sobre `develop` actualizado el flujo completo de timeline + biblioteca en frontend y backend, dejando operativo el circuito upload -> procesamiento -> biblioteca -> edicion -> compartir.
+
+Rama de trabajo: `feature/integracion-timeline-library-flow`.
+
+## Cambios realizados
+
+- Se sincronizo la base de trabajo con `develop` remoto y se recreo una rama limpia para integrar sin arrastrar archivos temporales locales.
+- Se integraron cambios de backend para worker estable, jobs automaticos/manuales, listado de clips, filtros de reframe y regeneracion de URLs presignadas.
+- Se agregaron endpoints y servicios para CRUD autenticado de videos (`my-videos`, detalle, rename, delete) y acciones de biblioteca de clips (detalle y delete por `job_id`).
+- Se integraron cambios de frontend en Home, Timeline y Library con polling estable, persistencia de draft, paginacion, busqueda backend y acciones CRUD.
+- Se incorporo la ruta `frontend/src/app/app/share/[clipId]/page.tsx` y se reforzo el deep-link de edicion desde biblioteca a timeline.
+- Se aplico ajuste visual del dashboard (paleta Catppuccin) y correccion del comportamiento del logo en navegacion.
+- Se resolvieron conflictos de integracion entre avances de `develop` y `feature/frontend-backend-timeline-library-flow` en archivos de auth/video.
+- Se actualizaron logs de trabajo existentes en `docs/frontend-pr-log.md` y `docs/backend-pr-log.md` con las nuevas entradas de esta rama.
+
+## Commits realizados
+
+- `fix(worker): stabilize processing flow and media output`
+- `feat(jobs): add smart auto-clips and user clips listing`
+- `feat(frontend): wire home upload flow to auto reframe jobs endpoint`
+- `feat(frontend): move preview workflow to timeline and fetch user clips`
+- `fix(api): regenerate clip output urls for status and my-clips`
+- `fix(frontend): handle unsupported video play promise in timeline`
+- `fix(frontend): persist home clip draft and stabilize preview polling`
+- `feat(frontend): add pagination to timeline and library clips`
+- `fix(frontend): improve home results loading and live preview transitions`
+- `feat(api): add search to my-clips and new my-videos endpoint`
+- `feat(frontend): add backend search and original videos library view`
+- `feat(api): accept optional reframe filters in manual jobs`
+- `feat(frontend): wire timeline editor to manual reframe endpoint`
+- `feat(api): add authenticated video CRUD endpoints`
+- `feat(frontend): add rename and delete actions to library videos`
+- `feat(api): add clip detail and delete endpoints for library actions`
+- `feat(frontend): add clip share route and stronger timeline edit deep-link`
+- `style(frontend): switch dashboard palette to catppuccin and fix home logo link`
+- `docs(worklog): registrar integracion timeline-library en rama nueva`
+
+## Archivos clave
+
+- `backend/api/app/api/v1/endpoints/job.py`
+- `backend/api/app/api/v1/endpoints/video.py`
+- `backend/api/app/services/job_service.py`
+- `backend/api/app/services/video_service.py`
+- `backend/worker/app/pipeline.py`
+- `backend/worker/app/worker.py`
+- `frontend/src/app/app/page.tsx`
+- `frontend/src/app/app/timeline/page.tsx`
+- `frontend/src/app/app/library/page.tsx`
+- `frontend/src/app/app/share/[clipId]/page.tsx`
+- `frontend/src/services/videoApi.ts`
+- `docs/frontend-pr-log.md`
+- `docs/backend-pr-log.md`
+- `docs/front_back-pr-log.md`
+
+## Validaciones locales
+
+Ejecutado en `frontend/`:
+
+- `npm run lint` -> OK
+
+Ejecutado en `backend/`:
+
+- `docker compose up -d --build` -> OK
+- `docker compose ps` -> servicios arriba
+- `worker` saludable y escuchando jobs
+- `alembic upgrade heads` requerido por multiple heads para crear esquema completo
+
+## Checklist antes de PR a develop
+
+- [x] Rama creada desde `develop` actualizado
+- [x] Integracion completa de `feature/frontend-backend-timeline-library-flow`
+- [x] Documentacion frontend/backend actualizada
+- [x] Log unificado frontend+backend agregado

--- a/docs/front_back-pr-log.md
+++ b/docs/front_back-pr-log.md
@@ -105,3 +105,136 @@ Agregar una opcion de salida para generar clips en formato "speaker split": arri
 
 - `npm run lint` en `frontend/` -> OK
 - `python3 -m py_compile` sobre archivos backend modificados -> OK
+
+## Ajuste de calidad visual (speaker split)
+
+### Problema detectado
+
+- En clips `speaker_split`, el panel superior podia deformar la imagen (aspecto estirado/achatado).
+- En entrevistas, algunos rostros quedaban demasiado al borde por recorte superior demasiado angosto.
+
+### Correccion aplicada
+
+- Se ajusto la composicion de `speaker_split` en `backend/worker/app/pipeline.py` para:
+  - calcular el recorte superior con el **mismo aspect ratio** del panel destino (evita deformacion),
+  - aumentar el espacio del panel superior para mostrar mejor el rostro,
+  - mantener el panel inferior con plano general en letterbox sin distorsion.
+
+## Ajuste de perfiles de contenido (entrevista/deportes)
+
+### Objetivo
+
+Evitar zoom excesivo en clips de futbol/deportes dentro de `speaker_split`, manteniendo mas contexto de jugada (jugador + balon + entorno).
+
+### Cambios realizados
+
+- Se agrego `content_profile` en requests de jobs (`interview` | `sports`) para reframe manual y automatico.
+- Se propago `content_profile` en toda la cadena API -> service -> Redis -> worker -> pipeline.
+- En Home se agrego selector de perfil de contenido al elegir `speaker_split`:
+  - `Entrevista (mas foco en rostro)`
+  - `Deportes (menos zoom, mas contexto)`
+- En pipeline, `speaker_split` ahora adapta composicion por perfil:
+  - `interview`: panel superior mas dominante y tracking mas directo.
+  - `sports`: panel superior mas bajo y centro suavizado hacia el medio del frame para reducir paneo agresivo y zoom percibido.
+
+### Archivos clave
+
+- `backend/api/app/schemas/job.py`
+- `backend/api/app/api/v1/endpoints/job.py`
+- `backend/api/app/services/job_service.py`
+- `backend/api/app/services/queue_service.py`
+- `backend/worker/app/worker.py`
+- `backend/worker/app/pipeline.py`
+- `frontend/src/services/videoApi.ts`
+- `frontend/src/app/app/page.tsx`
+
+## Hotfix de persistencia de clips
+
+### Problema detectado
+
+- Los jobs terminaban el procesamiento en worker, pero fallaban al guardar resultado con error DB:
+  `value too long for type character varying(500)` en `jobs.output_path`.
+- Consecuencia: el clip no quedaba en `DONE` ni visible en Home/Biblioteca, aunque el archivo se subia a MinIO.
+
+### Correccion aplicada
+
+- En `backend/worker/app/worker.py` se dejo de persistir la URL firmada completa en `output_path`.
+- Ahora se guarda el `storage_path` corto (ej. `s3://...`) y la API genera URL presignada al consultar estado/listados.
+- Se ajusto manejo de errores en update de DB para hacer `rollback()` antes de marcar `FAILED`, evitando `PendingRollbackError` en cadena.
+
+## Hotfix de estabilidad worker + Home
+
+### Problemas detectados
+
+- Algunos jobs terminaban procesamiento, pero el worker podia caer con `StaleDataError`/`ObjectDeletedError` al persistir estado final.
+- En Home, en ciertos flujos quedaba UI desincronizada (skeleton sin clips hasta recargar/navegar).
+
+### Correcciones aplicadas
+
+- `backend/worker/app/worker.py`:
+  - Se agrego persistencia de estado robusta con update directo por `job_id` (`update_job_state`) para evitar caidas por filas ausentes o stale ORM.
+  - En fallos de pipeline/upload/update se guarda estado `FAILED` de forma tolerante a errores, sin tumbar el proceso principal.
+- `frontend/src/app/app/page.tsx`:
+  - Se agrego hydrate de respaldo desde `my-clips` cuando Home pierde estado local de jobs, para mostrar resultados sin requerir recarga manual.
+- `backend/worker/app/pipeline.py`:
+  - En perfil `sports`, el panel inferior de `speaker_split` usa `cover` (menos bandas negras) y ajuste de proporcion para reducir hueco visual.
+
+## Hotfix timeline editor
+
+### Problema detectado
+
+- En timeline manual, la creacion de job podia reusar un job existente del mismo video (pendiente/running/failed), haciendo que el recorte solicitado no se encolara como nuevo trabajo.
+
+### Correccion aplicada
+
+- En `backend/api/app/services/job_service.py`, el flujo `reframe_video` paso a crear job nuevo (`allow_reuse=False`) para respetar cada solicitud del timeline editor.
+
+## Mejora de autodeteccion de clips en Home
+
+### Objetivo
+
+Generar clips automaticos con deteccion real de momentos importantes y duracion variable definida por backend (sin hardcode fijo de 15s) para el flujo de Home/Panel.
+
+### Cambios aplicados
+
+- `backend/api/app/schemas/job.py`
+  - `clips_count` y `clip_duration_sec` pasaron a opcionales en auto reframe.
+  - Se amplio `content_profile` a `auto | interview | sports | music`.
+- `backend/api/app/services/job_service.py`
+  - Nuevo modo inteligente de seleccion de segmentos:
+    - analisis de no-silencios (`silencedetect`),
+    - deteccion de cambios de escena (`select='gt(scene,0.35)' + showinfo`),
+    - ranking de candidatos con separacion minima.
+  - Backend decide cantidad de clips si no viene en request (`2-5` segun duracion total).
+  - Duracion por clip variable por perfil:
+    - `sports`: mas corta y dinamica,
+    - `music`: mas extensa para frase/coro,
+    - `interview`: intermedia para idea completa.
+  - En `content_profile=auto`, se resuelve perfil final por heuristica (nombre de archivo + densidad de escena + ratio de no-silencio).
+  - Los jobs auto encolan el `resolved_profile` para que el worker aplique framing acorde.
+- `frontend/src/services/videoApi.ts`
+  - En auto reframe ya no envia defaults hardcodeados de `clips_count` y `clip_duration_sec`.
+  - `content_profile` ahora soporta `auto` y `music`.
+- `frontend/src/app/app/page.tsx`
+  - Home ahora usa por defecto `Auto detectar` para perfil de contenido.
+  - Se agrego opcion manual de override (`Entrevista`, `Deportes`, `Musica`) para pruebas.
+
+### Validaciones
+
+- `python3 -m py_compile` en backend -> OK
+- `npm run lint` en frontend -> OK
+- `docker compose up -d --build api worker` -> OK
+
+## Ajuste fino de highlights para futbol/deportes
+
+### Objetivo
+
+Priorizar mejor la secuencia previa y posterior a jugadas importantes (pre-gol + gol + reaccion), no solo el instante del pico.
+
+### Cambios aplicados
+
+- En `backend/api/app/services/job_service.py` se incorporo ventana contextual para `sports`:
+  - los anchors de highlights/escenas ahora se expanden de forma asimetrica,
+  - mayor peso al contexto previo (~62%) y cierre posterior,
+  - minima longitud garantizada por clip.
+- Se reemplazo almacenamiento de duracion por almacenamiento de rango candidato (`start/end`) para mantener contexto exacto en deportes.

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -65,3 +65,50 @@ Ejecutado en `frontend/`:
 - [x] Commits convencionales y atomicos
 - [x] `npm run lint` OK
 - [x] Documentacion actualizada
+
+## Objetivo de la rama
+
+Integrar sobre `develop` actualizado el flujo completo de timeline + biblioteca (frontend/backend) para dejar operativas las vistas de clips/videos, acciones CRUD, navegacion de edicion profunda y ruta de compartir.
+
+Rama de trabajo: `feature/integracion-timeline-library-flow`.
+
+## Cambios realizados
+
+- Se integraron en `frontend/src/app/app/page.tsx` y `frontend/src/components/home/GeneratedClipsSection.tsx` las mejoras de Home para jobs automaticos, persistencia de draft, polling estable y transiciones de preview.
+- Se incorporo `frontend/src/app/app/timeline/page.tsx` con editor manual conectado al endpoint de reframe, incluyendo seleccion de clip/video, paginacion y busqueda contra backend.
+- Se amplió `frontend/src/app/app/library/page.tsx` con vistas de `Clips` y `Videos originales`, mas acciones de renombrar/eliminar para videos y editar/compartir/eliminar para clips.
+- Se agrego `frontend/src/app/app/share/[clipId]/page.tsx` para preparar el flujo de compartir por red social y se fortalecio el deep-link de `Editar` hacia timeline por `clipId`/`videoId`.
+- Se actualizaron servicios en `frontend/src/services/videoApi.ts` para soportar listados paginados/buscables, CRUD de videos y clips, y creacion de jobs manuales/automaticos.
+- Se aplico refresh visual en dashboard (`frontend/src/app/globals.css`, `frontend/src/components/branding/HaceloCortoLogo.tsx`, `frontend/src/components/layout/NavBar.tsx`) con paleta Catppuccin y correccion de navegacion del logo.
+
+## Commits realizados
+
+- `feat(frontend): wire home upload flow to auto reframe jobs endpoint`
+- `feat(frontend): move preview workflow to timeline and fetch user clips`
+- `feat(frontend): add backend search and original videos library view`
+- `feat(frontend): wire timeline editor to manual reframe endpoint`
+- `feat(frontend): add rename and delete actions to library videos`
+- `feat(frontend): add clip share route and stronger timeline edit deep-link`
+- `style(frontend): switch dashboard palette to catppuccin and fix home logo link`
+
+## Archivos clave
+
+- `frontend/src/app/app/page.tsx`
+- `frontend/src/app/app/timeline/page.tsx`
+- `frontend/src/app/app/library/page.tsx`
+- `frontend/src/app/app/share/[clipId]/page.tsx`
+- `frontend/src/services/videoApi.ts`
+- `docs/frontend-pr-log.md`
+
+## Validaciones locales
+
+Ejecutado en `frontend/`:
+
+- `npm run lint` -> OK
+
+## Checklist antes de PR a develop
+
+- [x] Rama creada desde `develop` actualizado
+- [x] Integracion de cambios frontend/backend de `feature/frontend-backend-timeline-library-flow`
+- [x] `npm run lint` OK
+- [x] Documentacion actualizada

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -3,7 +3,7 @@
 import { Panel } from "@/src/components/ui/Panel";
 import { videoApi, type UserClipItem, type UserVideoItem } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
-import { Clock3, Download, Search, Tag } from "lucide-react";
+import { Check, Clock3, Download, PencilLine, Search, Tag, Trash2, X } from "lucide-react";
 import { useEffect, useState } from "react";
 
 const PAGE_SIZE = 12;
@@ -39,6 +39,10 @@ export default function LibraryPage() {
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [editingVideoId, setEditingVideoId] = useState<string | null>(null);
+  const [draftFilename, setDraftFilename] = useState("");
+  const [isSavingVideo, setIsSavingVideo] = useState(false);
+  const [deletingVideoId, setDeletingVideoId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!token) {
@@ -93,6 +97,73 @@ export default function LibraryPage() {
   }, [token, page, query, view]);
 
   const totalPages = Math.max(1, Math.ceil((view === "clips" ? totalClips : totalVideos) / PAGE_SIZE));
+
+  const handleStartRename = (video: UserVideoItem) => {
+    setEditingVideoId(video.video_id);
+    setDraftFilename(video.filename);
+  };
+
+  const handleCancelRename = () => {
+    setEditingVideoId(null);
+    setDraftFilename("");
+  };
+
+  const handleSaveRename = async (videoId: string) => {
+    if (!token || isSavingVideo) {
+      return;
+    }
+
+    const cleanedFilename = draftFilename.trim();
+    if (!cleanedFilename) {
+      setError("El nombre del video no puede estar vacio.");
+      return;
+    }
+
+    setIsSavingVideo(true);
+    setError(null);
+
+    try {
+      const updated = await videoApi.updateMyVideo(videoId, token, { filename: cleanedFilename });
+      setVideos((prev) => prev.map((item) => (item.video_id === videoId ? updated : item)));
+      handleCancelRename();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "No pudimos actualizar el nombre del video.");
+    } finally {
+      setIsSavingVideo(false);
+    }
+  };
+
+  const handleDeleteVideo = async (video: UserVideoItem) => {
+    if (!token || deletingVideoId) {
+      return;
+    }
+
+    const confirmed = window.confirm(`Vas a eliminar ${video.filename}. Esta accion no se puede deshacer.`);
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingVideoId(video.video_id);
+    setError(null);
+
+    try {
+      await videoApi.deleteMyVideo(video.video_id, token);
+      let shouldStepBackPage = false;
+      setVideos((prev) => {
+        shouldStepBackPage = prev.length === 1;
+        return prev.filter((item) => item.video_id !== video.video_id);
+      });
+      setTotalVideos((prev) => Math.max(0, prev - 1));
+
+      if (shouldStepBackPage && page > 1) {
+        setPage((prev) => Math.max(1, prev - 1));
+      }
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : "No pudimos eliminar el video.");
+    } finally {
+      setDeletingVideoId(null);
+    }
+  };
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
@@ -258,7 +329,37 @@ export default function LibraryPage() {
               </div>
 
               <h2 className="font-display text-lg text-white">Video {video.video_id.slice(0, 8)}</h2>
-              <p className="mt-2 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-xs text-white/70">{video.filename}</p>
+              {editingVideoId === video.video_id ? (
+                <div className="mt-2 space-y-2">
+                  <input
+                    value={draftFilename}
+                    onChange={(event) => setDraftFilename(event.target.value)}
+                    className="w-full rounded-lg border border-white/20 bg-night-900/70 px-3 py-2 text-xs text-white outline-none transition focus:border-neon-cyan/50"
+                    maxLength={255}
+                    autoFocus
+                  />
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 rounded-lg border border-emerald-300/45 bg-emerald-300/10 px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-emerald-200 transition hover:bg-emerald-300/20 disabled:opacity-40"
+                      disabled={isSavingVideo}
+                      onClick={() => void handleSaveRename(video.video_id)}
+                    >
+                      <Check size={12} /> Guardar
+                    </button>
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/70 transition hover:border-white/40 hover:text-white"
+                      disabled={isSavingVideo}
+                      onClick={handleCancelRename}
+                    >
+                      <X size={12} /> Cancelar
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <p className="mt-2 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-xs text-white/70">{video.filename}</p>
+              )}
               <p className="mt-2 inline-flex rounded-full border border-neon-cyan/35 bg-neon-cyan/10 px-2 py-1 text-xs text-neon-cyan">
                 Estado: {video.status ?? "uploaded"}
               </p>
@@ -280,6 +381,26 @@ export default function LibraryPage() {
                   </span>
                 )}
               </div>
+
+              {editingVideoId !== video.video_id ? (
+                <div className="mt-2 grid grid-cols-2 gap-2">
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-cyan/40 hover:text-neon-cyan"
+                    onClick={() => handleStartRename(video)}
+                  >
+                    <PencilLine size={12} /> Renombrar
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center gap-1 rounded-lg border border-rose-300/45 bg-rose-300/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-rose-200 transition hover:bg-rose-300/20 disabled:opacity-40"
+                    disabled={deletingVideoId === video.video_id}
+                    onClick={() => void handleDeleteVideo(video)}
+                  >
+                    <Trash2 size={12} /> {deletingVideoId === video.video_id ? "Eliminando..." : "Eliminar"}
+                  </button>
+                </div>
+              ) : null}
             </article>
           ))}
         </div>

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -6,6 +6,8 @@ import { useAuthStore } from "@/src/store/useAuthStore";
 import { Clock3, Download, Search, Tag } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
+const PAGE_SIZE = 12;
+
 type VisualStatus = "listo" | "revision" | "render";
 
 const statusStyles: Record<VisualStatus, string> = {
@@ -28,6 +30,8 @@ function mapStatus(status: string): VisualStatus {
 export default function LibraryPage() {
   const token = useAuthStore((state) => state.token);
   const [clips, setClips] = useState<UserClipItem[]>([]);
+  const [totalClips, setTotalClips] = useState(0);
+  const [page, setPage] = useState(1);
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -45,9 +49,13 @@ export default function LibraryPage() {
       setIsLoading(true);
       setError(null);
       try {
-        const response = await videoApi.getMyClips(token, { limit: 100, offset: 0 });
+        const response = await videoApi.getMyClips(token, {
+          limit: PAGE_SIZE,
+          offset: (page - 1) * PAGE_SIZE
+        });
         if (!cancelled) {
           setClips(response.clips);
+          setTotalClips(response.total);
         }
       } catch (loadError) {
         if (!cancelled) {
@@ -65,7 +73,9 @@ export default function LibraryPage() {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [token, page]);
+
+  const totalPages = Math.max(1, Math.ceil(totalClips / PAGE_SIZE));
 
   const filteredClips = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -102,7 +112,10 @@ export default function LibraryPage() {
               placeholder="Buscar por id de job o archivo fuente..."
               className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/40"
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setPage(1);
+              }}
             />
           </label>
         </div>
@@ -184,9 +197,35 @@ export default function LibraryPage() {
               )}
             </div>
           </article>
-        );
+          );
         })}
       </div>
+
+      {totalPages > 1 ? (
+        <Panel className="mt-5">
+          <div className="flex items-center justify-between text-sm text-white/80">
+            <span>Pagina {page} de {totalPages}</span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:cursor-not-allowed disabled:opacity-40"
+                disabled={page <= 1 || isLoading}
+                onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+              >
+                Anterior
+              </button>
+              <button
+                type="button"
+                className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:cursor-not-allowed disabled:opacity-40"
+                disabled={page >= totalPages || isLoading}
+                onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+              >
+                Siguiente
+              </button>
+            </div>
+          </div>
+        </Panel>
+      ) : null}
     </section>
   );
 }

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { Panel } from "@/src/components/ui/Panel";
-import { videoApi, type UserClipItem } from "@/src/services/videoApi";
+import { videoApi, type UserClipItem, type UserVideoItem } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { Clock3, Download, Search, Tag } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 const PAGE_SIZE = 12;
+type LibraryView = "clips" | "videos";
 
 type VisualStatus = "listo" | "revision" | "render";
 
@@ -29,8 +30,11 @@ function mapStatus(status: string): VisualStatus {
 
 export default function LibraryPage() {
   const token = useAuthStore((state) => state.token);
+  const [view, setView] = useState<LibraryView>("clips");
   const [clips, setClips] = useState<UserClipItem[]>([]);
+  const [videos, setVideos] = useState<UserVideoItem[]>([]);
   const [totalClips, setTotalClips] = useState(0);
+  const [totalVideos, setTotalVideos] = useState(0);
   const [page, setPage] = useState(1);
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -45,17 +49,30 @@ export default function LibraryPage() {
 
     let cancelled = false;
 
-    const loadClips = async () => {
+    const loadData = async () => {
       setIsLoading(true);
       setError(null);
       try {
-        const response = await videoApi.getMyClips(token, {
-          limit: PAGE_SIZE,
-          offset: (page - 1) * PAGE_SIZE
-        });
-        if (!cancelled) {
-          setClips(response.clips);
-          setTotalClips(response.total);
+        if (view === "clips") {
+          const response = await videoApi.getMyClips(token, {
+            limit: PAGE_SIZE,
+            offset: (page - 1) * PAGE_SIZE,
+            query
+          });
+          if (!cancelled) {
+            setClips(response.clips);
+            setTotalClips(response.total);
+          }
+        } else {
+          const response = await videoApi.getMyVideos(token, {
+            limit: PAGE_SIZE,
+            offset: (page - 1) * PAGE_SIZE,
+            query
+          });
+          if (!cancelled) {
+            setVideos(response.videos);
+            setTotalVideos(response.total);
+          }
         }
       } catch (loadError) {
         if (!cancelled) {
@@ -68,28 +85,14 @@ export default function LibraryPage() {
       }
     };
 
-    void loadClips();
+    void loadData();
 
     return () => {
       cancelled = true;
     };
-  }, [token, page]);
+  }, [token, page, query, view]);
 
-  const totalPages = Math.max(1, Math.ceil(totalClips / PAGE_SIZE));
-
-  const filteredClips = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery) {
-      return clips;
-    }
-
-    return clips.filter((clip) => {
-      return (
-        clip.source_filename.toLowerCase().includes(normalizedQuery) ||
-        clip.job_id.toLowerCase().includes(normalizedQuery)
-      );
-    });
-  }, [clips, query]);
+  const totalPages = Math.max(1, Math.ceil((view === "clips" ? totalClips : totalVideos) / PAGE_SIZE));
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
@@ -98,18 +101,47 @@ export default function LibraryPage() {
         <div className="pointer-events-none absolute -bottom-16 left-1/4 h-44 w-44 rounded-full bg-neon-magenta/15 blur-3xl" />
 
         <div className="relative animate-fade-up">
-          <p className="text-xs uppercase tracking-[0.25em] text-neon-cyan/80">biblioteca clips</p>
-          <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Todos tus clips en un solo lugar</h1>
+          <p className="text-xs uppercase tracking-[0.25em] text-neon-cyan/80">biblioteca</p>
+          <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Tus clips y videos originales</h1>
           <p className="mt-2 max-w-2xl text-sm text-white/70">
-            Visualiza resultados reales de `my-clips`, revisa estado de render y organiza salidas para publicar mas rapido.
+            Cambia entre clips generados y videos subidos originales. La busqueda se hace en backend por nombre o ID.
           </p>
+        </div>
+
+        <div className="relative mt-4 inline-flex rounded-xl border border-white/12 bg-white/5 p-1 text-xs">
+          <button
+            type="button"
+            className={[
+              "rounded-lg px-3 py-1.5 transition",
+              view === "clips" ? "bg-neon-cyan/20 text-neon-cyan" : "text-white/70 hover:text-white"
+            ].join(" ")}
+            onClick={() => {
+              setView("clips");
+              setPage(1);
+            }}
+          >
+            Clips
+          </button>
+          <button
+            type="button"
+            className={[
+              "rounded-lg px-3 py-1.5 transition",
+              view === "videos" ? "bg-neon-cyan/20 text-neon-cyan" : "text-white/70 hover:text-white"
+            ].join(" ")}
+            onClick={() => {
+              setView("videos");
+              setPage(1);
+            }}
+          >
+            Videos originales
+          </button>
         </div>
 
         <div className="relative mt-5 grid gap-3 sm:grid-cols-1">
           <label className="group flex items-center gap-3 rounded-xl border border-white/12 bg-white/5 px-3 py-2 transition hover:border-neon-cyan/40">
             <Search size={15} className="text-neon-cyan/80" />
             <input
-              placeholder="Buscar por id de job o archivo fuente..."
+              placeholder={view === "clips" ? "Buscar por id de job o archivo fuente..." : "Buscar por id de video o archivo subido..."}
               className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/40"
               value={query}
               onChange={(event) => {
@@ -133,14 +165,21 @@ export default function LibraryPage() {
         </Panel>
       ) : null}
 
-      {!isLoading && !error && filteredClips.length === 0 ? (
+      {!isLoading && !error && view === "clips" && clips.length === 0 ? (
         <Panel className="mt-5">
           <p className="text-sm text-white/70">No encontramos clips para esa busqueda.</p>
         </Panel>
       ) : null}
 
-      <div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        {filteredClips.map((clip, index) => {
+      {!isLoading && !error && view === "videos" && videos.length === 0 ? (
+        <Panel className="mt-5">
+          <p className="text-sm text-white/70">No encontramos videos subidos para esa busqueda.</p>
+        </Panel>
+      ) : null}
+
+      {view === "clips" ? (
+        <div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {clips.map((clip, index) => {
           const visualStatus = mapStatus(clip.status);
 
           return (
@@ -198,8 +237,53 @@ export default function LibraryPage() {
             </div>
           </article>
           );
-        })}
-      </div>
+          })}
+        </div>
+      ) : (
+        <div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {videos.map((video, index) => (
+            <article
+              key={video.video_id}
+              className="group animate-fade-up rounded-2xl border border-white/10 bg-gradient-to-b from-night-800/80 to-night-900/80 p-4 shadow-panel transition duration-300 hover:-translate-y-1 hover:border-neon-cyan/40"
+              style={{ animationDelay: `${index * 90}ms` }}
+            >
+              <div className="relative mb-3 overflow-hidden rounded-xl border border-white/10 bg-night-900/80">
+                {video.preview_url ? (
+                  <video controls preload="metadata" className="aspect-[16/9] w-full object-cover" src={video.preview_url} />
+                ) : (
+                  <div className="aspect-[16/9] grid place-items-center bg-[radial-gradient(circle_at_20%_20%,rgba(53,208,255,0.22),transparent_45%),#0d1630] text-xs text-white/65">
+                    Sin preview disponible
+                  </div>
+                )}
+              </div>
+
+              <h2 className="font-display text-lg text-white">Video {video.video_id.slice(0, 8)}</h2>
+              <p className="mt-2 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-xs text-white/70">{video.filename}</p>
+              <p className="mt-2 inline-flex rounded-full border border-neon-cyan/35 bg-neon-cyan/10 px-2 py-1 text-xs text-neon-cyan">
+                Estado: {video.status ?? "uploaded"}
+              </p>
+
+              <div className="mt-4 flex items-center gap-2">
+                {video.preview_url ? (
+                  <a
+                    href={video.preview_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-neon-cyan transition hover:bg-neon-cyan/20"
+                  >
+                    <Download size={13} />
+                    Abrir video
+                  </a>
+                ) : (
+                  <span className="inline-flex flex-1 items-center justify-center rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/65">
+                    Sin URL disponible
+                  </span>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
 
       {totalPages > 1 ? (
         <Panel className="mt-5">

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -1,64 +1,86 @@
 "use client";
 
 import { Panel } from "@/src/components/ui/Panel";
-import { Clock3, Download, Filter, Play, Search, Sparkles, Tag } from "lucide-react";
+import { videoApi, type UserClipItem } from "@/src/services/videoApi";
+import { useAuthStore } from "@/src/store/useAuthStore";
+import { Clock3, Download, Search, Tag } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
-type ClipCard = {
-  id: string;
-  title: string;
-  duration: string;
-  source: string;
-  preset: string;
-  status: "listo" | "revision" | "render";
-  ratio: "9:16" | "1:1";
-};
+type VisualStatus = "listo" | "revision" | "render";
 
-const clips: ClipCard[] = [
-  {
-    id: "clip-01",
-    title: "Hook de apertura",
-    duration: "00:28",
-    source: "entrevista-founder.mp4",
-    preset: "Impact",
-    status: "listo",
-    ratio: "9:16"
-  },
-  {
-    id: "clip-02",
-    title: "Comparativa rapida",
-    duration: "00:22",
-    source: "demo-producto.mov",
-    preset: "Fast Cut",
-    status: "revision",
-    ratio: "1:1"
-  },
-  {
-    id: "clip-03",
-    title: "CTA final",
-    duration: "00:17",
-    source: "webinar-growth.mp4",
-    preset: "Story",
-    status: "render",
-    ratio: "9:16"
-  },
-  {
-    id: "clip-04",
-    title: "Momento viral",
-    duration: "00:31",
-    source: "podcast-episodio-12.mp4",
-    preset: "Impact",
-    status: "listo",
-    ratio: "9:16"
-  }
-];
-
-const statusStyles: Record<ClipCard["status"], string> = {
+const statusStyles: Record<VisualStatus, string> = {
   listo: "border-emerald-300/40 bg-emerald-300/10 text-emerald-200",
   revision: "border-amber-300/45 bg-amber-300/10 text-amber-100",
   render: "border-sky-300/45 bg-sky-300/10 text-sky-100"
 };
 
+function mapStatus(status: string): VisualStatus {
+  const normalized = status.toLowerCase();
+  if (normalized === "done" || normalized === "completed") {
+    return "listo";
+  }
+  if (normalized === "failed" || normalized === "error") {
+    return "revision";
+  }
+  return "render";
+}
+
 export default function LibraryPage() {
+  const token = useAuthStore((state) => state.token);
+  const [clips, setClips] = useState<UserClipItem[]>([]);
+  const [query, setQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setIsLoading(false);
+      setError("No encontramos una sesion activa para traer la biblioteca.");
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadClips = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await videoApi.getMyClips(token, { limit: 100, offset: 0 });
+        if (!cancelled) {
+          setClips(response.clips);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(loadError instanceof Error ? loadError.message : "No pudimos cargar la biblioteca.");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadClips();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const filteredClips = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return clips;
+    }
+
+    return clips.filter((clip) => {
+      return (
+        clip.source_filename.toLowerCase().includes(normalizedQuery) ||
+        clip.job_id.toLowerCase().includes(normalizedQuery)
+      );
+    });
+  }, [clips, query]);
+
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
       <Panel className="relative overflow-hidden border-neon-cyan/25 bg-gradient-to-r from-night-900 via-night-800/85 to-night-900 p-5 sm:p-6">
@@ -69,80 +91,101 @@ export default function LibraryPage() {
           <p className="text-xs uppercase tracking-[0.25em] text-neon-cyan/80">biblioteca clips</p>
           <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Todos tus clips en un solo lugar</h1>
           <p className="mt-2 max-w-2xl text-sm text-white/70">
-            Visualiza resultados, revisa estado de render y organiza salidas para publicar mas rapido.
+            Visualiza resultados reales de `my-clips`, revisa estado de render y organiza salidas para publicar mas rapido.
           </p>
         </div>
 
-        <div className="relative mt-5 grid gap-3 sm:grid-cols-[1fr_auto_auto]">
+        <div className="relative mt-5 grid gap-3 sm:grid-cols-1">
           <label className="group flex items-center gap-3 rounded-xl border border-white/12 bg-white/5 px-3 py-2 transition hover:border-neon-cyan/40">
             <Search size={15} className="text-neon-cyan/80" />
             <input
-              placeholder="Buscar por titulo o archivo..."
+              placeholder="Buscar por id de job o archivo fuente..."
               className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/40"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
             />
           </label>
-
-          <button className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm text-white/80 transition hover:border-neon-cyan/45 hover:text-white">
-            <Filter size={14} />
-            Filtros
-          </button>
-
-          <button className="inline-flex items-center justify-center gap-2 rounded-xl border border-neon-cyan/45 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan transition hover:bg-neon-cyan/20">
-            <Sparkles size={14} />
-            Nueva seleccion IA
-          </button>
         </div>
       </Panel>
 
+      {error ? (
+        <Panel className="mt-5">
+          <p className="rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{error}</p>
+        </Panel>
+      ) : null}
+
+      {isLoading ? (
+        <Panel className="mt-5">
+          <p className="text-sm text-white/70">Cargando clips de biblioteca...</p>
+        </Panel>
+      ) : null}
+
+      {!isLoading && !error && filteredClips.length === 0 ? (
+        <Panel className="mt-5">
+          <p className="text-sm text-white/70">No encontramos clips para esa busqueda.</p>
+        </Panel>
+      ) : null}
+
       <div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        {clips.map((clip, index) => (
+        {filteredClips.map((clip, index) => {
+          const visualStatus = mapStatus(clip.status);
+
+          return (
           <article
-            key={clip.id}
+            key={clip.job_id}
             className="group animate-fade-up rounded-2xl border border-white/10 bg-gradient-to-b from-night-800/80 to-night-900/80 p-4 shadow-panel transition duration-300 hover:-translate-y-1 hover:border-neon-cyan/40"
             style={{ animationDelay: `${index * 90}ms` }}
           >
             <div className="relative mb-3 overflow-hidden rounded-xl border border-white/10 bg-night-900/80">
-              <div className="aspect-[9/13] bg-[radial-gradient(circle_at_20%_20%,rgba(53,208,255,0.32),transparent_45%),radial-gradient(circle_at_80%_78%,rgba(255,79,216,0.28),transparent_50%),#0d1630]" />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-transparent to-transparent" />
+              {clip.output_path ? (
+                <video controls preload="metadata" className="aspect-[9/13] w-full object-cover" src={clip.output_path} />
+              ) : (
+                <div className="aspect-[9/13] bg-[radial-gradient(circle_at_20%_20%,rgba(53,208,255,0.32),transparent_45%),radial-gradient(circle_at_80%_78%,rgba(255,79,216,0.28),transparent_50%),#0d1630]" />
+              )}
 
-              <button className="absolute left-3 top-3 grid h-8 w-8 place-items-center rounded-full border border-white/30 bg-night-900/70 text-white transition group-hover:animate-drift group-hover:border-neon-cyan/70 group-hover:text-neon-cyan">
-                <Play size={14} />
-              </button>
-
-              <span className={`absolute right-3 top-3 rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.2em] ${statusStyles[clip.status]}`}>
-                {clip.status}
+              <span className={`absolute right-3 top-3 rounded-full border px-2 py-1 text-[10px] uppercase tracking-[0.2em] ${statusStyles[visualStatus]}`}>
+                {visualStatus}
               </span>
 
               <div className="absolute bottom-3 left-3 right-3 flex items-center justify-between text-xs text-white/85">
                 <span className="inline-flex items-center gap-1 rounded-full bg-black/35 px-2 py-1 backdrop-blur-sm">
                   <Clock3 size={12} />
-                  {clip.duration}
+                  clip
                 </span>
-                <span className="rounded-full bg-black/35 px-2 py-1 backdrop-blur-sm">{clip.ratio}</span>
+                <span className="rounded-full bg-black/35 px-2 py-1 backdrop-blur-sm">9:16</span>
               </div>
             </div>
 
-            <h2 className="font-display text-lg text-white">{clip.title}</h2>
+            <h2 className="font-display text-lg text-white">Job {clip.job_id.slice(0, 8)}</h2>
 
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
               <span className="inline-flex items-center gap-1 rounded-full border border-neon-violet/35 bg-neon-violet/10 px-2 py-1 text-neon-violet">
                 <Tag size={11} />
-                {clip.preset}
+                Auto Reframe
               </span>
-              <span className="rounded-full border border-white/15 bg-white/5 px-2 py-1 text-white/70">{clip.source}</span>
+              <span className="rounded-full border border-white/15 bg-white/5 px-2 py-1 text-white/70">{clip.source_filename}</span>
             </div>
 
             <div className="mt-4 flex items-center gap-2">
-              <button className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-neon-cyan transition hover:bg-neon-cyan/20">
-                <Download size={13} />
-                Descargar
-              </button>
-              <button className="rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-xs text-white/80 transition hover:border-white/30 hover:text-white">
-                Ver detalles
-              </button>
+              {clip.output_path ? (
+                <a
+                  href={clip.output_path}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-neon-cyan transition hover:bg-neon-cyan/20"
+                >
+                  <Download size={13} />
+                  Abrir clip
+                </a>
+              ) : (
+                <span className="inline-flex flex-1 items-center justify-center rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/65">
+                  Sin URL disponible
+                </span>
+              )}
             </div>
           </article>
-        ))}
+        );
+        })}
       </div>
     </section>
   );

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -3,7 +3,8 @@
 import { Panel } from "@/src/components/ui/Panel";
 import { videoApi, type UserClipItem, type UserVideoItem } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
-import { Check, Clock3, Download, PencilLine, Search, Tag, Trash2, X } from "lucide-react";
+import { Check, Clock3, Download, PencilLine, Search, Share2, Tag, Trash2, X } from "lucide-react";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 const PAGE_SIZE = 12;
@@ -43,6 +44,7 @@ export default function LibraryPage() {
   const [draftFilename, setDraftFilename] = useState("");
   const [isSavingVideo, setIsSavingVideo] = useState(false);
   const [deletingVideoId, setDeletingVideoId] = useState<string | null>(null);
+  const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!token) {
@@ -162,6 +164,38 @@ export default function LibraryPage() {
       setError(deleteError instanceof Error ? deleteError.message : "No pudimos eliminar el video.");
     } finally {
       setDeletingVideoId(null);
+    }
+  };
+
+  const handleDeleteClip = async (clip: UserClipItem) => {
+    if (!token || deletingClipId) {
+      return;
+    }
+
+    const confirmed = window.confirm(`Vas a eliminar el clip ${clip.job_id.slice(0, 8)}. Esta accion no se puede deshacer.`);
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingClipId(clip.job_id);
+    setError(null);
+
+    try {
+      await videoApi.deleteMyClip(clip.job_id, token);
+      let shouldStepBackPage = false;
+      setClips((prev) => {
+        shouldStepBackPage = prev.length === 1;
+        return prev.filter((item) => item.job_id !== clip.job_id);
+      });
+      setTotalClips((prev) => Math.max(0, prev - 1));
+
+      if (shouldStepBackPage && page > 1) {
+        setPage((prev) => Math.max(1, prev - 1));
+      }
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : "No pudimos eliminar el clip.");
+    } finally {
+      setDeletingClipId(null);
     }
   };
 
@@ -305,6 +339,29 @@ export default function LibraryPage() {
                   Sin URL disponible
                 </span>
               )}
+            </div>
+
+            <div className="mt-2 grid grid-cols-3 gap-2">
+              <Link
+                href={`/app/timeline?videoId=${clip.video_id}&clipId=${clip.job_id}`}
+                className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-cyan/40 hover:text-neon-cyan"
+              >
+                <PencilLine size={12} /> Editar
+              </Link>
+              <Link
+                href={`/app/share/${clip.job_id}`}
+                className="inline-flex items-center justify-center gap-1 rounded-lg border border-neon-mint/40 bg-neon-mint/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-neon-mint transition hover:bg-neon-mint/20"
+              >
+                <Share2 size={12} /> Compartir
+              </Link>
+              <button
+                type="button"
+                className="inline-flex items-center justify-center gap-1 rounded-lg border border-rose-300/45 bg-rose-300/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-rose-200 transition hover:bg-rose-300/20 disabled:opacity-40"
+                disabled={deletingClipId === clip.job_id}
+                onClick={() => void handleDeleteClip(clip)}
+              >
+                <Trash2 size={12} /> {deletingClipId === clip.job_id ? "Eliminando..." : "Eliminar"}
+              </button>
             </div>
           </article>
           );

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -3,8 +3,6 @@
 import { GeneratedClipsSection, type Clip } from "@/src/components/home/GeneratedClipsSection";
 import { ProjectStatusPanel } from "@/src/components/home/ProjectStatusPanel";
 import { UploadDropzone } from "@/src/components/home/UploadDropzone";
-import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
-import { VideoSettings } from "@/src/components/home/VideoSettings";
 import { Panel } from "@/src/components/ui/Panel";
 import { VideoApiError, type AutoReframeJobItem, type VideoUploadResponse, videoApi } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
@@ -22,25 +20,34 @@ function toTimeLabel(seconds: number) {
 
 function mapJobStatusToClipStatus(status: string): Clip["status"] {
   const normalized = status.toLowerCase();
-  if (normalized === "completed") {
+  if (normalized === "completed" || normalized === "done") {
     return "listo";
   }
 
-  if (normalized === "failed") {
+  if (normalized === "failed" || normalized === "error") {
     return "revision";
   }
 
   return "render";
 }
 
-function mapJobsToClips(jobs: AutoReframeJobItem[]): Clip[] {
-  return jobs.map((job, index) => ({
+function mapJobsToClips(
+  jobs: AutoReframeJobItem[],
+  jobStatusMap: Record<string, { status: string; outputPath: string | null }>
+): Clip[] {
+  return jobs.map((job, index) => {
+    const statusInfo = jobStatusMap[job.job_id];
+    const status = statusInfo?.status ?? job.status;
+
+    return {
     id: job.job_id,
     title: `Clip ${index + 1}`,
     duration: toTimeLabel(Math.max(job.end_sec - job.start_sec, 0)),
     preset: "Auto Reframe",
-    status: mapJobStatusToClipStatus(job.status)
-  }));
+    status: mapJobStatusToClipStatus(status),
+    previewUrl: statusInfo?.outputPath ?? null
+  };
+  });
 }
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
@@ -75,28 +82,60 @@ export default function AppHomePage() {
   const [uploadedVideo, setUploadedVideo] = useState<VideoUploadResponse | null>(null);
   const [autoJobCount, setAutoJobCount] = useState(0);
   const [createdJobs, setCreatedJobs] = useState<AutoReframeJobItem[]>([]);
-  const [videoPreviewUrl, setVideoPreviewUrl] = useState<string | null>(null);
+  const [jobStatusMap, setJobStatusMap] = useState<Record<string, { status: string; outputPath: string | null }>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [jobError, setJobError] = useState<string | null>(null);
 
   const hasVideo = Boolean(uploadedVideo);
-  const visibleClips = useMemo(() => mapJobsToClips(createdJobs), [createdJobs]);
+  const visibleClips = useMemo(() => mapJobsToClips(createdJobs, jobStatusMap), [createdJobs, jobStatusMap]);
 
   useEffect(() => {
-    return () => {
-      if (videoPreviewUrl) {
-        URL.revokeObjectURL(videoPreviewUrl);
+    if (!token || createdJobs.length === 0) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const syncStatuses = async () => {
+      try {
+        const statuses = await Promise.all(createdJobs.map((job) => videoApi.getJobStatus(job.job_id, token)));
+        if (cancelled) {
+          return;
+        }
+
+        const nextMap: Record<string, { status: string; outputPath: string | null }> = {};
+        statuses.forEach((item) => {
+          nextMap[item.job_id] = {
+            status: item.status,
+            outputPath: item.output_path
+          };
+        });
+
+        setJobStatusMap(nextMap);
+      } catch {
+        if (!cancelled) {
+          setJobError((prev) => prev ?? "No pudimos actualizar el estado de algunos clips generados.");
+        }
       }
     };
-  }, [videoPreviewUrl]);
+
+    void syncStatuses();
+    const intervalId = window.setInterval(() => {
+      void syncStatuses();
+    }, 6000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [createdJobs, token]);
 
   const handleUpload = async (file: File) => {
-    const localPreviewUrl = URL.createObjectURL(file);
-
     setIsUploading(true);
     setIsCreatingJobs(false);
     setUploadedVideo(null);
     setCreatedJobs([]);
+    setJobStatusMap({});
     setAutoJobCount(0);
     setUploadError(null);
     setJobError(null);
@@ -106,20 +145,12 @@ export default function AppHomePage() {
     try {
       uploaded = await videoApi.upload(file, token);
     } catch (error) {
-      URL.revokeObjectURL(localPreviewUrl);
-      setVideoPreviewUrl(null);
       setUploadError(normalizeVideoError(error, "No pudimos subir el video."));
       setIsUploading(false);
       return;
     }
 
     setUploadedVideo(uploaded);
-    setVideoPreviewUrl((prev) => {
-      if (prev) {
-        URL.revokeObjectURL(prev);
-      }
-      return localPreviewUrl;
-    });
     setIsUploading(false);
 
     if (!token) {
@@ -133,6 +164,12 @@ export default function AppHomePage() {
       const autoJobs = await videoApi.createAutoReframeJobs(uploaded.video_id, token);
       setCreatedJobs(autoJobs.jobs);
       setAutoJobCount(autoJobs.total_jobs);
+
+      const initialMap: Record<string, { status: string; outputPath: string | null }> = {};
+      autoJobs.jobs.forEach((job) => {
+        initialMap[job.job_id] = { status: job.status, outputPath: null };
+      });
+      setJobStatusMap(initialMap);
     } catch (error) {
       setJobError(normalizeVideoError(error, "No pudimos crear los clips automaticos."));
     } finally {
@@ -140,7 +177,6 @@ export default function AppHomePage() {
     }
   };
 
-  const showPreview = Boolean(videoPreviewUrl && hasVideo && !isUploading);
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
       <div className="grid gap-5 xl:grid-cols-[1.55fr_0.95fr]">
@@ -164,24 +200,6 @@ export default function AppHomePage() {
           />
         </Panel>
       </div>
-      {showPreview && (<div className="mt-5 flex flex-col gap-5 lg:flex-row">
-        <Panel>
-          <p className="text-xs uppercase tracking-[0.22em] text-white/65">timeline</p>
-          <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Preview y recorte</h3>
-          <VideoPreview
-            videoPreviewUrl={videoPreviewUrl}
-            onTrimChange={(start, end) => {
-              console.log("Enviar al backend:", { start, end });
-            }}
-          />
-        </Panel>
-        <Panel>
-          <p className="text-xs uppercase tracking-[0.22em] text-white/65">configuracion</p>
-          <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Ajustes de recorte</h3>
-          <VideoSettings />
-        </Panel>
-      </div>)}
-
       <Panel className="mt-5">
         <GeneratedClipsSection clips={visibleClips} showLoading={isUploading || isCreatingJobs} />
       </Panel>

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -6,15 +6,42 @@ import { UploadDropzone } from "@/src/components/home/UploadDropzone";
 import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
 import { VideoSettings } from "@/src/components/home/VideoSettings";
 import { Panel } from "@/src/components/ui/Panel";
-import { VideoApiError, type VideoUploadResponse, videoApi } from "@/src/services/videoApi";
+import { VideoApiError, type AutoReframeJobItem, type VideoUploadResponse, videoApi } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useEffect, useMemo, useState } from "react";
 
-const mockClips: Clip[] = [
-  { id: "clip-1", title: "Hook inicial", duration: "00:31", preset: "Impact", status: "listo" },
-  { id: "clip-2", title: "Momento clave", duration: "00:24", preset: "Story", status: "revision" },
-  { id: "clip-3", title: "CTA final", duration: "00:18", preset: "Fast Cut", status: "render" }
-];
+function toTimeLabel(seconds: number) {
+  const min = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const sec = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${min}:${sec}`;
+}
+
+function mapJobStatusToClipStatus(status: string): Clip["status"] {
+  const normalized = status.toLowerCase();
+  if (normalized === "completed") {
+    return "listo";
+  }
+
+  if (normalized === "failed") {
+    return "revision";
+  }
+
+  return "render";
+}
+
+function mapJobsToClips(jobs: AutoReframeJobItem[]): Clip[] {
+  return jobs.map((job, index) => ({
+    id: job.job_id,
+    title: `Clip ${index + 1}`,
+    duration: toTimeLabel(Math.max(job.end_sec - job.start_sec, 0)),
+    preset: "Auto Reframe",
+    status: mapJobStatusToClipStatus(job.status)
+  }));
+}
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
   if (error instanceof VideoApiError) {
@@ -44,12 +71,16 @@ function normalizeVideoError(error: unknown, fallbackMessage: string) {
 export default function AppHomePage() {
   const token = useAuthStore((state) => state.token);
   const [isUploading, setIsUploading] = useState(false);
+  const [isCreatingJobs, setIsCreatingJobs] = useState(false);
   const [uploadedVideo, setUploadedVideo] = useState<VideoUploadResponse | null>(null);
+  const [autoJobCount, setAutoJobCount] = useState(0);
+  const [createdJobs, setCreatedJobs] = useState<AutoReframeJobItem[]>([]);
   const [videoPreviewUrl, setVideoPreviewUrl] = useState<string | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [jobError, setJobError] = useState<string | null>(null);
 
   const hasVideo = Boolean(uploadedVideo);
-  const visibleClips = useMemo(() => (hasVideo && !isUploading ? mockClips : []), [hasVideo, isUploading]);
+  const visibleClips = useMemo(() => mapJobsToClips(createdJobs), [createdJobs]);
 
   useEffect(() => {
     return () => {
@@ -63,24 +94,49 @@ export default function AppHomePage() {
     const localPreviewUrl = URL.createObjectURL(file);
 
     setIsUploading(true);
+    setIsCreatingJobs(false);
     setUploadedVideo(null);
+    setCreatedJobs([]);
+    setAutoJobCount(0);
     setUploadError(null);
+    setJobError(null);
+
+    let uploaded: VideoUploadResponse;
 
     try {
-      const uploaded = await videoApi.upload(file, token);
-      setUploadedVideo(uploaded);
-      setVideoPreviewUrl((prev) => {
-        if (prev) {
-          URL.revokeObjectURL(prev);
-        }
-        return localPreviewUrl;
-      });
+      uploaded = await videoApi.upload(file, token);
     } catch (error) {
       URL.revokeObjectURL(localPreviewUrl);
       setVideoPreviewUrl(null);
       setUploadError(normalizeVideoError(error, "No pudimos subir el video."));
-    } finally {
       setIsUploading(false);
+      return;
+    }
+
+    setUploadedVideo(uploaded);
+    setVideoPreviewUrl((prev) => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return localPreviewUrl;
+    });
+    setIsUploading(false);
+
+    if (!token) {
+      setJobError("No encontramos tu sesion para crear clips automaticos. Volve a iniciar sesion.");
+      return;
+    }
+
+    setIsCreatingJobs(true);
+
+    try {
+      const autoJobs = await videoApi.createAutoReframeJobs(uploaded.video_id, token);
+      setCreatedJobs(autoJobs.jobs);
+      setAutoJobCount(autoJobs.total_jobs);
+    } catch (error) {
+      setJobError(normalizeVideoError(error, "No pudimos crear los clips automaticos."));
+    } finally {
+      setIsCreatingJobs(false);
     }
   };
 
@@ -102,26 +158,32 @@ export default function AppHomePage() {
             isUploading={isUploading}
             uploadError={uploadError}
             videoId={uploadedVideo?.video_id ?? null}
-            videoPreviewUrl={videoPreviewUrl}
+            isCreatingJobs={isCreatingJobs}
+            jobsCreated={autoJobCount}
+            jobError={jobError}
           />
         </Panel>
       </div>
-      {showPreview &&(<div className="flex flex-col lg:flex-row gap-5 mt-5">
-        <Panel >
-          <VideoPreview videoPreviewUrl={videoPreviewUrl}
-          onTrimChange={(start, end) => {
-        console.log("Enviar al backend:", { start, end });
-      }}
+      {showPreview && (<div className="mt-5 flex flex-col gap-5 lg:flex-row">
+        <Panel>
+          <p className="text-xs uppercase tracking-[0.22em] text-white/65">timeline</p>
+          <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Preview y recorte</h3>
+          <VideoPreview
+            videoPreviewUrl={videoPreviewUrl}
+            onTrimChange={(start, end) => {
+              console.log("Enviar al backend:", { start, end });
+            }}
           />
         </Panel>
         <Panel>
+          <p className="text-xs uppercase tracking-[0.22em] text-white/65">configuracion</p>
+          <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Ajustes de recorte</h3>
           <VideoSettings />
         </Panel>
-
       </div>)}
-      
+
       <Panel className="mt-5">
-        <GeneratedClipsSection clips={visibleClips} showLoading={isUploading} />
+        <GeneratedClipsSection clips={visibleClips} showLoading={isUploading || isCreatingJobs} />
       </Panel>
     </section>
   );

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -86,6 +86,7 @@ export default function AppHomePage() {
   const token = useAuthStore((state) => state.token);
   const [isUploading, setIsUploading] = useState(false);
   const [isCreatingJobs, setIsCreatingJobs] = useState(false);
+  const [isPollingStatuses, setIsPollingStatuses] = useState(false);
   const [uploadedVideo, setUploadedVideo] = useState<VideoUploadResponse | null>(null);
   const [autoJobCount, setAutoJobCount] = useState(0);
   const [createdJobs, setCreatedJobs] = useState<AutoReframeJobItem[]>([]);
@@ -140,6 +141,7 @@ export default function AppHomePage() {
 
   useEffect(() => {
     if (!token || createdJobs.length === 0) {
+      setIsPollingStatuses(false);
       return;
     }
 
@@ -178,6 +180,8 @@ export default function AppHomePage() {
         if (!shouldContinuePolling) {
           window.clearInterval(intervalId);
         }
+
+        setIsPollingStatuses(shouldContinuePolling);
       } catch {
         if (!cancelled) {
           setJobError((prev) => prev ?? "No pudimos actualizar el estado de algunos clips generados.");
@@ -185,6 +189,7 @@ export default function AppHomePage() {
       }
     };
 
+    setIsPollingStatuses(true);
     const intervalId = window.setInterval(() => {
       void syncStatuses();
     }, 6000);
@@ -193,6 +198,7 @@ export default function AppHomePage() {
     return () => {
       cancelled = true;
       window.clearInterval(intervalId);
+      setIsPollingStatuses(false);
     };
   }, [createdJobs, token]);
 
@@ -268,7 +274,11 @@ export default function AppHomePage() {
         </Panel>
       </div>
       <Panel className="mt-5">
-        <GeneratedClipsSection clips={visibleClips} showLoading={isUploading || isCreatingJobs} />
+        <GeneratedClipsSection
+          clips={visibleClips}
+          showLoading={isUploading || (isCreatingJobs && createdJobs.length === 0)}
+          isRefreshingStatuses={isPollingStatuses}
+        />
       </Panel>
     </section>
   );

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -4,12 +4,19 @@ import { GeneratedClipsSection, type Clip } from "@/src/components/home/Generate
 import { ProjectStatusPanel } from "@/src/components/home/ProjectStatusPanel";
 import { UploadDropzone } from "@/src/components/home/UploadDropzone";
 import { Panel } from "@/src/components/ui/Panel";
-import { VideoApiError, type AutoReframeJobItem, type VideoUploadResponse, videoApi } from "@/src/services/videoApi";
+import {
+  VideoApiError,
+  type AutoReframeJobItem,
+  type UserClipItem,
+  type VideoUploadResponse,
+  videoApi
+} from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useEffect, useMemo, useState } from "react";
 
 const HOME_DRAFT_KEY = "home:uploaded-video-draft";
 type ClipOutputStyle = "vertical" | "speaker_split";
+type ClipContentProfile = "auto" | "interview" | "sports" | "music";
 
 function toTimeLabel(seconds: number) {
   const min = Math.floor(seconds / 60)
@@ -51,6 +58,17 @@ function mapJobsToClips(
       previewUrl: statusInfo?.outputPath ?? null
     };
   });
+}
+
+function mapUserClipsToCards(clips: UserClipItem[]): Clip[] {
+  return clips.map((clip, index) => ({
+    id: clip.job_id,
+    title: `Clip ${index + 1}`,
+    duration: "00:15",
+    preset: "Auto Reframe",
+    status: mapJobStatusToClipStatus(clip.status),
+    previewUrl: clip.output_path
+  }));
 }
 
 function isTerminalStatus(status: string) {
@@ -95,9 +113,16 @@ export default function AppHomePage() {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [jobError, setJobError] = useState<string | null>(null);
   const [outputStyle, setOutputStyle] = useState<ClipOutputStyle>("vertical");
+  const [contentProfile, setContentProfile] = useState<ClipContentProfile>("auto");
+  const [fallbackClips, setFallbackClips] = useState<UserClipItem[]>([]);
 
   const hasVideo = Boolean(uploadedVideo);
-  const visibleClips = useMemo(() => mapJobsToClips(createdJobs, jobStatusMap), [createdJobs, jobStatusMap]);
+  const visibleClips = useMemo(() => {
+    if (createdJobs.length > 0) {
+      return mapJobsToClips(createdJobs, jobStatusMap);
+    }
+    return mapUserClipsToCards(fallbackClips);
+  }, [createdJobs, jobStatusMap, fallbackClips]);
 
   useEffect(() => {
     try {
@@ -111,6 +136,7 @@ export default function AppHomePage() {
         createdJobs: AutoReframeJobItem[];
         autoJobCount: number;
         outputStyle?: ClipOutputStyle;
+        contentProfile?: ClipContentProfile;
       };
 
       if (parsed.uploadedVideo) {
@@ -124,6 +150,14 @@ export default function AppHomePage() {
       }
       if (parsed.outputStyle === "vertical" || parsed.outputStyle === "speaker_split") {
         setOutputStyle(parsed.outputStyle);
+      }
+      if (
+        parsed.contentProfile === "auto" ||
+        parsed.contentProfile === "interview" ||
+        parsed.contentProfile === "sports" ||
+        parsed.contentProfile === "music"
+      ) {
+        setContentProfile(parsed.contentProfile);
       }
     } catch {
       window.localStorage.removeItem(HOME_DRAFT_KEY);
@@ -140,11 +174,12 @@ export default function AppHomePage() {
       uploadedVideo,
       createdJobs,
       autoJobCount,
-      outputStyle
+      outputStyle,
+      contentProfile
     };
 
     window.localStorage.setItem(HOME_DRAFT_KEY, JSON.stringify(payload));
-  }, [uploadedVideo, createdJobs, autoJobCount, outputStyle]);
+  }, [uploadedVideo, createdJobs, autoJobCount, outputStyle, contentProfile]);
 
   useEffect(() => {
     if (!token || createdJobs.length === 0) {
@@ -214,6 +249,7 @@ export default function AppHomePage() {
     setIsCreatingJobs(false);
     setUploadedVideo(null);
     setCreatedJobs([]);
+    setFallbackClips([]);
     setJobStatusMap({});
     setAutoJobCount(0);
     setUploadError(null);
@@ -242,7 +278,8 @@ export default function AppHomePage() {
 
     try {
       const autoJobs = await videoApi.createAutoReframeJobs(uploaded.video_id, token, {
-        outputStyle
+        outputStyle,
+        contentProfile
       });
       setCreatedJobs(autoJobs.jobs);
       setAutoJobCount(autoJobs.total_jobs);
@@ -258,6 +295,37 @@ export default function AppHomePage() {
       setIsCreatingJobs(false);
     }
   };
+
+  useEffect(() => {
+    if (!token || !uploadedVideo || createdJobs.length > 0 || isUploading || isCreatingJobs) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const hydrateFromLibrary = async () => {
+      try {
+        const data = await videoApi.getMyClips(token, { limit: 40, offset: 0 });
+        if (cancelled) {
+          return;
+        }
+
+        const related = data.clips.filter((clip) => clip.video_id === uploadedVideo.video_id);
+        if (related.length > 0) {
+          setFallbackClips(related);
+          setAutoJobCount((prev) => (prev > 0 ? prev : related.length));
+        }
+      } catch {
+        // Silencioso: este hydrate es best-effort para evitar estados vacios en Home.
+      }
+    };
+
+    void hydrateFromLibrary();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, uploadedVideo, createdJobs.length, isUploading, isCreatingJobs]);
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
@@ -289,6 +357,65 @@ export default function AppHomePage() {
                 Split speaker (arriba foco, abajo plano general)
               </button>
             </div>
+
+            <div className="mt-3">
+              <p className="text-xs uppercase tracking-[0.18em] text-white/55">Perfil de contenido (auto en Home)</p>
+              <div className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                <button
+                  type="button"
+                  onClick={() => setContentProfile("auto")}
+                  className={`rounded-lg border px-3 py-2 text-left text-sm transition ${
+                    contentProfile === "auto"
+                      ? "border-neon-mint/45 bg-neon-mint/15 text-neon-mint"
+                      : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                  }`}
+                >
+                  Auto detectar
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setContentProfile("interview")}
+                  className={`rounded-lg border px-3 py-2 text-left text-sm transition ${
+                    contentProfile === "interview"
+                      ? "border-neon-mint/45 bg-neon-mint/15 text-neon-mint"
+                      : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                  }`}
+                >
+                  Entrevista
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setContentProfile("sports")}
+                  className={`rounded-lg border px-3 py-2 text-left text-sm transition ${
+                    contentProfile === "sports"
+                      ? "border-neon-mint/45 bg-neon-mint/15 text-neon-mint"
+                      : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                  }`}
+                >
+                  Deportes
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setContentProfile("music")}
+                  className={`rounded-lg border px-3 py-2 text-left text-sm transition ${
+                    contentProfile === "music"
+                      ? "border-neon-mint/45 bg-neon-mint/15 text-neon-mint"
+                      : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                  }`}
+                >
+                  Musica
+                </button>
+              </div>
+            </div>
+
+            {outputStyle === "speaker_split" && (
+              <div className="mt-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-white/55">Ajuste de layout speaker split</p>
+                <div className="mt-2 text-xs text-white/70">
+                  En `Auto detectar`, si el backend clasifica como `deportes`, aplica framing mas abierto.
+                </div>
+              </div>
+            )}
           </div>
           <UploadDropzone
             onUpload={handleUpload}

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -8,6 +8,8 @@ import { VideoApiError, type AutoReframeJobItem, type VideoUploadResponse, video
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useEffect, useMemo, useState } from "react";
 
+const HOME_DRAFT_KEY = "home:uploaded-video-draft";
+
 function toTimeLabel(seconds: number) {
   const min = Math.floor(seconds / 60)
     .toString()
@@ -40,14 +42,19 @@ function mapJobsToClips(
     const status = statusInfo?.status ?? job.status;
 
     return {
-    id: job.job_id,
-    title: `Clip ${index + 1}`,
-    duration: toTimeLabel(Math.max(job.end_sec - job.start_sec, 0)),
-    preset: "Auto Reframe",
-    status: mapJobStatusToClipStatus(status),
-    previewUrl: statusInfo?.outputPath ?? null
-  };
+      id: job.job_id,
+      title: `Clip ${index + 1}`,
+      duration: toTimeLabel(Math.max(job.end_sec - job.start_sec, 0)),
+      preset: "Auto Reframe",
+      status: mapJobStatusToClipStatus(status),
+      previewUrl: statusInfo?.outputPath ?? null
+    };
   });
+}
+
+function isTerminalStatus(status: string) {
+  const normalized = status.toLowerCase();
+  return normalized === "done" || normalized === "completed" || normalized === "failed" || normalized === "error";
 }
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
@@ -90,6 +97,48 @@ export default function AppHomePage() {
   const visibleClips = useMemo(() => mapJobsToClips(createdJobs, jobStatusMap), [createdJobs, jobStatusMap]);
 
   useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(HOME_DRAFT_KEY);
+      if (!raw) {
+        return;
+      }
+
+      const parsed = JSON.parse(raw) as {
+        uploadedVideo: VideoUploadResponse | null;
+        createdJobs: AutoReframeJobItem[];
+        autoJobCount: number;
+      };
+
+      if (parsed.uploadedVideo) {
+        setUploadedVideo(parsed.uploadedVideo);
+      }
+      if (Array.isArray(parsed.createdJobs)) {
+        setCreatedJobs(parsed.createdJobs);
+      }
+      if (typeof parsed.autoJobCount === "number") {
+        setAutoJobCount(parsed.autoJobCount);
+      }
+    } catch {
+      window.localStorage.removeItem(HOME_DRAFT_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!uploadedVideo) {
+      window.localStorage.removeItem(HOME_DRAFT_KEY);
+      return;
+    }
+
+    const payload = {
+      uploadedVideo,
+      createdJobs,
+      autoJobCount
+    };
+
+    window.localStorage.setItem(HOME_DRAFT_KEY, JSON.stringify(payload));
+  }, [uploadedVideo, createdJobs, autoJobCount]);
+
+  useEffect(() => {
     if (!token || createdJobs.length === 0) {
       return;
     }
@@ -103,15 +152,32 @@ export default function AppHomePage() {
           return;
         }
 
-        const nextMap: Record<string, { status: string; outputPath: string | null }> = {};
-        statuses.forEach((item) => {
-          nextMap[item.job_id] = {
-            status: item.status,
-            outputPath: item.output_path
-          };
+        let shouldContinuePolling = false;
+
+        setJobStatusMap((prev) => {
+          const nextMap: Record<string, { status: string; outputPath: string | null }> = {};
+
+          statuses.forEach((item) => {
+            const previous = prev[item.job_id];
+            const stableOutputPath = previous?.outputPath ?? item.output_path ?? null;
+            nextMap[item.job_id] = {
+              status: item.status,
+              outputPath: stableOutputPath
+            };
+
+            const waitingForOutput = !stableOutputPath && (item.status.toLowerCase() === "done" || item.status.toLowerCase() === "completed");
+            if (!isTerminalStatus(item.status) || waitingForOutput) {
+              shouldContinuePolling = true;
+            }
+          });
+
+          const hasDiff = JSON.stringify(prev) !== JSON.stringify(nextMap);
+          return hasDiff ? nextMap : prev;
         });
 
-        setJobStatusMap(nextMap);
+        if (!shouldContinuePolling) {
+          window.clearInterval(intervalId);
+        }
       } catch {
         if (!cancelled) {
           setJobError((prev) => prev ?? "No pudimos actualizar el estado de algunos clips generados.");
@@ -119,10 +185,10 @@ export default function AppHomePage() {
       }
     };
 
-    void syncStatuses();
     const intervalId = window.setInterval(() => {
       void syncStatuses();
     }, 6000);
+    void syncStatuses();
 
     return () => {
       cancelled = true;
@@ -139,6 +205,7 @@ export default function AppHomePage() {
     setAutoJobCount(0);
     setUploadError(null);
     setJobError(null);
+    window.localStorage.removeItem(HOME_DRAFT_KEY);
 
     let uploaded: VideoUploadResponse;
 

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from "@/src/store/useAuthStore";
 import { useEffect, useMemo, useState } from "react";
 
 const HOME_DRAFT_KEY = "home:uploaded-video-draft";
+type ClipOutputStyle = "vertical" | "speaker_split";
 
 function toTimeLabel(seconds: number) {
   const min = Math.floor(seconds / 60)
@@ -93,6 +94,7 @@ export default function AppHomePage() {
   const [jobStatusMap, setJobStatusMap] = useState<Record<string, { status: string; outputPath: string | null }>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [jobError, setJobError] = useState<string | null>(null);
+  const [outputStyle, setOutputStyle] = useState<ClipOutputStyle>("vertical");
 
   const hasVideo = Boolean(uploadedVideo);
   const visibleClips = useMemo(() => mapJobsToClips(createdJobs, jobStatusMap), [createdJobs, jobStatusMap]);
@@ -108,6 +110,7 @@ export default function AppHomePage() {
         uploadedVideo: VideoUploadResponse | null;
         createdJobs: AutoReframeJobItem[];
         autoJobCount: number;
+        outputStyle?: ClipOutputStyle;
       };
 
       if (parsed.uploadedVideo) {
@@ -118,6 +121,9 @@ export default function AppHomePage() {
       }
       if (typeof parsed.autoJobCount === "number") {
         setAutoJobCount(parsed.autoJobCount);
+      }
+      if (parsed.outputStyle === "vertical" || parsed.outputStyle === "speaker_split") {
+        setOutputStyle(parsed.outputStyle);
       }
     } catch {
       window.localStorage.removeItem(HOME_DRAFT_KEY);
@@ -133,11 +139,12 @@ export default function AppHomePage() {
     const payload = {
       uploadedVideo,
       createdJobs,
-      autoJobCount
+      autoJobCount,
+      outputStyle
     };
 
     window.localStorage.setItem(HOME_DRAFT_KEY, JSON.stringify(payload));
-  }, [uploadedVideo, createdJobs, autoJobCount]);
+  }, [uploadedVideo, createdJobs, autoJobCount, outputStyle]);
 
   useEffect(() => {
     if (!token || createdJobs.length === 0) {
@@ -234,7 +241,9 @@ export default function AppHomePage() {
     setIsCreatingJobs(true);
 
     try {
-      const autoJobs = await videoApi.createAutoReframeJobs(uploaded.video_id, token);
+      const autoJobs = await videoApi.createAutoReframeJobs(uploaded.video_id, token, {
+        outputStyle
+      });
       setCreatedJobs(autoJobs.jobs);
       setAutoJobCount(autoJobs.total_jobs);
 
@@ -254,6 +263,33 @@ export default function AppHomePage() {
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
       <div className="grid gap-5 xl:grid-cols-[1.55fr_0.95fr]">
         <Panel variant="accent" className="p-4 sm:p-5">
+          <div className="mb-4 rounded-xl border border-white/12 bg-white/5 p-3">
+            <p className="text-xs uppercase tracking-[0.18em] text-white/60">Estilo de clip</p>
+            <div className="mt-2 grid gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => setOutputStyle("vertical")}
+                className={`rounded-lg border px-3 py-2 text-left text-sm transition ${
+                  outputStyle === "vertical"
+                    ? "border-neon-cyan/45 bg-neon-cyan/15 text-neon-cyan"
+                    : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                }`}
+              >
+                Vertical clasico 9:16
+              </button>
+              <button
+                type="button"
+                onClick={() => setOutputStyle("speaker_split")}
+                className={`rounded-lg border px-3 py-2 text-left text-sm transition ${
+                  outputStyle === "speaker_split"
+                    ? "border-neon-cyan/45 bg-neon-cyan/15 text-neon-cyan"
+                    : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                }`}
+              >
+                Split speaker (arriba foco, abajo plano general)
+              </button>
+            </div>
+          </div>
           <UploadDropzone
             onUpload={handleUpload}
             isUploading={isUploading}

--- a/frontend/src/app/app/share/[clipId]/page.tsx
+++ b/frontend/src/app/app/share/[clipId]/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Button } from "@/src/components/ui/Button";
+import { Panel } from "@/src/components/ui/Panel";
+import { videoApi, type UserClipItem, VideoApiError } from "@/src/services/videoApi";
+import { useAuthStore } from "@/src/store/useAuthStore";
+import { Facebook, Instagram, MessageCircle, Music2, Share2 } from "lucide-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { type ComponentType, useEffect, useState } from "react";
+
+type SocialTarget = {
+  id: string;
+  label: string;
+  icon: ComponentType<{ size?: number; className?: string }>;
+};
+
+const socialTargets: SocialTarget[] = [
+  { id: "instagram", label: "Instagram", icon: Instagram },
+  { id: "tiktok", label: "TikTok", icon: Music2 },
+  { id: "facebook", label: "Facebook", icon: Facebook },
+  { id: "x", label: "X", icon: Share2 },
+  { id: "whatsapp", label: "WhatsApp", icon: MessageCircle }
+];
+
+function normalizeVideoError(error: unknown, fallbackMessage: string) {
+  if (error instanceof VideoApiError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallbackMessage;
+}
+
+export default function ShareClipPage() {
+  const params = useParams<{ clipId: string }>();
+  const clipId = params?.clipId ?? "";
+  const token = useAuthStore((state) => state.token);
+
+  const [clip, setClip] = useState<UserClipItem | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setIsLoading(false);
+      setError("No encontramos una sesion activa para compartir este clip.");
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadClip = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await videoApi.getMyClips(token, {
+          limit: 10,
+          offset: 0,
+          query: clipId
+        });
+
+        const selectedClip = response.clips.find((item) => item.job_id === clipId) ?? null;
+
+        if (!cancelled) {
+          if (!selectedClip) {
+            setError("No encontramos el clip solicitado.");
+            setClip(null);
+          } else {
+            setClip(selectedClip);
+          }
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(normalizeVideoError(loadError, "No pudimos cargar el clip para compartir."));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadClip();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clipId, token]);
+
+  return (
+    <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+      <Panel className="border-neon-mint/25 bg-gradient-to-r from-night-900 via-night-800/80 to-night-900 p-5 sm:p-6">
+        <p className="text-xs uppercase tracking-[0.25em] text-neon-mint/75">compartir clip</p>
+        <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Publicacion por red social</h1>
+        <p className="mt-2 text-sm text-white/70">
+          Desde esta pantalla podras conectar la subida individual de un clip para cada red. Por ahora dejamos el flujo preparado.
+        </p>
+
+        {isLoading ? <p className="mt-4 text-sm text-white/70">Cargando clip...</p> : null}
+
+        {error ? (
+          <p className="mt-4 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{error}</p>
+        ) : null}
+
+        {!isLoading && !error && clip ? (
+          <div className="mt-5 grid gap-5 xl:grid-cols-[1.1fr_0.9fr]">
+            <div className="rounded-2xl border border-white/10 bg-night-900/70 p-4">
+              {clip.output_path ? (
+                <video controls preload="metadata" className="aspect-[9/13] w-full rounded-xl border border-white/10 object-cover" src={clip.output_path} />
+              ) : (
+                <div className="grid aspect-[9/13] place-items-center rounded-xl border border-white/10 bg-night-800/80 text-sm text-white/65">
+                  El clip todavia no tiene preview disponible.
+                </div>
+              )}
+
+              <div className="mt-3 space-y-1 text-xs text-white/75">
+                <p>Clip: {clip.job_id}</p>
+                <p>Video: {clip.video_id}</p>
+                <p>Estado: {clip.status}</p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              {socialTargets.map((target) => {
+                const Icon = target.icon;
+                return (
+                  <div key={target.id} className="rounded-xl border border-white/12 bg-white/5 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="inline-flex items-center gap-2 text-sm font-semibold text-white">
+                        <Icon size={16} className="text-neon-mint" />
+                        {target.label}
+                      </p>
+                      <Button
+                        className="w-auto px-3 py-2 text-xs"
+                        onClick={() => setInfo(`Flujo de subida a ${target.label} preparado. Integramos API en el siguiente paso.`)}
+                      >
+                        Subir
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+
+              {info ? <p className="rounded-xl border border-neon-cyan/35 bg-neon-cyan/10 px-3 py-2 text-xs text-neon-cyan">{info}</p> : null}
+              <Link
+                href="/app/library"
+                className="inline-flex items-center gap-2 rounded-lg border border-white/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.15em] text-white/80 transition hover:border-white/40 hover:text-white"
+              >
+                Volver a biblioteca
+              </Link>
+            </div>
+          </div>
+        ) : null}
+      </Panel>
+    </section>
+  );
+}

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { VideoSettings } from "@/src/components/home/VideoSettings";
+import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
+import { Panel } from "@/src/components/ui/Panel";
+import { videoApi, type UserClipItem, VideoApiError } from "@/src/services/videoApi";
+import { useAuthStore } from "@/src/store/useAuthStore";
+import { useEffect, useMemo, useState } from "react";
+
+function normalizeClipStatus(status: string) {
+  const normalized = status.toLowerCase();
+  if (normalized === "done" || normalized === "completed") {
+    return "listo";
+  }
+  if (normalized === "failed" || normalized === "error") {
+    return "error";
+  }
+  return "render";
+}
+
+function normalizeVideoError(error: unknown, fallbackMessage: string) {
+  if (error instanceof VideoApiError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return fallbackMessage;
+}
+
+export default function TimelinePage() {
+  const token = useAuthStore((state) => state.token);
+  const [clips, setClips] = useState<UserClipItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setIsLoading(false);
+      setError("No encontramos una sesion activa para cargar el timeline.");
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadClips = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await videoApi.getMyClips(token, { limit: 100, offset: 0 });
+        if (cancelled) {
+          return;
+        }
+
+        setClips(response.clips);
+        setSelectedClipId((prev) => prev ?? response.clips[0]?.job_id ?? null);
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(normalizeVideoError(loadError, "No pudimos cargar tus clips."));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadClips();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const selectedClip = useMemo(
+    () => clips.find((clip) => clip.job_id === selectedClipId) ?? null,
+    [clips, selectedClipId]
+  );
+
+  const selectedPreviewUrl = selectedClip?.output_path ?? null;
+
+  return (
+    <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="grid gap-5 xl:grid-cols-[1.55fr_0.95fr]">
+        <Panel>
+          <p className="text-xs uppercase tracking-[0.22em] text-white/65">timeline</p>
+          <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Preview y recorte</h3>
+
+          {isLoading ? (
+            <p className="mt-4 text-sm text-white/70">Cargando clips...</p>
+          ) : error ? (
+            <p className="mt-4 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{error}</p>
+          ) : selectedPreviewUrl ? (
+            <VideoPreview
+              videoPreviewUrl={selectedPreviewUrl}
+              onTrimChange={(start, end) => {
+                console.log("Ajuste de recorte en timeline:", { start, end });
+              }}
+            />
+          ) : (
+            <p className="mt-4 text-sm text-white/70">
+              Este clip todavia no tiene salida lista para preview. Proba otro clip o espera a que termine el render.
+            </p>
+          )}
+
+          {!isLoading && clips.length > 0 ? (
+            <div className="mt-4 grid gap-2 sm:grid-cols-2">
+              {clips.map((clip) => {
+                const normalized = normalizeClipStatus(clip.status);
+                return (
+                  <button
+                    type="button"
+                    key={clip.job_id}
+                    onClick={() => setSelectedClipId(clip.job_id)}
+                    className={[
+                      "rounded-xl border px-3 py-2 text-left text-sm transition",
+                      selectedClipId === clip.job_id
+                        ? "border-neon-cyan/45 bg-neon-cyan/10 text-white"
+                        : "border-white/10 bg-white/5 text-white/75 hover:border-white/20 hover:text-white"
+                    ].join(" ")}
+                  >
+                    <p className="font-semibold">Clip {clip.job_id.slice(0, 8)}</p>
+                    <p className="mt-1 text-xs text-white/60">Fuente: {clip.source_filename}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-neon-cyan/80">Estado: {normalized}</p>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+        </Panel>
+
+        <Panel>
+          <p className="text-xs uppercase tracking-[0.22em] text-white/65">configuracion</p>
+          <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Ajustes de recorte</h3>
+          <VideoSettings />
+        </Panel>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -7,6 +7,8 @@ import { videoApi, type UserClipItem, VideoApiError } from "@/src/services/video
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useEffect, useMemo, useState } from "react";
 
+const PAGE_SIZE = 10;
+
 function normalizeClipStatus(status: string) {
   const normalized = status.toLowerCase();
   if (normalized === "done" || normalized === "completed") {
@@ -33,6 +35,8 @@ function normalizeVideoError(error: unknown, fallbackMessage: string) {
 export default function TimelinePage() {
   const token = useAuthStore((state) => state.token);
   const [clips, setClips] = useState<UserClipItem[]>([]);
+  const [totalClips, setTotalClips] = useState(0);
+  const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
@@ -50,13 +54,17 @@ export default function TimelinePage() {
       setIsLoading(true);
       setError(null);
       try {
-        const response = await videoApi.getMyClips(token, { limit: 100, offset: 0 });
+        const response = await videoApi.getMyClips(token, {
+          limit: PAGE_SIZE,
+          offset: (page - 1) * PAGE_SIZE
+        });
         if (cancelled) {
           return;
         }
 
         setClips(response.clips);
-        setSelectedClipId((prev) => prev ?? response.clips[0]?.job_id ?? null);
+        setTotalClips(response.total);
+        setSelectedClipId(response.clips[0]?.job_id ?? null);
       } catch (loadError) {
         if (!cancelled) {
           setError(normalizeVideoError(loadError, "No pudimos cargar tus clips."));
@@ -73,7 +81,9 @@ export default function TimelinePage() {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [token, page]);
+
+  const totalPages = Math.max(1, Math.ceil(totalClips / PAGE_SIZE));
 
   const selectedClip = useMemo(
     () => clips.find((clip) => clip.job_id === selectedClipId) ?? null,
@@ -107,28 +117,54 @@ export default function TimelinePage() {
           )}
 
           {!isLoading && clips.length > 0 ? (
-            <div className="mt-4 grid gap-2 sm:grid-cols-2">
-              {clips.map((clip) => {
-                const normalized = normalizeClipStatus(clip.status);
-                return (
-                  <button
-                    type="button"
-                    key={clip.job_id}
-                    onClick={() => setSelectedClipId(clip.job_id)}
-                    className={[
-                      "rounded-xl border px-3 py-2 text-left text-sm transition",
-                      selectedClipId === clip.job_id
-                        ? "border-neon-cyan/45 bg-neon-cyan/10 text-white"
-                        : "border-white/10 bg-white/5 text-white/75 hover:border-white/20 hover:text-white"
-                    ].join(" ")}
-                  >
-                    <p className="font-semibold">Clip {clip.job_id.slice(0, 8)}</p>
-                    <p className="mt-1 text-xs text-white/60">Fuente: {clip.source_filename}</p>
-                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-neon-cyan/80">Estado: {normalized}</p>
-                  </button>
-                );
-              })}
-            </div>
+            <>
+              <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                {clips.map((clip) => {
+                  const normalized = normalizeClipStatus(clip.status);
+                  return (
+                    <button
+                      type="button"
+                      key={clip.job_id}
+                      onClick={() => setSelectedClipId(clip.job_id)}
+                      className={[
+                        "rounded-xl border px-3 py-2 text-left text-sm transition",
+                        selectedClipId === clip.job_id
+                          ? "border-neon-cyan/45 bg-neon-cyan/10 text-white"
+                          : "border-white/10 bg-white/5 text-white/75 hover:border-white/20 hover:text-white"
+                      ].join(" ")}
+                    >
+                      <p className="font-semibold">Clip {clip.job_id.slice(0, 8)}</p>
+                      <p className="mt-1 text-xs text-white/60">Fuente: {clip.source_filename}</p>
+                      <p className="mt-1 text-xs uppercase tracking-[0.16em] text-neon-cyan/80">Estado: {normalized}</p>
+                    </button>
+                  );
+                })}
+              </div>
+
+              {totalPages > 1 ? (
+                <div className="mt-4 flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/80">
+                  <span>Pagina {page} de {totalPages}</span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:cursor-not-allowed disabled:opacity-40"
+                      disabled={page <= 1 || isLoading}
+                      onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                    >
+                      Anterior
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:cursor-not-allowed disabled:opacity-40"
+                      disabled={page >= totalPages || isLoading}
+                      onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </>
           ) : null}
         </Panel>
 

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -4,10 +4,11 @@ import { VideoSettings } from "@/src/components/home/VideoSettings";
 import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
 import { Panel } from "@/src/components/ui/Panel";
 import { Button } from "@/src/components/ui/Button";
-import { videoApi, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
+import { videoApi, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useVideoSettingsStore } from "@/src/store/useVideoSettingsStore";
 import { Search } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 const PAGE_SIZE = 10;
@@ -25,6 +26,9 @@ function normalizeVideoError(error: unknown, fallbackMessage: string) {
 }
 
 export default function TimelinePage() {
+  const searchParams = useSearchParams();
+  const preferredVideoId = searchParams.get("videoId")?.trim() ?? "";
+  const preferredClipId = searchParams.get("clipId")?.trim() ?? "";
   const token = useAuthStore((state) => state.token);
   const settings = useVideoSettingsStore((state) => state.settings);
   const [videos, setVideos] = useState<UserVideoItem[]>([]);
@@ -34,6 +38,7 @@ export default function TimelinePage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedVideoId, setSelectedVideoId] = useState<string | null>(null);
+  const [focusedClip, setFocusedClip] = useState<UserClipItem | null>(null);
   const [trimStart, setTrimStart] = useState(0);
   const [trimEnd, setTrimEnd] = useState(15);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -53,6 +58,21 @@ export default function TimelinePage() {
       setIsLoading(true);
       setError(null);
       try {
+        let selectedClip: UserClipItem | null = null;
+        let preferredVideoFromQuery = preferredVideoId;
+
+        if (preferredClipId) {
+          try {
+            const clipResponse = await videoApi.getMyClipById(preferredClipId, token);
+            selectedClip = clipResponse.clip;
+            if (selectedClip && !preferredVideoFromQuery) {
+              preferredVideoFromQuery = selectedClip.video_id;
+            }
+          } catch {
+            selectedClip = null;
+          }
+        }
+
         const response = await videoApi.getMyVideos(token, {
           limit: PAGE_SIZE,
           offset: (page - 1) * PAGE_SIZE,
@@ -62,13 +82,37 @@ export default function TimelinePage() {
           return;
         }
 
-        setVideos(response.videos);
+        let nextVideos = response.videos;
+
+        if (preferredVideoFromQuery && !response.videos.some((video) => video.video_id === preferredVideoFromQuery)) {
+          try {
+            const preferredVideo = await videoApi.getMyVideoById(preferredVideoFromQuery, token);
+            nextVideos = [
+              {
+                video_id: preferredVideo.video_id,
+                filename: preferredVideo.filename,
+                status: preferredVideo.status,
+                uploaded_at: preferredVideo.uploaded_at,
+                preview_url: preferredVideo.preview_url
+              },
+              ...response.videos.filter((video) => video.video_id !== preferredVideo.video_id)
+            ];
+          } catch {
+            nextVideos = response.videos;
+          }
+        }
+
+        setVideos(nextVideos);
+        setFocusedClip(selectedClip);
         setTotalVideos(response.total);
         setSelectedVideoId((prev) => {
-          if (prev && response.videos.some((video) => video.video_id === prev)) {
+          if (preferredVideoFromQuery && nextVideos.some((video) => video.video_id === preferredVideoFromQuery)) {
+            return preferredVideoFromQuery;
+          }
+          if (prev && nextVideos.some((video) => video.video_id === prev)) {
             return prev;
           }
-          return response.videos[0]?.video_id ?? null;
+          return nextVideos[0]?.video_id ?? null;
         });
       } catch (loadError) {
         if (!cancelled) {
@@ -86,7 +130,7 @@ export default function TimelinePage() {
     return () => {
       cancelled = true;
     };
-  }, [token, page, query]);
+  }, [token, page, preferredClipId, preferredVideoId, query]);
 
   const totalPages = Math.max(1, Math.ceil(totalVideos / PAGE_SIZE));
 
@@ -95,7 +139,10 @@ export default function TimelinePage() {
     [videos, selectedVideoId]
   );
 
-  const selectedPreviewUrl = selectedVideo?.preview_url ?? null;
+  const selectedPreviewUrl =
+    focusedClip && focusedClip.video_id === selectedVideoId
+      ? (focusedClip.output_path ?? selectedVideo?.preview_url ?? null)
+      : (selectedVideo?.preview_url ?? null);
 
   const handleCreateJob = async () => {
     if (!token || !selectedVideoId) {
@@ -147,6 +194,12 @@ export default function TimelinePage() {
             />
           </label>
 
+          {focusedClip ? (
+            <div className="mt-3 rounded-xl border border-neon-cyan/35 bg-neon-cyan/10 px-3 py-2 text-xs text-neon-cyan">
+              Editando desde clip {focusedClip.job_id.slice(0, 8)} sobre video {focusedClip.video_id.slice(0, 8)}.
+            </div>
+          ) : null}
+
           {isLoading ? (
             <p className="mt-4 text-sm text-white/70">Cargando videos...</p>
           ) : error ? (
@@ -182,7 +235,12 @@ export default function TimelinePage() {
                     <button
                       type="button"
                       key={video.video_id}
-                      onClick={() => setSelectedVideoId(video.video_id)}
+                      onClick={() => {
+                        setSelectedVideoId(video.video_id);
+                        if (focusedClip && focusedClip.video_id !== video.video_id) {
+                          setFocusedClip(null);
+                        }
+                      }}
                       className={[
                         "rounded-xl border px-3 py-2 text-left text-sm transition",
                         selectedVideoId === video.video_id

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -3,23 +3,14 @@
 import { VideoSettings } from "@/src/components/home/VideoSettings";
 import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
 import { Panel } from "@/src/components/ui/Panel";
-import { videoApi, type UserClipItem, VideoApiError } from "@/src/services/videoApi";
+import { Button } from "@/src/components/ui/Button";
+import { videoApi, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
+import { useVideoSettingsStore } from "@/src/store/useVideoSettingsStore";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 const PAGE_SIZE = 10;
-
-function normalizeClipStatus(status: string) {
-  const normalized = status.toLowerCase();
-  if (normalized === "done" || normalized === "completed") {
-    return "listo";
-  }
-  if (normalized === "failed" || normalized === "error") {
-    return "error";
-  }
-  return "render";
-}
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
   if (error instanceof VideoApiError) {
@@ -35,13 +26,19 @@ function normalizeVideoError(error: unknown, fallbackMessage: string) {
 
 export default function TimelinePage() {
   const token = useAuthStore((state) => state.token);
-  const [clips, setClips] = useState<UserClipItem[]>([]);
-  const [totalClips, setTotalClips] = useState(0);
+  const settings = useVideoSettingsStore((state) => state.settings);
+  const [videos, setVideos] = useState<UserVideoItem[]>([]);
+  const [totalVideos, setTotalVideos] = useState(0);
   const [page, setPage] = useState(1);
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
+  const [selectedVideoId, setSelectedVideoId] = useState<string | null>(null);
+  const [trimStart, setTrimStart] = useState(0);
+  const [trimEnd, setTrimEnd] = useState(15);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitInfo, setSubmitInfo] = useState<string | null>(null);
 
   useEffect(() => {
     if (!token) {
@@ -52,11 +49,11 @@ export default function TimelinePage() {
 
     let cancelled = false;
 
-    const loadClips = async () => {
+    const loadVideos = async () => {
       setIsLoading(true);
       setError(null);
       try {
-        const response = await videoApi.getMyClips(token, {
+        const response = await videoApi.getMyVideos(token, {
           limit: PAGE_SIZE,
           offset: (page - 1) * PAGE_SIZE,
           query
@@ -65,12 +62,17 @@ export default function TimelinePage() {
           return;
         }
 
-        setClips(response.clips);
-        setTotalClips(response.total);
-        setSelectedClipId(response.clips[0]?.job_id ?? null);
+        setVideos(response.videos);
+        setTotalVideos(response.total);
+        setSelectedVideoId((prev) => {
+          if (prev && response.videos.some((video) => video.video_id === prev)) {
+            return prev;
+          }
+          return response.videos[0]?.video_id ?? null;
+        });
       } catch (loadError) {
         if (!cancelled) {
-          setError(normalizeVideoError(loadError, "No pudimos cargar tus clips."));
+          setError(normalizeVideoError(loadError, "No pudimos cargar tus videos."));
         }
       } finally {
         if (!cancelled) {
@@ -79,21 +81,52 @@ export default function TimelinePage() {
       }
     };
 
-    void loadClips();
+    void loadVideos();
 
     return () => {
       cancelled = true;
     };
   }, [token, page, query]);
 
-  const totalPages = Math.max(1, Math.ceil(totalClips / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(totalVideos / PAGE_SIZE));
 
-  const selectedClip = useMemo(
-    () => clips.find((clip) => clip.job_id === selectedClipId) ?? null,
-    [clips, selectedClipId]
+  const selectedVideo = useMemo(
+    () => videos.find((video) => video.video_id === selectedVideoId) ?? null,
+    [videos, selectedVideoId]
   );
 
-  const selectedPreviewUrl = selectedClip?.output_path ?? null;
+  const selectedPreviewUrl = selectedVideo?.preview_url ?? null;
+
+  const handleCreateJob = async () => {
+    if (!token || !selectedVideoId) {
+      setSubmitError("Selecciona un video y verifica tu sesion para crear el clip.");
+      return;
+    }
+
+    const normalizedStart = Math.max(0, Math.floor(trimStart));
+    const normalizedEnd = Math.max(normalizedStart + 1, Math.ceil(trimEnd));
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setSubmitInfo(null);
+
+    try {
+      const response = await videoApi.createReframeJob(selectedVideoId, token, {
+        start_sec: normalizedStart,
+        end_sec: normalizedEnd,
+        crop_to_vertical: settings.cropToVertical,
+        subtitles: settings.subtitles,
+        face_tracking: settings.faceTracking,
+        color_filter: settings.colorFilter
+      });
+
+      setSubmitInfo(`Clip enviado a cola. Job ${response.job_id.slice(0, 8)} en estado ${response.status}.`);
+    } catch (createError) {
+      setSubmitError(normalizeVideoError(createError, "No pudimos crear el clip desde timeline."));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
@@ -115,42 +148,51 @@ export default function TimelinePage() {
           </label>
 
           {isLoading ? (
-            <p className="mt-4 text-sm text-white/70">Cargando clips...</p>
+            <p className="mt-4 text-sm text-white/70">Cargando videos...</p>
           ) : error ? (
             <p className="mt-4 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{error}</p>
           ) : selectedPreviewUrl ? (
             <VideoPreview
               videoPreviewUrl={selectedPreviewUrl}
               onTrimChange={(start, end) => {
-                console.log("Ajuste de recorte en timeline:", { start, end });
+                setTrimStart(start);
+                setTrimEnd(end);
               }}
             />
           ) : (
             <p className="mt-4 text-sm text-white/70">
-              Este clip todavia no tiene salida lista para preview. Proba otro clip o espera a que termine el render.
+              Este video todavia no tiene URL de preview disponible. Prueba con otro video.
             </p>
           )}
 
-          {!isLoading && clips.length > 0 ? (
+          <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
+            <p>Recorte seleccionado: {Math.floor(trimStart)}s - {Math.ceil(trimEnd)}s</p>
+            <Button className="mt-3 w-auto px-4" onClick={handleCreateJob} disabled={isSubmitting || !selectedVideoId}>
+              {isSubmitting ? "Creando clip..." : "Generar clip con timeline"}
+            </Button>
+            {submitInfo ? <p className="mt-2 text-xs text-neon-mint">{submitInfo}</p> : null}
+            {submitError ? <p className="mt-2 text-xs text-rose-200">{submitError}</p> : null}
+          </div>
+
+          {!isLoading && videos.length > 0 ? (
             <>
               <div className="mt-4 grid gap-2 sm:grid-cols-2">
-                {clips.map((clip) => {
-                  const normalized = normalizeClipStatus(clip.status);
+                {videos.map((video) => {
                   return (
                     <button
                       type="button"
-                      key={clip.job_id}
-                      onClick={() => setSelectedClipId(clip.job_id)}
+                      key={video.video_id}
+                      onClick={() => setSelectedVideoId(video.video_id)}
                       className={[
                         "rounded-xl border px-3 py-2 text-left text-sm transition",
-                        selectedClipId === clip.job_id
+                        selectedVideoId === video.video_id
                           ? "border-neon-cyan/45 bg-neon-cyan/10 text-white"
                           : "border-white/10 bg-white/5 text-white/75 hover:border-white/20 hover:text-white"
                       ].join(" ")}
                     >
-                      <p className="font-semibold">Clip {clip.job_id.slice(0, 8)}</p>
-                      <p className="mt-1 text-xs text-white/60">Fuente: {clip.source_filename}</p>
-                      <p className="mt-1 text-xs uppercase tracking-[0.16em] text-neon-cyan/80">Estado: {normalized}</p>
+                      <p className="font-semibold">Video {video.video_id.slice(0, 8)}</p>
+                      <p className="mt-1 text-xs text-white/60">Archivo: {video.filename}</p>
+                      <p className="mt-1 text-xs uppercase tracking-[0.16em] text-neon-cyan/80">Estado: {video.status ?? "uploaded"}</p>
                     </button>
                   );
                 })}

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -5,6 +5,7 @@ import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPre
 import { Panel } from "@/src/components/ui/Panel";
 import { videoApi, type UserClipItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
+import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 const PAGE_SIZE = 10;
@@ -37,6 +38,7 @@ export default function TimelinePage() {
   const [clips, setClips] = useState<UserClipItem[]>([]);
   const [totalClips, setTotalClips] = useState(0);
   const [page, setPage] = useState(1);
+  const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
@@ -56,7 +58,8 @@ export default function TimelinePage() {
       try {
         const response = await videoApi.getMyClips(token, {
           limit: PAGE_SIZE,
-          offset: (page - 1) * PAGE_SIZE
+          offset: (page - 1) * PAGE_SIZE,
+          query
         });
         if (cancelled) {
           return;
@@ -81,7 +84,7 @@ export default function TimelinePage() {
     return () => {
       cancelled = true;
     };
-  }, [token, page]);
+  }, [token, page, query]);
 
   const totalPages = Math.max(1, Math.ceil(totalClips / PAGE_SIZE));
 
@@ -98,6 +101,18 @@ export default function TimelinePage() {
         <Panel>
           <p className="text-xs uppercase tracking-[0.22em] text-white/65">timeline</p>
           <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Preview y recorte</h3>
+          <label className="mt-3 flex items-center gap-2 rounded-xl border border-white/12 bg-white/5 px-3 py-2 text-sm text-white/80 transition hover:border-neon-cyan/40">
+            <Search size={14} className="text-neon-cyan/80" />
+            <input
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setPage(1);
+              }}
+              placeholder="Buscar clip por job o archivo..."
+              className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/40"
+            />
+          </label>
 
           {isLoading ? (
             <p className="mt-4 text-sm text-white/70">Cargando clips...</p>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -5,18 +5,18 @@
   --font-sans: "Space Grotesk", "Segoe UI", sans-serif;
   --font-display: "Sora", "Segoe UI", sans-serif;
 
-  --color-night-950: #060b16;
-  --color-night-900: #0a1020;
-  --color-night-800: #121a2e;
-  --color-night-700: #1b2740;
+  --color-night-950: #11111b;
+  --color-night-900: #181825;
+  --color-night-800: #1e1e2e;
+  --color-night-700: #313244;
 
-  --color-neon-cyan: #35d0ff;
-  --color-neon-magenta: #ff4fd8;
-  --color-neon-violet: #6f7cff;
-  --color-neon-mint: #4bffd2;
+  --color-neon-cyan: #89dceb;
+  --color-neon-magenta: #f5c2e7;
+  --color-neon-violet: #cba6f7;
+  --color-neon-mint: #a6e3a1;
 
-  --shadow-glow: 0 10px 35px rgba(53, 208, 255, 0.24);
-  --shadow-panel: 0 20px 60px rgba(5, 8, 20, 0.55);
+  --shadow-glow: 0 10px 35px rgba(137, 220, 235, 0.26);
+  --shadow-panel: 0 20px 60px rgba(17, 17, 27, 0.62);
 
   --animate-fade-up: fade-up 0.55s ease-out both;
   --animate-drift: drift 5s ease-in-out infinite;
@@ -47,8 +47,8 @@
 
 :root {
   font-family: "Space Grotesk", "Segoe UI", sans-serif;
-  color: #d8e6ff;
-  background: #060b16;
+  color: #cdd6f4;
+  background: #11111b;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -56,7 +56,7 @@
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: #22325a #101a32;
+  scrollbar-color: #45475a #1e1e2e;
 }
 
 *::-webkit-scrollbar {
@@ -65,12 +65,12 @@
 }
 
 *::-webkit-scrollbar-thumb {
-  background: #22325a;
+  background: #45475a;
   border-radius: 999px;
 }
 
 *::-webkit-scrollbar-track {
-  background: #101a32;
+  background: #1e1e2e;
 }
 
 body {
@@ -78,9 +78,9 @@ body {
   min-width: 320px;
   min-height: 100vh;
   background:
-    radial-gradient(circle at 12% 20%, rgba(111, 124, 255, 0.24), transparent 40%),
-    radial-gradient(circle at 84% 14%, rgba(255, 79, 216, 0.18), transparent 45%),
-    radial-gradient(circle at 50% 90%, rgba(53, 208, 255, 0.2), transparent 48%),
-    #060b16;
-  color: #d8e6ff;
+    radial-gradient(circle at 12% 20%, rgba(203, 166, 247, 0.24), transparent 40%),
+    radial-gradient(circle at 84% 14%, rgba(245, 194, 231, 0.18), transparent 45%),
+    radial-gradient(circle at 50% 90%, rgba(137, 220, 235, 0.2), transparent 48%),
+    #11111b;
+  color: #cdd6f4;
 }

--- a/frontend/src/components/branding/HaceloCortoLogo.tsx
+++ b/frontend/src/components/branding/HaceloCortoLogo.tsx
@@ -20,13 +20,13 @@ interface HaceloCortoLogoProps {
 }
 
 const defaultPalette: LogoPalette = {
-  gradientAStart: "#7AA2F7",
-  gradientAMid: "#2AC3DE",
-  gradientAEnd: "#BB9AF7",
-  gradientBStart: "#F7768E",
-  gradientBMid: "#2AC3DE",
-  gradientBEnd: "#7DCFFF",
-  nodeFill: "#0B1020"
+  gradientAStart: "#89B4FA",
+  gradientAMid: "#89DCEB",
+  gradientAEnd: "#CBA6F7",
+  gradientBStart: "#F5C2E7",
+  gradientBMid: "#89DCEB",
+  gradientBEnd: "#A6E3A1",
+  nodeFill: "#1E1E2E"
 };
 
 export function HaceloCortoLogo({

--- a/frontend/src/components/home/GeneratedClipsSection.tsx
+++ b/frontend/src/components/home/GeneratedClipsSection.tsx
@@ -13,6 +13,7 @@ type Clip = {
 type GeneratedClipsSectionProps = {
   clips: Clip[];
   showLoading: boolean;
+  isRefreshingStatuses?: boolean;
 };
 
 const statusStyles: Record<Clip["status"], string> = {
@@ -21,7 +22,7 @@ const statusStyles: Record<Clip["status"], string> = {
   render: "border-neon-cyan/45 bg-neon-cyan/15 text-neon-cyan"
 };
 
-export function GeneratedClipsSection({ clips, showLoading }: GeneratedClipsSectionProps) {
+export function GeneratedClipsSection({ clips, showLoading, isRefreshingStatuses = false }: GeneratedClipsSectionProps) {
   return (
     <section>
       <p className="text-xs uppercase tracking-[0.22em] text-white/65">clips generados</p>
@@ -58,7 +59,11 @@ export function GeneratedClipsSection({ clips, showLoading }: GeneratedClipsSect
                   />
                 </div>
               ) : (
-                <div className="aspect-[9/16] rounded-xl border border-neon-cyan/30 bg-[radial-gradient(circle_at_30%_20%,rgba(53,208,255,0.24),transparent_45%),radial-gradient(circle_at_70%_80%,rgba(255,79,216,0.2),transparent_45%)]" />
+                <div className="aspect-[9/16] rounded-xl border border-neon-cyan/30 bg-[radial-gradient(circle_at_30%_20%,rgba(53,208,255,0.24),transparent_45%),radial-gradient(circle_at_70%_80%,rgba(255,79,216,0.2),transparent_45%)] p-3">
+                  <div className="flex h-full items-center justify-center rounded-lg border border-white/15 bg-black/25 text-center text-xs text-white/75">
+                    {clip.status === "listo" ? "Preparando preview..." : "Procesando clip..."}
+                  </div>
+                </div>
               )}
               <div className="mt-3 flex items-center justify-between gap-2">
                 <p className="font-display text-lg text-white">{clip.title}</p>
@@ -73,6 +78,7 @@ export function GeneratedClipsSection({ clips, showLoading }: GeneratedClipsSect
               </div>
               <p className="mt-1 text-sm text-white/75">{clip.duration}</p>
               <p className="mt-2 rounded-lg border border-white/15 px-2 py-1 text-xs text-white/80">Preset: {clip.preset}</p>
+              {isRefreshingStatuses ? <p className="mt-2 text-xs text-white/60">Actualizando estado de jobs...</p> : null}
               <div className="mt-3">
                 <Link
                   href="/app/timeline"

--- a/frontend/src/components/home/GeneratedClipsSection.tsx
+++ b/frontend/src/components/home/GeneratedClipsSection.tsx
@@ -7,6 +7,7 @@ type Clip = {
   duration: string;
   preset: string;
   status: "listo" | "revision" | "render";
+  previewUrl?: string | null;
 };
 
 type GeneratedClipsSectionProps = {
@@ -41,13 +42,24 @@ export function GeneratedClipsSection({ clips, showLoading }: GeneratedClipsSect
           Todavia no hay clips generados. Subi un video para empezar.
         </div>
       ) : (
-        <Link  href="/app/shortDetails" className="mt-5 grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(14rem,1fr))]">
+        <div className="mt-5 grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(14rem,1fr))]">
           {clips.map((clip) => (
             <article
               key={clip.id}
               className="rounded-2xl border border-white/15 bg-gradient-to-b from-night-900/70 to-night-800/45 p-4 transition hover:-translate-y-0.5 hover:border-neon-cyan/35"
             >
-              <div className="aspect-[9/16] rounded-xl border border-neon-cyan/30 bg-[radial-gradient(circle_at_30%_20%,rgba(53,208,255,0.24),transparent_45%),radial-gradient(circle_at_70%_80%,rgba(255,79,216,0.2),transparent_45%)]" />
+              {clip.previewUrl ? (
+                <div className="overflow-hidden rounded-xl border border-neon-cyan/30 bg-black">
+                  <video
+                    controls
+                    preload="metadata"
+                    src={clip.previewUrl}
+                    className="aspect-[9/16] w-full object-cover"
+                  />
+                </div>
+              ) : (
+                <div className="aspect-[9/16] rounded-xl border border-neon-cyan/30 bg-[radial-gradient(circle_at_30%_20%,rgba(53,208,255,0.24),transparent_45%),radial-gradient(circle_at_70%_80%,rgba(255,79,216,0.2),transparent_45%)]" />
+              )}
               <div className="mt-3 flex items-center justify-between gap-2">
                 <p className="font-display text-lg text-white">{clip.title}</p>
                 <span
@@ -61,9 +73,17 @@ export function GeneratedClipsSection({ clips, showLoading }: GeneratedClipsSect
               </div>
               <p className="mt-1 text-sm text-white/75">{clip.duration}</p>
               <p className="mt-2 rounded-lg border border-white/15 px-2 py-1 text-xs text-white/80">Preset: {clip.preset}</p>
+              <div className="mt-3">
+                <Link
+                  href="/app/timeline"
+                  className="inline-flex rounded-lg border border-neon-cyan/35 bg-neon-cyan/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-neon-cyan transition hover:bg-neon-cyan/20"
+                >
+                  Editar en timeline
+                </Link>
+              </div>
             </article>
           ))}
-        </Link>
+        </div>
       )}
     </section>
   );

--- a/frontend/src/components/home/ProjectStatusPanel.tsx
+++ b/frontend/src/components/home/ProjectStatusPanel.tsx
@@ -6,7 +6,9 @@ type ProjectStatusPanelProps = {
   isUploading: boolean;
   uploadError: string | null;
   videoId: string | null;
-  videoPreviewUrl: string | null;
+  isCreatingJobs: boolean;
+  jobsCreated: number;
+  jobError: string | null;
 };
 
 export function ProjectStatusPanel({
@@ -14,11 +16,25 @@ export function ProjectStatusPanel({
   isUploading,
   uploadError,
   videoId,
-  videoPreviewUrl
+  isCreatingJobs,
+  jobsCreated,
+  jobError
 }: ProjectStatusPanelProps) {
-  const status = uploadError ? "Error de carga" : isUploading ? "Procesando" : hasVideo ? "Video cargado" : "Sin video";
-  const progress = isUploading ? 45 : hasVideo ? 100 : 0;
-  const showPreview = Boolean(videoPreviewUrl && hasVideo && !isUploading);
+  const status = uploadError
+    ? "Error de carga"
+    : jobError
+      ? "Error al crear clips"
+      : isUploading
+        ? "Subiendo video"
+        : isCreatingJobs
+          ? "Creando clips"
+          : jobsCreated > 0
+            ? "Clips en proceso"
+            : hasVideo
+              ? "Video cargado"
+              : "Sin video";
+
+  const progress = isUploading ? 35 : isCreatingJobs ? 70 : jobsCreated > 0 ? 100 : hasVideo ? 55 : 0;
 
   return (
     <section>
@@ -32,48 +48,36 @@ export function ProjectStatusPanel({
         </span> */}
       </div>
 
-      {showPreview ? (
-        <div className="mt-4 rounded-xl border border-white/15 bg-white/5 p-3">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-white/80">Preview del video</span>
-            <span className="text-neon-mint">Listo</span>
-          </div>
-
-          {/* <div className="mt-2 overflow-hidden rounded-lg border border-white/15 bg-black/40">
-            <video
-              controls
-              preload="metadata"
-              className="max-h-44 w-full object-contain"
-              src={videoPreviewUrl ?? undefined}
-            />
-          </div> */}
+      <div className="mt-4 rounded-xl border border-white/15 bg-white/5 p-3">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-white/80">Progreso</span>
+          <span className="text-white">{progress}%</span>
         </div>
-      ) : (
-        <div className="mt-4 rounded-xl border border-white/15 bg-white/5 p-3">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-white/80">Progreso</span>
-            <span className="text-white">{progress}%</span>
-          </div>
-          <div className="mt-2 h-2 rounded-full bg-night-950/90">
-            <div
-              className="h-full rounded-full bg-gradient-to-r from-neon-cyan to-neon-violet transition-all duration-500"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
+        <div className="mt-2 h-2 rounded-full bg-night-950/90">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-neon-cyan to-neon-violet transition-all duration-500"
+            style={{ width: `${progress}%` }}
+          />
         </div>
-      )}
+      </div>
 
       <ul className="mt-4 space-y-2 text-sm text-white/80">
         <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Upload recibido</li>
-        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Analisis de escenas</li>
-        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Generacion de clips</li>
+        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Generacion automatica de segmentos</li>
+        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Encolado de jobs de reframe</li>
       </ul>
+      {jobsCreated > 0 ? <p className="mt-3 text-xs text-neon-cyan">Jobs creados: {jobsCreated}</p> : null}
       {videoId ? <p className="mt-3 text-xs text-white/60">ID de video: {videoId}</p> : null}
       {uploadError ? (
         <p className="mt-3 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{uploadError}</p>
       ) : null}
+      {jobError ? (
+        <p className="mt-3 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{jobError}</p>
+      ) : null}
 
-      {isUploading ? <Loader className="mt-4" label="Analizando video en segundo plano..." /> : null}
+      {isUploading || isCreatingJobs ? (
+        <Loader className="mt-4" label={isUploading ? "Subiendo video..." : "Creando clips automaticos..."} />
+      ) : null}
     </section>
   );
 }

--- a/frontend/src/components/home/videoPrevewTimeLine/VideoPlayer.tsx
+++ b/frontend/src/components/home/videoPrevewTimeLine/VideoPlayer.tsx
@@ -66,8 +66,11 @@ export function VideoPlayer({
         video.currentTime = start;
       }
 
-      video.play();
-      setIsPlaying(true);
+      void video.play().then(() => {
+        setIsPlaying(true);
+      }).catch(() => {
+        setIsPlaying(false);
+      });
     } else {
       video.pause();
       setIsPlaying(false);

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -40,7 +40,7 @@ export default function NavBar(
           >
             <Menu size={18} /> 
           </button>
-            <Link href="/" className="inline-flex items-center" aria-label="Ir al home">
+            <Link href="/app" className="inline-flex items-center" aria-label="Ir al home">
               <HaceloCortoLogo
                 variant="compact"
                 className="h-8 w-auto text-white lg:hidden sm:h-9"

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -58,6 +58,21 @@ export type UserClipsResponse = {
   clips: UserClipItem[];
 };
 
+export type UserVideoItem = {
+  video_id: string;
+  filename: string;
+  status: string | null;
+  uploaded_at: string;
+  preview_url: string | null;
+};
+
+export type UserVideosResponse = {
+  total: number;
+  limit: number;
+  offset: number;
+  videos: UserVideoItem[];
+};
+
 const apiBaseUrl = env.apiBaseUrl.replace(/\/$/, "");
 
 export class VideoApiError extends Error {
@@ -184,11 +199,16 @@ export const videoApi = {
     return parseResponse<JobStatusResponse>(response);
   },
 
-  async getMyClips(token: string, options?: { limit?: number; offset?: number }) {
+  async getMyClips(token: string, options?: { limit?: number; offset?: number; query?: string }) {
     const params = new URLSearchParams({
       limit: String(options?.limit ?? 50),
       offset: String(options?.offset ?? 0)
     });
+
+    const query = options?.query?.trim();
+    if (query) {
+      params.set("q", query);
+    }
 
     const response = await fetch(`${apiBaseUrl}/api/v1/jobs/my-clips?${params.toString()}`, {
       method: "GET",
@@ -198,5 +218,26 @@ export const videoApi = {
     });
 
     return parseResponse<UserClipsResponse>(response);
+  },
+
+  async getMyVideos(token: string, options?: { limit?: number; offset?: number; query?: string }) {
+    const params = new URLSearchParams({
+      limit: String(options?.limit ?? 20),
+      offset: String(options?.offset ?? 0)
+    });
+
+    const query = options?.query?.trim();
+    if (query) {
+      params.set("q", query);
+    }
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/videos/my-videos?${params.toString()}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<UserVideosResponse>(response);
   }
 };

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -36,6 +36,25 @@ export type AutoReframeResponse = {
   jobs: AutoReframeJobItem[];
 };
 
+export type ReframeJobRequest = {
+  start_sec: number;
+  end_sec: number;
+  crop_to_vertical?: boolean;
+  subtitles?: boolean;
+  face_tracking?: boolean;
+  color_filter?: boolean;
+};
+
+export type ReframeJobResponse = {
+  job_id: string;
+  job_type: string;
+  status: string;
+  filename: string;
+  start_sec: number;
+  end_sec: number;
+  created_at: string;
+};
+
 export type JobStatusResponse = {
   job_id: string;
   status: string;
@@ -186,6 +205,19 @@ export const videoApi = {
     });
 
     return parseResponse<AutoReframeResponse>(response);
+  },
+
+  async createReframeJob(videoId: string, token: string, payload: ReframeJobRequest) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    return parseResponse<ReframeJobResponse>(response);
   },
 
   async getJobStatus(jobId: string, token: string) {

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -43,6 +43,7 @@ export type ReframeJobRequest = {
   subtitles?: boolean;
   face_tracking?: boolean;
   color_filter?: boolean;
+  output_style?: "vertical" | "speaker_split";
 };
 
 export type ReframeJobResponse = {
@@ -202,11 +203,12 @@ export const videoApi = {
   async createAutoReframeJobs(
     videoId: string,
     token: string,
-    options?: { clipsCount?: number; clipDurationSec?: number }
+    options?: { clipsCount?: number; clipDurationSec?: number; outputStyle?: "vertical" | "speaker_split" }
   ) {
     const body = {
       clips_count: options?.clipsCount ?? 3,
-      clip_duration_sec: options?.clipDurationSec ?? 15
+      clip_duration_sec: options?.clipDurationSec ?? 15,
+      output_style: options?.outputStyle ?? "vertical"
     };
 
     const response = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto`, {

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -44,6 +44,7 @@ export type ReframeJobRequest = {
   face_tracking?: boolean;
   color_filter?: boolean;
   output_style?: "vertical" | "speaker_split";
+  content_profile?: "auto" | "interview" | "sports" | "music";
 };
 
 export type ReframeJobResponse = {
@@ -203,13 +204,24 @@ export const videoApi = {
   async createAutoReframeJobs(
     videoId: string,
     token: string,
-    options?: { clipsCount?: number; clipDurationSec?: number; outputStyle?: "vertical" | "speaker_split" }
+    options?: {
+      clipsCount?: number;
+      clipDurationSec?: number;
+      outputStyle?: "vertical" | "speaker_split";
+      contentProfile?: "auto" | "interview" | "sports" | "music";
+    }
   ) {
-    const body = {
-      clips_count: options?.clipsCount ?? 3,
-      clip_duration_sec: options?.clipDurationSec ?? 15,
-      output_style: options?.outputStyle ?? "vertical"
+    const body: Record<string, unknown> = {
+      output_style: options?.outputStyle ?? "vertical",
+      content_profile: options?.contentProfile ?? "auto"
     };
+
+    if (typeof options?.clipsCount === "number") {
+      body.clips_count = options.clipsCount;
+    }
+    if (typeof options?.clipDurationSec === "number") {
+      body.clip_duration_sec = options.clipDurationSec;
+    }
 
     const response = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto`, {
       method: "POST",

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -36,6 +36,28 @@ export type AutoReframeResponse = {
   jobs: AutoReframeJobItem[];
 };
 
+export type JobStatusResponse = {
+  job_id: string;
+  status: string;
+  output_path: string | null;
+};
+
+export type UserClipItem = {
+  job_id: string;
+  video_id: string;
+  status: string;
+  output_path: string | null;
+  source_filename: string;
+  created_at: string;
+};
+
+export type UserClipsResponse = {
+  total: number;
+  limit: number;
+  offset: number;
+  clips: UserClipItem[];
+};
+
 const apiBaseUrl = env.apiBaseUrl.replace(/\/$/, "");
 
 export class VideoApiError extends Error {
@@ -149,5 +171,32 @@ export const videoApi = {
     });
 
     return parseResponse<AutoReframeResponse>(response);
+  },
+
+  async getJobStatus(jobId: string, token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/jobs/status/${jobId}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<JobStatusResponse>(response);
+  },
+
+  async getMyClips(token: string, options?: { limit?: number; offset?: number }) {
+    const params = new URLSearchParams({
+      limit: String(options?.limit ?? 50),
+      offset: String(options?.offset ?? 0)
+    });
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/jobs/my-clips?${params.toString()}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<UserClipsResponse>(response);
   }
 };

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -19,6 +19,23 @@ export type VideoUrlResponse = {
   filename: string;
 };
 
+export type AutoReframeJobItem = {
+  job_id: string;
+  job_type: string;
+  status: string;
+  start_sec: number;
+  end_sec: number;
+  created_at: string;
+};
+
+export type AutoReframeResponse = {
+  video_id: string;
+  total_jobs: number;
+  clip_duration_sec: number;
+  used_video_duration_sec: number | null;
+  jobs: AutoReframeJobItem[];
+};
+
 const apiBaseUrl = env.apiBaseUrl.replace(/\/$/, "");
 
 export class VideoApiError extends Error {
@@ -110,5 +127,27 @@ export const videoApi = {
     });
 
     return parseResponse<VideoUrlResponse>(response);
+  },
+
+  async createAutoReframeJobs(
+    videoId: string,
+    token: string,
+    options?: { clipsCount?: number; clipDurationSec?: number }
+  ) {
+    const body = {
+      clips_count: options?.clipsCount ?? 3,
+      clip_duration_sec: options?.clipDurationSec ?? 15
+    };
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(body)
+    });
+
+    return parseResponse<AutoReframeResponse>(response);
   }
 };

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -77,6 +77,10 @@ export type UserClipsResponse = {
   clips: UserClipItem[];
 };
 
+export type UserClipDetailResponse = {
+  clip: UserClipItem;
+};
+
 export type UserVideoItem = {
   video_id: string;
   filename: string;
@@ -260,6 +264,28 @@ export const videoApi = {
     });
 
     return parseResponse<UserClipsResponse>(response);
+  },
+
+  async deleteMyClip(jobId: string, token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/jobs/${jobId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<null>(response);
+  },
+
+  async getMyClipById(jobId: string, token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/jobs/${jobId}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<UserClipDetailResponse>(response);
   },
 
   async getMyVideos(token: string, options?: { limit?: number; offset?: number; query?: string }) {

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -85,6 +85,16 @@ export type UserVideoItem = {
   preview_url: string | null;
 };
 
+export type UserVideoDetail = {
+  video_id: string;
+  filename: string;
+  status: string | null;
+  uploaded_at: string;
+  updated_at: string;
+  storage_path: string | null;
+  preview_url: string | null;
+};
+
 export type UserVideosResponse = {
   total: number;
   limit: number;
@@ -271,5 +281,40 @@ export const videoApi = {
     });
 
     return parseResponse<UserVideosResponse>(response);
+  },
+
+  async getMyVideoById(videoId: string, token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/videos/${videoId}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<UserVideoDetail>(response);
+  },
+
+  async updateMyVideo(videoId: string, token: string, payload: { filename: string }) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/videos/${videoId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    return parseResponse<UserVideoItem>(response);
+  },
+
+  async deleteMyVideo(videoId: string, token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/videos/${videoId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<null>(response);
   }
 };


### PR DESCRIPTION
# Frontend + Backend PR Worklog

## Objetivo de la rama
Integrar sobre `develop` actualizado el flujo completo de timeline + biblioteca en frontend y backend, dejando operativo el circuito upload -> procesamiento -> biblioteca -> edicion -> compartir.
Rama de trabajo: `feature/integracion-timeline-library-flow`.
                                                                       
## Cambios realizados

- Se sincronizo la base de trabajo con `develop` remoto y se recreo una rama limpia para integrar sin arrastrar archivos temporales locales.
- Se integraron cambios de backend para worker estable, jobs automaticos/manuales, listado de clips, filtros de reframe y regeneracion de URLs presignadas.
- Se agregaron endpoints y servicios para CRUD autenticado de videos (`my-videos`, detalle, rename, delete) y acciones de biblioteca de clips (detalle y delete por `job_id`).                                       - Se integraron cambios de frontend en Home, Timeline y Library con polling estable, persistencia de draft, paginacion, busqueda backend y acciones CRUD.
- Se incorporo la ruta `frontend/src/app/app/share/[clipId]/page.tsx` y se reforzo el deep-link de edicion desde biblioteca a timeline.
- Se aplico ajuste visual del dashboard (paleta Catppuccin) y correccion del comportamiento del logo en navegacion.
- Se resolvieron conflictos de integracion entre avances de `develop` y `feature/frontend-backend-timeline-library-flow` en archivos de auth/video.
- Se actualizaron logs de trabajo existentes en `docs/frontend-pr-log.md` y `docs/backend-pr-log.md` con las nuevas entradas de esta rama.

## Commits realizados

- `fix(worker): stabilize processing flow and media output`
- `feat(jobs): add smart auto-clips and user clips listing`            
- `feat(frontend): wire home upload flow to auto reframe jobs endpoint`
- `feat(frontend): move preview workflow to timeline and fetch user clips`                                                                    
- `fix(api): regenerate clip output urls for status and my-clips`
- `fix(frontend): handle unsupported video play promise in timeline`
- `fix(frontend): persist home clip draft and stabilize preview polling`
- `feat(frontend): add pagination to timeline and library clips`
- `fix(frontend): improve home results loading and live preview transitions`
- `feat(api): add search to my-clips and new my-videos endpoint`
- `feat(frontend): add backend search and original videos library view`
- `feat(api): accept optional reframe filters in manual jobs`
- `feat(frontend): wire timeline editor to manual reframe endpoint`
- `feat(api): add authenticated video CRUD endpoints`
- `feat(frontend): add rename and delete actions to library videos`
- `feat(api): add clip detail and delete endpoints for library actions`
- `feat(frontend): add clip share route and stronger timeline edit deep-link`                                                                 - `style(frontend): switch dashboard palette to catppuccin and fix home logo link`
- `docs(worklog): registrar integracion timeline-library en rama nueva`

## Archivos clave
- `backend/api/app/api/v1/endpoints/job.py`                            
- `backend/api/app/api/v1/endpoints/video.py`
- `backend/api/app/services/job_service.py`                            
- `backend/api/app/services/video_service.py`
- `backend/worker/app/pipeline.py`                                     
- `backend/worker/app/worker.py`
- `frontend/src/app/app/page.tsx`
- `frontend/src/app/app/timeline/page.tsx`                             
- `frontend/src/app/app/library/page.tsx`
- `frontend/src/app/app/share/[clipId]/page.tsx`                       
- `frontend/src/services/videoApi.ts`
- `docs/frontend-pr-log.md`                                            
- `docs/backend-pr-log.md`
- `docs/front_back-pr-log.md`
                                                                       
## Validaciones locales

Ejecutado en `frontend/`:
- `npm run lint` -> OK
                                                                       
Ejecutado en `backend/`:

- `docker compose up -d --build` -> OK                                 
- `docker compose ps` -> servicios arriba
- `worker` saludable y escuchando jobs
- `alembic upgrade heads` requerido por multiple heads para crear esquema completo
                                                                       
## Checklist antes de PR a develop
                                                                       
- [x] Rama creada desde `develop` actualizado
- [x] Integracion completa de `feature/frontend-backend-timeline-library-flow`                                                               
- [ ] Documentacion frontend/backend actualizada
- [x] Log unificado frontend+backend agregado

