### PR TITLE
Feature/frontend sync upload develop

### DIFF
--- a/backend/api/app/services/video_service.py
+++ b/backend/api/app/services/video_service.py
@@ -26,13 +26,14 @@ from app.utils.exceptions import (
     NotFoundException,
     ForbiddenException,
     VideoDBException,
-    VideoValidationException
+    VideoValidationException,
 )
 
 MAX_FILENAME_LENGTH = 255
 FILENAME_REGEX = r"^[\w\-. ]+$"  # letras, números, _, -, ., espacio
 
 logger = setup_logging()
+
 
 class VideoService:
     """Servicio de videos - Maneja validación, almacenamiento y metadata"""
@@ -50,11 +51,9 @@ class VideoService:
         "video/webm",
     }
 
-
     def __init__(self, db: Session, storage_service: StorageService):
         self.db = db
         self.storage = storage_service
-        
 
     def _validate_file(self, file: UploadFile) -> int:
         """
@@ -83,9 +82,18 @@ class VideoService:
         # Validar MIME type
         if file.content_type:
             if file.content_type not in self.ALLOWED_MIME_TYPES:
-                raise VideoValidationException(
-                    f"Tipo de archivo no válido. MIME type: {file.content_type}"
-                )
+                if (
+                    file.content_type == "application/octet-stream"
+                    and ext in self.ALLOWED_EXTENSIONS
+                ):
+                    logger.info(
+                        "MIME type generico application/octet-stream aceptado por extension valida '%s'",
+                        ext,
+                    )
+                else:
+                    raise VideoValidationException(
+                        f"Tipo de archivo no válido. MIME type: {file.content_type}"
+                    )
 
         # Obtener tamaño
         try:
@@ -110,7 +118,6 @@ class VideoService:
 
         return size_bytes
 
-
     def _get_user_video(self, video_id: UUID, user_id: UUID) -> Video:
         video = self.db.query(Video).filter(Video.id == video_id).first()
         if not video:
@@ -118,7 +125,6 @@ class VideoService:
         if video.user_id != user_id:
             raise ForbiddenException("No tienes permisos para acceder a este video")
         return video
-
 
     def _to_user_video_item(self, video: Video) -> UserVideoItem:
         return UserVideoItem(
@@ -129,17 +135,21 @@ class VideoService:
             preview_url=self._build_preview_url(video),
         )
 
-
     def _build_preview_url(self, video: Video, expires_in: int = 3600) -> str | None:
         if not video.storage_path:
             return None
         try:
-            return self.storage.get_video_public_url(video.storage_path, expires_in=expires_in)
-        
+            return self.storage.get_video_public_url(
+                video.storage_path, expires_in=expires_in
+            )
+
         except Exception as exc:
-            logger.warning(f"Error generando URL de preview para video {video.id}: {exc}")
-            raise VideoValidationException("No se pudo generar la URL de preview", str(exc))
-        
+            logger.warning(
+                f"Error generando URL de preview para video {video.id}: {exc}"
+            )
+            raise VideoValidationException(
+                "No se pudo generar la URL de preview", str(exc)
+            )
 
     def get_user_video(self, video_id: UUID, user_id: UUID) -> UserVideoDetailResponse:
         video = self._get_user_video(video_id, user_id)
@@ -153,7 +163,6 @@ class VideoService:
             preview_url=self._build_preview_url(video),
         )
 
-
     def update_user_video(
         self, video_id: UUID, user_id: UUID, payload: UpdateVideoRequest
     ) -> UserVideoItem:
@@ -165,7 +174,7 @@ class VideoService:
         - No modifica el objeto físico en MinIO.
         """
         video = self._get_user_video(video_id, user_id)
-        
+
         base_name = payload.filename.strip()
 
         # 1️⃣ No vacío
@@ -180,9 +189,7 @@ class VideoService:
 
         # 3️⃣ Caracteres permitidos
         if not re.match(FILENAME_REGEX, base_name):
-            raise VideoValidationException(
-                "El nombre contiene caracteres inválidos"
-            )
+            raise VideoValidationException("El nombre contiene caracteres inválidos")
 
         # 4️⃣ Conservar extensión original
         original_ext = Path(video.original_filename).suffix
@@ -201,13 +208,14 @@ class VideoService:
 
         return self._to_user_video_item(video)
 
-
     def delete_user_video(self, video_id: UUID, user_id: UUID) -> None:
         video = self._get_user_video(video_id, user_id)
 
         if not video.storage_path:
-            raise BadRequestException("El video no tiene una ruta de almacenamiento válida")
-        
+            raise BadRequestException(
+                "El video no tiene una ruta de almacenamiento válida"
+            )
+
         self.storage.delete_video_from_storage(video.storage_path)
 
         try:
@@ -216,7 +224,6 @@ class VideoService:
         except Exception as exc:
             self.db.rollback()
             raise VideoDBException("Error eliminando video", str(exc))
-
 
     def upload_video_authenticated(
         self, file: UploadFile, user_id: UUID
@@ -238,15 +245,17 @@ class VideoService:
         """
         size_bytes = self._validate_file(file)
 
-        storage_path, bucket, object_key = self.storage.upload_fileobj_to_minio(file.file, file.filename)
+        storage_path, bucket, object_key = self.storage.upload_fileobj_to_minio(
+            file.file, file.filename
+        )
 
         # Crear registro en DB/commit
         try:
             video = Video(
-                user_id = user_id,
-                original_filename = file.filename,
-                storage_path = storage_path,
-                status = VideoStatus.PENDING_METADATA,
+                user_id=user_id,
+                original_filename=file.filename,
+                storage_path=storage_path,
+                status=VideoStatus.PENDING_METADATA,
             )
             self.db.add(video)
             self.db.commit()
@@ -257,7 +266,7 @@ class VideoService:
             except Exception:
                 pass
             raise VideoDBException("Error guardando video en DB", str(exc))
-        
+
         return VideoUploadResponse(
             video_id=video.id,
             bucket=bucket,
@@ -269,7 +278,6 @@ class VideoService:
             storage_path=video.storage_path,
             uploaded_at=video.created_at,
         )
-
 
     def get_video_url(self, video_id: UUID, expires_in: int = 3600) -> VideoURLResponse:
         """
@@ -296,7 +304,9 @@ class VideoService:
                 "El video no tiene una ruta de almacenamiento válida"
             )
 
-        url = self.storage.get_video_public_url(video.storage_path, expires_in=expires_in)
+        url = self.storage.get_video_public_url(
+            video.storage_path, expires_in=expires_in
+        )
 
         return VideoURLResponse(
             video_id=video.id,
@@ -304,7 +314,6 @@ class VideoService:
             expires_in_seconds=expires_in,
             filename=video.original_filename,
         )
-
 
     def list_user_videos(
         self,

--- a/backend/worker/app/pipeline.py
+++ b/backend/worker/app/pipeline.py
@@ -48,7 +48,7 @@ DEBUG = os.getenv("WORKER_PIPELINE_DEBUG", "false").strip().lower() in {
 }
 
 # output routes and dirs
-OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR = Path(os.getenv("WORKER_OUTPUT_DIR", "/tmp/worker"))
 NORMALIZED_VIDEO = OUTPUT_DIR / "normalized"
 PROCESSED_VIDEO = OUTPUT_DIR / "processed"
 RESULT_VIDEO = OUTPUT_DIR / "result"

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -118,3 +118,29 @@ Intentado en `backend/api/`:
 - [x] Rama creada desde `develop` actualizado
 - [x] Integracion de cambios backend/frontend de `feature/frontend-backend-timeline-library-flow`
 - [x] Documentacion actualizada
+
+## Objetivo de la rama
+
+Registrar por separado los ajustes de backend detectados durante `feature/frontend-sync-upload-develop`, para enviarlos en PR backend independiente del PR frontend.
+
+Rama de trabajo origen: `feature/frontend-sync-upload-develop`.
+
+## Cambios implementados (backend)
+
+- Se habilito en `backend/api/app/services/video_service.py` la aceptacion de `application/octet-stream` cuando la extension es valida (ej. `.webm`), evitando rechazo de uploads desde drag/drop en navegador.
+- Se actualizo `backend/worker/app/pipeline.py` para usar `WORKER_OUTPUT_DIR` y default seguro `/tmp/worker`, reduciendo fallos por permisos en rutas temporales.
+
+## Nota operativa para deploy
+
+- Validar en cada entorno que `WORKER_OUTPUT_DIR` apunte a un path escribible por el proceso worker.
+- Verificar permisos del volumen temporal en infraestructura para prevenir `PermissionError` durante normalizacion/procesamiento.
+
+## Commits relacionados
+
+- `fix(frontend): stabilize auto2 flow and unblock video uploads` (incluye estos cambios backend en el mismo commit)
+
+## Archivos clave
+
+- `backend/api/app/services/video_service.py`
+- `backend/worker/app/pipeline.py`
+- `docs/backend-pr-log.md`

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -129,11 +129,17 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - Se adapto la integracion de Home para el refactor de backend priorizando `POST /api/v1/jobs/reframe/{video_id}/auto2` con fallback automatico a `/auto` cuando `auto2` no existe.
 - Se normalizo la respuesta de `auto2` en frontend para no romper el flujo aunque no devuelva arreglo `jobs`.
 - Se agrego polling temporal de biblioteca tras generar jobs automaticos para hidratar clips cuando el backend procesa de forma asincronica y no retorna jobs individuales de inmediato.
+- Se envio `clips_count` y `clip_duration_sec` por defecto desde frontend al crear jobs automaticos para evitar `400` en `auto2` cuando backend exige esos parametros.
+- Se mejoro el mensaje de error en Home para mostrar detalle real de backend (ya no se tapa siempre con mensaje generico de archivo invalido).
+- Se habilito en backend upload de videos `.webm` cuando el navegador envia `application/octet-stream` (caso reproducido con drag/drop en Chrome).
+- Se movio el directorio temporal del worker a `/tmp/worker` para evitar crash por permisos en `backend/tmp` (`PermissionError: tmp/normalized`).
 
 ## Commits realizados
 
 - `fix(frontend): align timeline clip creation with backend constraints`
 - `fix(frontend): support auto2 job orchestration and async clip hydration`
+- `fix(frontend): send auto2 defaults and surface backend 400 details`
+- `fix(backend): accept octet-stream video uploads and avoid worker tmp permission crashes`
 - `docs(frontend): log timeline compatibility updates on develop sync`
 
 ## Archivos clave

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -131,8 +131,6 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - Se agrego polling temporal de biblioteca tras generar jobs automaticos para hidratar clips cuando el backend procesa de forma asincronica y no retorna jobs individuales de inmediato.
 - Se envio `clips_count` y `clip_duration_sec` por defecto desde frontend al crear jobs automaticos para evitar `400` en `auto2` cuando backend exige esos parametros.
 - Se mejoro el mensaje de error en Home para mostrar detalle real de backend (ya no se tapa siempre con mensaje generico de archivo invalido).
-- Se habilito en backend upload de videos `.webm` cuando el navegador envia `application/octet-stream` (caso reproducido con drag/drop en Chrome).
-- Se movio el directorio temporal del worker a `/tmp/worker` para evitar crash por permisos en `backend/tmp` (`PermissionError: tmp/normalized`).
 - Se ajusto Home para que la hidratacion de clips siga activa hasta completar la cantidad esperada de resultados, evitando que aparezca solo el primer clip si el resto termina mas tarde.
 - Se mejoro la grilla de `clips generados` en Home para que una sola tarjeta no se estire a pantalla completa (cards con ancho consistente desde el primer render).
 - Se removio la opcion lateral `Settings IA` del sidebar.
@@ -141,16 +139,14 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 
 ## Nota destacada
 
-- Riesgo para produccion detectado: si el worker usa un volumen/path sin permisos de escritura para temporales, el pipeline puede fallar con `PermissionError` y dejar jobs sin completar (impacta generacion de clips).
-- Mitigacion aplicada en esta rama: uso de directorio temporal seguro `/tmp/worker` en `backend/worker/app/pipeline.py`.
-- Seguimiento recomendado para backend: parametrizar y validar el path temporal por entorno (ej. `WORKER_OUTPUT_DIR`) y verificar permisos del volumen en deploy.
+- Dependencia backend detectada fuera del alcance de este PR frontend: si el worker usa un volumen/path sin permisos de escritura para temporales, el pipeline puede fallar con `PermissionError` y dejar jobs sin completar.
+- Seguimiento recomendado para PR backend: parametrizar y validar el path temporal por entorno (ej. `WORKER_OUTPUT_DIR`) y verificar permisos del volumen en deploy.
 
 ## Commits realizados
 
 - `fix(frontend): align timeline clip creation with backend constraints`
 - `fix(frontend): support auto2 job orchestration and async clip hydration`
 - `fix(frontend): send auto2 defaults and surface backend 400 details`
-- `fix(backend): accept octet-stream video uploads and avoid worker tmp permission crashes`
 - `docs(frontend): log timeline compatibility updates on develop sync`
 - `docs(frontend): update worklog with auto2 integration fixes`
 - `docs(frontend): record upload and worker stability fixes`
@@ -168,8 +164,6 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - `frontend/src/components/layout/Sidebar.tsx`
 - `frontend/src/app/app/export/page.tsx`
 - `frontend/src/app/app/page.tsx`
-- `backend/api/app/services/video_service.py`
-- `backend/worker/app/pipeline.py`
 - `docs/frontend-pr-log.md`
 
 ## Validaciones locales

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -134,6 +134,12 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - Se habilito en backend upload de videos `.webm` cuando el navegador envia `application/octet-stream` (caso reproducido con drag/drop en Chrome).
 - Se movio el directorio temporal del worker a `/tmp/worker` para evitar crash por permisos en `backend/tmp` (`PermissionError: tmp/normalized`).
 
+## Nota destacada
+
+- Riesgo para produccion detectado: si el worker usa un volumen/path sin permisos de escritura para temporales, el pipeline puede fallar con `PermissionError` y dejar jobs sin completar (impacta generacion de clips).
+- Mitigacion aplicada en esta rama: uso de directorio temporal seguro `/tmp/worker` en `backend/worker/app/pipeline.py`.
+- Seguimiento recomendado para backend: parametrizar y validar el path temporal por entorno (ej. `WORKER_OUTPUT_DIR`) y verificar permisos del volumen en deploy.
+
 ## Commits realizados
 
 - `fix(frontend): align timeline clip creation with backend constraints`
@@ -141,12 +147,16 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - `fix(frontend): send auto2 defaults and surface backend 400 details`
 - `fix(backend): accept octet-stream video uploads and avoid worker tmp permission crashes`
 - `docs(frontend): log timeline compatibility updates on develop sync`
+- `docs(frontend): update worklog with auto2 integration fixes`
+- `docs(frontend): record upload and worker stability fixes`
 
 ## Archivos clave
 
 - `frontend/src/app/app/timeline/page.tsx`
 - `frontend/src/components/home/VideoSettings.tsx`
 - `frontend/src/components/home/videoPrevewTimeLine/useVideoTrim.ts`
+- `backend/api/app/services/video_service.py`
+- `backend/worker/app/pipeline.py`
 - `docs/frontend-pr-log.md`
 
 ## Validaciones locales

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -137,6 +137,7 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - Se mejoro la grilla de `clips generados` en Home para que una sola tarjeta no se estire a pantalla completa (cards con ancho consistente desde el primer render).
 - Se removio la opcion lateral `Settings IA` del sidebar.
 - Se creo `frontend/src/app/app/export/page.tsx` como nueva vista de exportacion con resumen de estado, listado de clips listos, descarga directa y copia de link.
+- Se corrigio Home para que la lista de resultados combine `createdJobs` con clips ya visibles en biblioteca del mismo `video_id`, evitando que se muestre solo 1 clip hasta recargar cuando los 3 jobs llegan de forma asincronica.
 
 ## Nota destacada
 
@@ -155,6 +156,8 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - `docs(frontend): record upload and worker stability fixes`
 - `feat(frontend): polish home clips grid and add export center view`
 - `docs(frontend): update worklog with home hydration and export page`
+- `fix(frontend): sync home clips with library hydration fallback`
+- `docs(frontend): log home clip sync fix without manual refresh`
 
 ## Archivos clave
 
@@ -164,6 +167,7 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - `frontend/src/components/home/GeneratedClipsSection.tsx`
 - `frontend/src/components/layout/Sidebar.tsx`
 - `frontend/src/app/app/export/page.tsx`
+- `frontend/src/app/app/page.tsx`
 - `backend/api/app/services/video_service.py`
 - `backend/worker/app/pipeline.py`
 - `docs/frontend-pr-log.md`

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -133,6 +133,10 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - Se mejoro el mensaje de error en Home para mostrar detalle real de backend (ya no se tapa siempre con mensaje generico de archivo invalido).
 - Se habilito en backend upload de videos `.webm` cuando el navegador envia `application/octet-stream` (caso reproducido con drag/drop en Chrome).
 - Se movio el directorio temporal del worker a `/tmp/worker` para evitar crash por permisos en `backend/tmp` (`PermissionError: tmp/normalized`).
+- Se ajusto Home para que la hidratacion de clips siga activa hasta completar la cantidad esperada de resultados, evitando que aparezca solo el primer clip si el resto termina mas tarde.
+- Se mejoro la grilla de `clips generados` en Home para que una sola tarjeta no se estire a pantalla completa (cards con ancho consistente desde el primer render).
+- Se removio la opcion lateral `Settings IA` del sidebar.
+- Se creo `frontend/src/app/app/export/page.tsx` como nueva vista de exportacion con resumen de estado, listado de clips listos, descarga directa y copia de link.
 
 ## Nota destacada
 
@@ -149,12 +153,17 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - `docs(frontend): log timeline compatibility updates on develop sync`
 - `docs(frontend): update worklog with auto2 integration fixes`
 - `docs(frontend): record upload and worker stability fixes`
+- `feat(frontend): polish home clips grid and add export center view`
+- `docs(frontend): update worklog with home hydration and export page`
 
 ## Archivos clave
 
 - `frontend/src/app/app/timeline/page.tsx`
 - `frontend/src/components/home/VideoSettings.tsx`
 - `frontend/src/components/home/videoPrevewTimeLine/useVideoTrim.ts`
+- `frontend/src/components/home/GeneratedClipsSection.tsx`
+- `frontend/src/components/layout/Sidebar.tsx`
+- `frontend/src/app/app/export/page.tsx`
 - `backend/api/app/services/video_service.py`
 - `backend/worker/app/pipeline.py`
 - `docs/frontend-pr-log.md`

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -112,3 +112,46 @@ Ejecutado en `frontend/`:
 - [x] Integracion de cambios frontend/backend de `feature/frontend-backend-timeline-library-flow`
 - [x] `npm run lint` OK
 - [x] Documentacion actualizada
+
+## Objetivo de la rama
+
+Ajustar el frontend a cambios recientes de backend en `develop`, priorizando estabilidad del flujo de timeline (crear clips y guardar nombre de video).
+
+Rama de trabajo: `feature/frontend-sync-upload-develop`.
+
+## Cambios realizados
+
+- Se alineo el timeline con la validacion actual de backend (duracion minima de 5s por clip) en `frontend/src/app/app/timeline/page.tsx` y `frontend/src/components/home/videoPrevewTimeLine/useVideoTrim.ts`.
+- Se reforzo el panel de ajustes en `frontend/src/components/home/VideoSettings.tsx` mostrando duracion estimada, minimo permitido y bloqueo del boton cuando el recorte no cumple reglas.
+- Se corrigio guardado de nombre en timeline para usar el `selectedVideoId` real y refrescar listado local luego de editar filename.
+- Se corrigio manejo de error en guardado de nombre para mostrar el mensaje real del backend en lugar de estado previo.
+- Se eliminaron warnings de lint pendientes en timeline/settings para mantener baseline limpia.
+
+## Commits realizados
+
+- `fix(frontend): align timeline clip creation with backend constraints`
+- `docs(frontend): log timeline compatibility updates on develop sync`
+
+## Archivos clave
+
+- `frontend/src/app/app/timeline/page.tsx`
+- `frontend/src/components/home/VideoSettings.tsx`
+- `frontend/src/components/home/videoPrevewTimeLine/useVideoTrim.ts`
+- `docs/frontend-pr-log.md`
+
+## Validaciones locales
+
+Ejecutado en `frontend/`:
+
+- `npm run lint` -> OK
+- `npm run test -- --run` -> OK
+- `npm run build` -> OK
+
+## Checklist antes de PR a develop
+
+- [x] Rama creada desde `develop`
+- [x] Commits convencionales y atomicos
+- [x] `npm run lint` OK
+- [x] `npm run test` OK
+- [x] `npm run build` OK
+- [x] Documentacion actualizada

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -126,10 +126,14 @@ Rama de trabajo: `feature/frontend-sync-upload-develop`.
 - Se corrigio guardado de nombre en timeline para usar el `selectedVideoId` real y refrescar listado local luego de editar filename.
 - Se corrigio manejo de error en guardado de nombre para mostrar el mensaje real del backend en lugar de estado previo.
 - Se eliminaron warnings de lint pendientes en timeline/settings para mantener baseline limpia.
+- Se adapto la integracion de Home para el refactor de backend priorizando `POST /api/v1/jobs/reframe/{video_id}/auto2` con fallback automatico a `/auto` cuando `auto2` no existe.
+- Se normalizo la respuesta de `auto2` en frontend para no romper el flujo aunque no devuelva arreglo `jobs`.
+- Se agrego polling temporal de biblioteca tras generar jobs automaticos para hidratar clips cuando el backend procesa de forma asincronica y no retorna jobs individuales de inmediato.
 
 ## Commits realizados
 
 - `fix(frontend): align timeline clip creation with backend constraints`
+- `fix(frontend): support auto2 job orchestration and async clip hydration`
 - `docs(frontend): log timeline compatibility updates on develop sync`
 
 ## Archivos clave

--- a/frontend/src/app/app/export/page.tsx
+++ b/frontend/src/app/app/export/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { Panel } from "@/src/components/ui/Panel";
+import { videoApi, type UserClipItem } from "@/src/services/videoApi";
+import { useAuthStore } from "@/src/store/useAuthStore";
+import { Check, Clock3, Copy, Download, FolderOpen, Link2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+const PAGE_SIZE = 30;
+
+function formatDateLabel(raw: string) {
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    return "fecha desconocida";
+  }
+  return new Intl.DateTimeFormat("es-AR", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(date);
+}
+
+function isClipReady(status: string) {
+  const normalized = status.toLowerCase();
+  return normalized === "done" || normalized === "completed";
+}
+
+export default function ExportPage() {
+  const token = useAuthStore((state) => state.token);
+  const [clips, setClips] = useState<UserClipItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setIsLoading(false);
+      setError("No encontramos sesion activa para cargar exportaciones.");
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await videoApi.getMyClips(token, { limit: PAGE_SIZE, offset: 0 });
+        if (cancelled) {
+          return;
+        }
+        setClips(response.clips);
+      } catch (loadError) {
+        if (cancelled) {
+          return;
+        }
+        setError(loadError instanceof Error ? loadError.message : "No pudimos cargar tus clips para exportacion.");
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const readyClips = useMemo(
+    () => clips.filter((clip) => isClipReady(clip.status) && Boolean(clip.output_path)),
+    [clips]
+  );
+  const pendingClips = useMemo(() => clips.filter((clip) => !isClipReady(clip.status)), [clips]);
+
+  const handleCopyLink = async (clip: UserClipItem) => {
+    if (!clip.output_path) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(clip.output_path);
+      setCopiedId(clip.job_id);
+      window.setTimeout(() => setCopiedId((prev) => (prev === clip.job_id ? null : prev)), 1800);
+    } catch {
+      setError("No pudimos copiar el enlace al portapapeles.");
+    }
+  };
+
+  return (
+    <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+      <Panel className="relative overflow-hidden border-neon-cyan/25 bg-gradient-to-r from-night-900 via-night-800/90 to-night-900 p-5 sm:p-6">
+        <div className="pointer-events-none absolute -right-14 -top-16 h-56 w-56 rounded-full bg-neon-cyan/20 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-16 left-1/4 h-44 w-44 rounded-full bg-neon-mint/10 blur-3xl" />
+
+        <div className="relative animate-fade-up">
+          <p className="text-xs uppercase tracking-[0.25em] text-neon-cyan/80">exportacion</p>
+          <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Centro de exportacion de clips</h1>
+          <p className="mt-2 max-w-2xl text-sm text-white/70">
+            Descarga tus ultimos clips listos, copia enlaces para compartir y controla rapidamente que piezas todavia siguen en proceso.
+          </p>
+        </div>
+
+        <div className="relative mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-xl border border-neon-cyan/30 bg-neon-cyan/10 p-3">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-neon-cyan/85">Clips listos</p>
+            <p className="mt-1 font-display text-2xl text-white">{readyClips.length}</p>
+          </div>
+          <div className="rounded-xl border border-amber-300/30 bg-amber-300/10 p-3">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-amber-100/85">En proceso</p>
+            <p className="mt-1 font-display text-2xl text-white">{pendingClips.length}</p>
+          </div>
+          <div className="rounded-xl border border-white/15 bg-white/5 p-3">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-white/65">Total reciente</p>
+            <p className="mt-1 font-display text-2xl text-white">{clips.length}</p>
+          </div>
+        </div>
+      </Panel>
+
+      {error ? (
+        <Panel className="mt-5">
+          <p className="rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{error}</p>
+        </Panel>
+      ) : null}
+
+      {isLoading ? (
+        <Panel className="mt-5">
+          <p className="text-sm text-white/70">Preparando exportaciones...</p>
+        </Panel>
+      ) : null}
+
+      {!isLoading && readyClips.length === 0 ? (
+        <Panel className="mt-5">
+          <p className="text-sm text-white/70">Todavia no hay clips listos para exportar.</p>
+        </Panel>
+      ) : null}
+
+      {readyClips.length > 0 ? (
+        <div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {readyClips.map((clip, index) => (
+            <article
+              key={clip.job_id}
+              className="group animate-fade-up rounded-2xl border border-white/10 bg-gradient-to-b from-night-800/80 to-night-900/80 p-4 shadow-panel transition duration-300 hover:-translate-y-1 hover:border-neon-cyan/40"
+              style={{ animationDelay: `${index * 70}ms` }}
+            >
+              <div className="relative mb-3 overflow-hidden rounded-xl border border-white/10 bg-night-900/80">
+                {clip.output_path ? (
+                  <video controls preload="metadata" className="aspect-[9/13] w-full object-cover" src={clip.output_path} />
+                ) : (
+                  <div className="aspect-[9/13] bg-night-900" />
+                )}
+                <span className="absolute right-3 top-3 rounded-full border border-emerald-300/40 bg-emerald-300/15 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-emerald-200">
+                  listo
+                </span>
+              </div>
+
+              <h2 className="font-display text-lg text-white">Clip {clip.job_id.slice(0, 8)}</h2>
+              <p className="mt-1 text-xs text-white/65">{clip.source_filename}</p>
+              <p className="mt-2 inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-[11px] text-white/70">
+                <Clock3 size={12} /> {formatDateLabel(clip.created_at)}
+              </p>
+
+              <div className="mt-4 grid grid-cols-2 gap-2">
+                <a
+                  href={clip.output_path ?? "#"}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center justify-center gap-1 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-neon-cyan transition hover:bg-neon-cyan/20"
+                >
+                  <Download size={12} /> Descargar
+                </a>
+                <button
+                  type="button"
+                  onClick={() => void handleCopyLink(clip)}
+                  className="inline-flex items-center justify-center gap-1 rounded-lg border border-neon-mint/40 bg-neon-mint/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-neon-mint transition hover:bg-neon-mint/20"
+                >
+                  {copiedId === clip.job_id ? <Check size={12} /> : <Copy size={12} />}
+                  {copiedId === clip.job_id ? "Copiado" : "Copiar link"}
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+
+      {pendingClips.length > 0 ? (
+        <Panel className="mt-5 border-white/12 bg-white/5 p-4 sm:p-5">
+          <div className="flex items-center gap-2 text-white/85">
+            <FolderOpen size={15} className="text-neon-cyan" />
+            <p className="text-sm font-medium">Clips en proceso</p>
+          </div>
+
+          <div className="mt-3 space-y-2">
+            {pendingClips.slice(0, 6).map((clip) => (
+              <div
+                key={clip.job_id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-white/10 bg-night-900/45 px-3 py-2 text-xs"
+              >
+                <span className="text-white/70">{clip.source_filename}</span>
+                <span className="inline-flex items-center gap-1 rounded-full border border-amber-300/40 bg-amber-300/10 px-2 py-1 uppercase tracking-[0.14em] text-amber-100">
+                  <Link2 size={11} /> {clip.status}
+                </span>
+              </div>
+            ))}
+          </div>
+        </Panel>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -112,6 +112,7 @@ export default function AppHomePage() {
   const [jobStatusMap, setJobStatusMap] = useState<Record<string, { status: string; outputPath: string | null }>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [jobError, setJobError] = useState<string | null>(null);
+  const [isHydratingClips, setIsHydratingClips] = useState(false);
   const [outputStyle, setOutputStyle] = useState<ClipOutputStyle>("vertical");
   const [contentProfile, setContentProfile] = useState<ClipContentProfile>("auto");
   const [fallbackClips, setFallbackClips] = useState<UserClipItem[]>([]);
@@ -298,13 +299,17 @@ export default function AppHomePage() {
 
   useEffect(() => {
     if (!token || !uploadedVideo || createdJobs.length > 0 || isUploading || isCreatingJobs) {
+      setIsHydratingClips(false);
       return;
     }
 
     let cancelled = false;
+    let attempts = 0;
+    const maxAttempts = 20;
 
     const hydrateFromLibrary = async () => {
       try {
+        attempts += 1;
         const data = await videoApi.getMyClips(token, { limit: 40, offset: 0 });
         if (cancelled) {
           return;
@@ -314,16 +319,30 @@ export default function AppHomePage() {
         if (related.length > 0) {
           setFallbackClips(related);
           setAutoJobCount((prev) => (prev > 0 ? prev : related.length));
+          setIsHydratingClips(false);
+          window.clearInterval(intervalId);
+          return;
+        }
+
+        if (attempts >= maxAttempts) {
+          setIsHydratingClips(false);
+          window.clearInterval(intervalId);
         }
       } catch {
         // Silencioso: este hydrate es best-effort para evitar estados vacios en Home.
       }
     };
 
+    setIsHydratingClips(true);
+    const intervalId = window.setInterval(() => {
+      void hydrateFromLibrary();
+    }, 5000);
     void hydrateFromLibrary();
 
     return () => {
       cancelled = true;
+      window.clearInterval(intervalId);
+      setIsHydratingClips(false);
     };
   }, [token, uploadedVideo, createdJobs.length, isUploading, isCreatingJobs]);
 
@@ -439,7 +458,7 @@ export default function AppHomePage() {
       <Panel className="mt-5">
         <GeneratedClipsSection
           clips={visibleClips}
-          showLoading={isUploading || (isCreatingJobs && createdJobs.length === 0)}
+          showLoading={isUploading || (isCreatingJobs && createdJobs.length === 0) || (isHydratingClips && visibleClips.length === 0)}
           isRefreshingStatuses={isPollingStatuses}
         />
       </Panel>

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -79,7 +79,7 @@ function isTerminalStatus(status: string) {
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
   if (error instanceof VideoApiError) {
     if (error.status === 400) {
-      return "El archivo de video es invalido o no cumple los requisitos.";
+      return error.message || "El archivo de video es invalido o no cumple los requisitos.";
     }
 
     if (error.status === 401) {

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -43,11 +43,15 @@ function mapJobStatusToClipStatus(status: string): Clip["status"] {
 
 function mapJobsToClips(
   jobs: AutoReframeJobItem[],
-  jobStatusMap: Record<string, { status: string; outputPath: string | null }>
+  jobStatusMap: Record<string, { status: string; outputPath: string | null }>,
+  fallbackClips: UserClipItem[]
 ): Clip[] {
-  return jobs.map((job, index) => {
+  const fallbackByJobId = new Map(fallbackClips.map((clip) => [clip.job_id, clip]));
+
+  const mappedFromJobs = jobs.map((job, index) => {
     const statusInfo = jobStatusMap[job.job_id];
-    const status = statusInfo?.status ?? job.status;
+    const fallbackClip = fallbackByJobId.get(job.job_id);
+    const status = statusInfo?.status ?? fallbackClip?.status ?? job.status;
 
     return {
       id: job.job_id,
@@ -55,9 +59,23 @@ function mapJobsToClips(
       duration: toTimeLabel(Math.max(job.end_sec - job.start_sec, 0)),
       preset: "Auto Reframe",
       status: mapJobStatusToClipStatus(status),
-      previewUrl: statusInfo?.outputPath ?? null
+      previewUrl: statusInfo?.outputPath ?? fallbackClip?.output_path ?? null
     };
   });
+
+  const knownIds = new Set(jobs.map((job) => job.job_id));
+  const mappedFromLibraryOnly = fallbackClips
+    .filter((clip) => !knownIds.has(clip.job_id))
+    .map((clip, index) => ({
+      id: clip.job_id,
+      title: `Clip ${mappedFromJobs.length + index + 1}`,
+      duration: "00:15",
+      preset: "Auto Reframe",
+      status: mapJobStatusToClipStatus(clip.status),
+      previewUrl: clip.output_path
+    }));
+
+  return [...mappedFromJobs, ...mappedFromLibraryOnly];
 }
 
 function mapUserClipsToCards(clips: UserClipItem[]): Clip[] {
@@ -120,7 +138,7 @@ export default function AppHomePage() {
   const hasVideo = Boolean(uploadedVideo);
   const visibleClips = useMemo(() => {
     if (createdJobs.length > 0) {
-      return mapJobsToClips(createdJobs, jobStatusMap);
+      return mapJobsToClips(createdJobs, jobStatusMap, fallbackClips);
     }
     return mapUserClipsToCards(fallbackClips);
   }, [createdJobs, jobStatusMap, fallbackClips]);
@@ -298,7 +316,17 @@ export default function AppHomePage() {
   };
 
   useEffect(() => {
-    if (!token || !uploadedVideo || createdJobs.length > 0 || isUploading || isCreatingJobs) {
+    if (!token || !uploadedVideo) {
+      setIsHydratingClips(false);
+      return;
+    }
+
+    const shouldHydrateFromLibrary =
+      !isUploading &&
+      !isCreatingJobs &&
+      (createdJobs.length === 0 || (autoJobCount > 0 && createdJobs.length < autoJobCount));
+
+    if (!shouldHydrateFromLibrary) {
       setIsHydratingClips(false);
       return;
     }

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -316,9 +316,12 @@ export default function AppHomePage() {
         }
 
         const related = data.clips.filter((clip) => clip.video_id === uploadedVideo.video_id);
-        if (related.length > 0) {
-          setFallbackClips(related);
-          setAutoJobCount((prev) => (prev > 0 ? prev : related.length));
+        setFallbackClips(related);
+        setAutoJobCount((prev) => (prev > 0 ? prev : related.length));
+
+        const expectedClips = autoJobCount > 0 ? autoJobCount : null;
+        const reachedExpectedCount = expectedClips !== null && related.length >= expectedClips;
+        if (reachedExpectedCount) {
           setIsHydratingClips(false);
           window.clearInterval(intervalId);
           return;
@@ -344,7 +347,7 @@ export default function AppHomePage() {
       window.clearInterval(intervalId);
       setIsHydratingClips(false);
     };
-  }, [token, uploadedVideo, createdJobs.length, isUploading, isCreatingJobs]);
+  }, [token, uploadedVideo, createdJobs.length, isUploading, isCreatingJobs, autoJobCount]);
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -3,7 +3,6 @@
 import { VideoSettings } from "@/src/components/home/VideoSettings";
 import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
 import { Panel } from "@/src/components/ui/Panel";
-import { Button } from "@/src/components/ui/Button";
 import { videoApi, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useVideoSettingsStore } from "@/src/store/useVideoSettingsStore";
@@ -12,6 +11,7 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 const PAGE_SIZE = 10;
+const MIN_CLIP_SECONDS = 5;
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
   if (error instanceof VideoApiError) {
@@ -54,16 +54,21 @@ export default function TimelinePage() {
       return;
     }
 
+    if (!selectedVideoId) {
+      setSubmitErrorSettings("Selecciona un video para guardar el nombre.");
+      return;
+    }
+
     setSubmitErrorSettings(null);
     setSubmitInfoSettings(null);
     try {
-      const updated = await videoApi.updateMyVideo(preferredVideoId, token, { filename: draftFilename });
-      // setVideos((prev) => prev.map((item) => (item.video_id === videoId ? updated : item)));
-          setSubmitInfoSettings(`Ajustes Guardados.`);
+      const updated = await videoApi.updateMyVideo(selectedVideoId, token, { filename: draftFilename.trim() });
+      setVideos((prev) => prev.map((item) => (item.video_id === selectedVideoId ? updated : item)));
+      setSubmitInfoSettings("Ajustes guardados.");
 
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : "No pudimos actualizar el nombre del video.");
-          setSubmitErrorSettings(error);
+      const message = saveError instanceof Error ? saveError.message : "No pudimos actualizar el nombre del video.";
+      setSubmitErrorSettings(message);
 
     }
 
@@ -164,6 +169,13 @@ export default function TimelinePage() {
     [videos, selectedVideoId]
   );
 
+  useEffect(() => {
+    if (!selectedVideo) {
+      return;
+    }
+    setDraftFilename(selectedVideo.filename);
+  }, [selectedVideo]);
+
   const selectedPreviewUrl =
     focusedClip && focusedClip.video_id === selectedVideoId
       ? (focusedClip.output_path ?? selectedVideo?.preview_url ?? null)
@@ -176,7 +188,7 @@ export default function TimelinePage() {
     }
 
     const normalizedStart = Math.max(0, Math.floor(trimStart));
-    const normalizedEnd = Math.max(normalizedStart + 1, Math.ceil(trimEnd));
+    const normalizedEnd = Math.max(normalizedStart + MIN_CLIP_SECONDS, Math.ceil(trimEnd));
 
     setIsSubmitting(true);
     setSubmitError(null);
@@ -335,7 +347,7 @@ export default function TimelinePage() {
         <Panel>
           <p className="text-xs uppercase tracking-[0.22em] text-white/65">configuracion</p>
           <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Ajustes de recorte</h3>
-          <VideoSettings submitInfoSettings={submitInfoSettings} submitErrorSettings={submitErrorSettings} videoEditarBool={videoEditarBool} draftFilename={draftFilename} setDraftFilename={setDraftFilename} saveRaname={saveRaname} trimStart={trimStart} trimEnd={trimEnd} isSubmitting={isSubmitting} submitInfo={submitInfo} selectedVideoId={selectedVideoId} submitError={submitError}  handleCreateJob={handleCreateJob} />
+          <VideoSettings submitInfoSettings={submitInfoSettings} submitErrorSettings={submitErrorSettings} videoEditarBool={videoEditarBool} draftFilename={draftFilename} setDraftFilename={setDraftFilename} saveRaname={saveRaname} trimStart={trimStart} trimEnd={trimEnd} minClipDurationSec={MIN_CLIP_SECONDS} isSubmitting={isSubmitting} submitInfo={submitInfo} selectedVideoId={selectedVideoId} submitError={submitError}  handleCreateJob={handleCreateJob} />
         </Panel>
       </div>
     </section>

--- a/frontend/src/components/home/GeneratedClipsSection.tsx
+++ b/frontend/src/components/home/GeneratedClipsSection.tsx
@@ -29,9 +29,9 @@ export function GeneratedClipsSection({ clips, showLoading, isRefreshingStatuses
       <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Lista de resultados</h3>
 
       {showLoading ? (
-        <div className="mt-5 grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(14rem,1fr))]">
+        <div className="mt-5 grid justify-center gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {[1, 2, 3].map((id) => (
-            <div key={id} className="rounded-2xl border border-white/10 bg-night-900/45 p-4">
+            <div key={id} className="w-full max-w-sm rounded-2xl border border-white/10 bg-night-900/45 p-4">
               <Skeleton className="aspect-[9/16] w-full rounded-xl" />
               <Skeleton className="mt-3 h-5 w-2/3" />
               <Skeleton className="mt-2 h-4 w-1/2" />
@@ -43,11 +43,11 @@ export function GeneratedClipsSection({ clips, showLoading, isRefreshingStatuses
           Todavia no hay clips generados. Subi un video para empezar.
         </div>
       ) : (
-        <div className="mt-5 grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(14rem,1fr))]">
+        <div className="mt-5 grid justify-center gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {clips.map((clip) => (
             <article
               key={clip.id}
-              className="rounded-2xl border border-white/15 bg-gradient-to-b from-night-900/70 to-night-800/45 p-4 transition hover:-translate-y-0.5 hover:border-neon-cyan/35"
+              className="w-full max-w-sm rounded-2xl border border-white/15 bg-gradient-to-b from-night-900/70 to-night-800/45 p-4 transition hover:-translate-y-0.5 hover:border-neon-cyan/35"
             >
               {clip.previewUrl ? (
                 <div className="overflow-hidden rounded-xl border border-neon-cyan/30 bg-black">

--- a/frontend/src/components/home/VideoSettings.tsx
+++ b/frontend/src/components/home/VideoSettings.tsx
@@ -7,6 +7,7 @@ type ButtonGeneraRecorte={
   trimStart :number,
   selectedVideoId: string | null,
   trimEnd:number,
+  minClipDurationSec:number,
   isSubmitting:boolean,
   submitInfo:string  | null, 
   submitError:string| null,
@@ -26,11 +27,12 @@ const settingItems: Array<{ key: keyof VideoSettings; label: string }> = [
   { key: "colorFilter", label: "Filtro de color" }
 ];
 
-export function VideoSettings( {submitInfoSettings,submitErrorSettings, trimStart,videoEditarBool,draftFilename,setDraftFilename, saveRaname,  trimEnd, isSubmitting,  submitInfo, submitError,selectedVideoId,handleCreateJob}:ButtonGeneraRecorte){
+export function VideoSettings( {submitInfoSettings,submitErrorSettings, trimStart,videoEditarBool,draftFilename,setDraftFilename, saveRaname,  trimEnd, minClipDurationSec, isSubmitting,  submitInfo, submitError,selectedVideoId,handleCreateJob}:ButtonGeneraRecorte){
       const settings = useVideoSettingsStore((state) => state.settings);
       const saveSettings = useVideoSettingsStore((state) => state.saveSettings);
-      const resetSettings = useVideoSettingsStore((state) => state.resetSettings);
-        const [draft, setDraft] = useState<VideoSettings>(settings);
+      const [draft, setDraft] = useState<VideoSettings>(settings);
+      const selectedDuration = Math.max(0, Math.ceil(trimEnd) - Math.floor(trimStart));
+      const canCreateClip = Boolean(selectedVideoId) && selectedDuration >= minClipDurationSec;
       
      const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -96,15 +98,18 @@ export function VideoSettings( {submitInfoSettings,submitErrorSettings, trimStar
                   </div>
 
 
-                  <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
+          <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
             <p>Recorte seleccionado: {Math.floor(trimStart)}s - {Math.ceil(trimEnd)}s</p>
-            <Button className="mt-3 w-auto px-4" onClick={handleCreateJob} disabled={isSubmitting || !selectedVideoId}>
+            <p className="mt-1 text-xs text-white/60">Duracion estimada: {selectedDuration}s (minimo {minClipDurationSec}s)</p>
+            <Button className="mt-3 w-auto px-4" onClick={handleCreateJob} disabled={isSubmitting || !canCreateClip}>
               {isSubmitting ? "Creando clip..." : "Generar clip con timeline"}
             </Button>
+            {!canCreateClip ? (
+              <p className="mt-2 text-xs text-amber-200">Ajusta el recorte para que tenga al menos {minClipDurationSec}s.</p>
+            ) : null}
             {submitInfo ? <p className="mt-2 text-xs text-neon-mint">{submitInfo}</p> : null}
             {submitError ? <p className="mt-2 text-xs text-rose-200">{submitError}</p> : null}
           </div> 
                 </form>
     </>)
 }
-

--- a/frontend/src/components/home/videoPrevewTimeLine/useVideoTrim.ts
+++ b/frontend/src/components/home/videoPrevewTimeLine/useVideoTrim.ts
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 
 type DragType = "start" | "end" | null;
+const MIN_CLIP_SECONDS = 5;
 
 export function useVideoTrim(
   duration: number,
@@ -19,6 +20,7 @@ export function useVideoTrim(
     duration > 0 && containerWidth > 0
       ? containerWidth / duration
       : 1;
+  const minGapPx = Math.max(MIN_CLIP_SECONDS * pixelsPerSecond, 1);
 
   // init
   useEffect(() => {
@@ -67,13 +69,13 @@ export function useVideoTrim(
     const x = e.clientX - rect.left;
 
     if (dragging.current === "start") {
-      const newStart = Math.min(Math.max(0, x), endPx - 5);
+      const newStart = Math.min(Math.max(0, x), endPx - minGapPx);
       setStartPx(newStart);
       notify(newStart / pixelsPerSecond, endPx / pixelsPerSecond);
     }
 
     if (dragging.current === "end") {
-      const newEnd = Math.max(Math.min(containerWidth, x), startPx + 5);
+      const newEnd = Math.max(Math.min(containerWidth, x), startPx + minGapPx);
       setEndPx(newEnd);
       notify(startPx / pixelsPerSecond, newEnd / pixelsPerSecond);
     }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Film, Home, Settings2, Upload, Waypoints, X } from "lucide-react";
+import { Film, Home, Upload, Waypoints, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -6,8 +6,7 @@ const items = [
   { icon: Home, label: "Panel", href: "/app" },
   { icon: Waypoints, label: "Timeline editor", href: "/app/timeline" },
   { icon: Film, label: "Biblioteca clips", href: "/app/library" },
-  { icon: Upload, label: "Exportacion", href: "/app/export" },
-  { icon: Settings2, label: "Settings IA", href: "/app/settings" }
+  { icon: Upload, label: "Exportacion", href: "/app/export" }
 ];
 
 interface SidebarProps {

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -218,16 +218,11 @@ export const videoApi = {
     }
   ) {
     const body: Record<string, unknown> = {
+      clips_count: options?.clipsCount ?? 3,
+      clip_duration_sec: options?.clipDurationSec ?? 15,
       output_style: options?.outputStyle ?? "vertical",
       content_profile: options?.contentProfile ?? "auto"
     };
-
-    if (typeof options?.clipsCount === "number") {
-      body.clips_count = options.clipsCount;
-    }
-    if (typeof options?.clipDurationSec === "number") {
-      body.clip_duration_sec = options.clipDurationSec;
-    }
 
     const auto2Response = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto2`, {
       method: "POST",

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -34,6 +34,12 @@ export type AutoReframeResponse = {
   clip_duration_sec: number;
   used_video_duration_sec: number | null;
   jobs: AutoReframeJobItem[];
+  orchestrator_job_id?: string;
+};
+
+type AutoReframeResponseV2 = {
+  job_id: string;
+  total_jobs: number;
 };
 
 export type ReframeJobRequest = {
@@ -223,7 +229,7 @@ export const videoApi = {
       body.clip_duration_sec = options.clipDurationSec;
     }
 
-    const response = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto`, {
+    const auto2Response = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto2`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -232,7 +238,37 @@ export const videoApi = {
       body: JSON.stringify(body)
     });
 
-    return parseResponse<AutoReframeResponse>(response);
+    if (auto2Response.ok) {
+      const payload = await parseResponse<AutoReframeResponse | AutoReframeResponseV2>(auto2Response);
+
+      if ("jobs" in payload) {
+        return payload;
+      }
+
+      return {
+        video_id: videoId,
+        total_jobs: payload.total_jobs ?? 0,
+        clip_duration_sec: options?.clipDurationSec ?? 15,
+        used_video_duration_sec: null,
+        jobs: [],
+        orchestrator_job_id: payload.job_id
+      };
+    }
+
+    if (auto2Response.status !== 404) {
+      return parseResponse<AutoReframeResponse>(auto2Response);
+    }
+
+    const fallbackResponse = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(body)
+    });
+
+    return parseResponse<AutoReframeResponse>(fallbackResponse);
   },
 
   async createReframeJob(videoId: string, token: string, payload: ReframeJobRequest) {


### PR DESCRIPTION
## Objetivo de la rama

Ajustar el frontend a cambios recientes de backend en `develop`, priorizando estabilidad del flujo de timeline (crear clips y guardar nombre de video).

Rama de trabajo: `feature/frontend-sync-upload-develop`.

## Cambios realizados

- Se alineo el timeline con la validacion actual de backend (duracion minima de 5s por clip) en `frontend/src/app/app/timeline/page.tsx` y `frontend/src/components/home/videoPrevewTimeLine/useVideoTrim.ts`.
- Se reforzo el panel de ajustes en `frontend/src/components/home/VideoSettings.tsx` mostrando duracion estimada, minimo permitido y bloqueo del boton cuando el recorte no cumple reglas.
- Se corrigio guardado de nombre en timeline para usar el `selectedVideoId` real y refrescar listado local luego de editar filename.
- Se corrigio manejo de error en guardado de nombre para mostrar el mensaje real del backend en lugar de estado previo.
- Se eliminaron warnings de lint pendientes en timeline/settings para mantener baseline limpia.
- Se adapto la integracion de Home para el refactor de backend priorizando `POST /api/v1/jobs/reframe/{video_id}/auto2` con fallback automatico a `/auto` cuando `auto2` no existe.
- Se normalizo la respuesta de `auto2` en frontend para no romper el flujo aunque no devuelva arreglo `jobs`.
- Se agrego polling temporal de biblioteca tras generar jobs automaticos para hidratar clips cuando el backend procesa de forma asincronica y no retorna jobs individuales de inmediato.
- Se envio `clips_count` y `clip_duration_sec` por defecto desde frontend al crear jobs automaticos para evitar `400` en `auto2` cuando backend exige esos parametros.
- Se mejoro el mensaje de error en Home para mostrar detalle real de backend (ya no se tapa siempre con mensaje generico de archivo invalido).
- Se ajusto Home para que la hidratacion de clips siga activa hasta completar la cantidad esperada de resultados, evitando que aparezca solo el primer clip si el resto termina mas tarde.
- Se mejoro la grilla de `clips generados` en Home para que una sola tarjeta no se estire a pantalla completa (cards con ancho consistente desde el primer render).
- Se removio la opcion lateral `Settings IA` del sidebar.
- Se creo `frontend/src/app/app/export/page.tsx` como nueva vista de exportacion con resumen de estado, listado de clips listos, descarga directa y copia de link.
- Se corrigio Home para que la lista de resultados combine `createdJobs` con clips ya visibles en biblioteca del mismo `video_id`, evitando que se muestre solo 1 clip hasta recargar cuando los 3 jobs llegan de forma asincronica.

## Nota destacada

- Dependencia backend detectada fuera del alcance de este PR frontend: si el worker usa un volumen/path sin permisos de escritura para temporales, el pipeline puede fallar con `PermissionError` y dejar jobs sin completar.
- Seguimiento recomendado para PR backend: parametrizar y validar el path temporal por entorno (ej. `WORKER_OUTPUT_DIR`) y verificar permisos del volumen en deploy.

## Commits realizados

- `fix(frontend): align timeline clip creation with backend constraints`
- `fix(frontend): support auto2 job orchestration and async clip hydration`
- `fix(frontend): send auto2 defaults and surface backend 400 details`
- `docs(frontend): log timeline compatibility updates on develop sync`
- `docs(frontend): update worklog with auto2 integration fixes`
- `docs(frontend): record upload and worker stability fixes`
- `feat(frontend): polish home clips grid and add export center view`
- `docs(frontend): update worklog with home hydration and export page`
- `fix(frontend): sync home clips with library hydration fallback`
- `docs(frontend): log home clip sync fix without manual refresh`

## Archivos clave

- `frontend/src/app/app/timeline/page.tsx`
- `frontend/src/components/home/VideoSettings.tsx`
- `frontend/src/components/home/videoPrevewTimeLine/useVideoTrim.ts`
- `frontend/src/components/home/GeneratedClipsSection.tsx`
- `frontend/src/components/layout/Sidebar.tsx`
- `frontend/src/app/app/export/page.tsx`
- `frontend/src/app/app/page.tsx`
- `docs/frontend-pr-log.md`

## Validaciones locales

Ejecutado en `frontend/`:

- `npm run lint` -> OK
- `npm run test -- --run` -> OK
- `npm run build` -> OK

## Checklist antes de PR a develop

- [x] Rama creada desde `develop`
- [x] Commits convencionales y atomicos
- [x] `npm run lint` OK
- [x] `npm run test` OK
- [x] `npm run build` OK
- [x] Documentacion actualizada
