### PR TITLE
Feature/frontend share social linking

### DIFF
--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -2,25 +2,24 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feat/frontend-google-login`
+Rama de trabajo actual: `feature/frontend-share-social-linking`
 
 ### Objetivo
 
-Conectar el flujo de login/registro del frontend con Google OAuth del backend y cerrar el circuito de callback para iniciar sesion real.
+Ajustar la vista de compartir clips para preparar vinculacion futura de redes sociales, mejorar responsive en tablet/desktop y dejar la experiencia lista para integrar endpoints de publicacion.
 
 ### Cambios implementados en curso
 
-- Se activaron los botones de Google en `frontend/src/app/auth/login/page.tsx` y `frontend/src/app/auth/register/page.tsx` para pedir la URL de OAuth al backend, guardar `state` en `sessionStorage` y redirigir al proveedor.
-- Se agregaron metodos en `frontend/src/services/authApi.ts` para `getGoogleAuthUrl` y `googleCallback`.
-- Se incorporo `completeGoogleAuth` en `frontend/src/store/useAuthStore.ts` para cerrar sesion local de forma consistente con login/register por email.
-- Se creo la pantalla `frontend/src/app/auth/callback/page.tsx` para validar `code/state`, ejecutar el callback contra backend y redirigir a `/app` al autenticar.
-- Se corrigio la pantalla de callback para evitar falsos negativos de `state invalido` en desarrollo (doble ejecucion de efectos por `reactStrictMode`) procesando cada `code` una sola vez y limpiando `sessionStorage` al finalizar autenticacion.
-- Se ajusto la ruta `auth/callback` para produccion (Next 16): se separo en componente cliente + `Suspense` en `page.tsx`, evitando el error de build por `useSearchParams()` fuera de boundary.
+- Se actualizaron acciones por red en `frontend/src/app/app/share/[clipId]/page.tsx` con estado de vinculacion local por plataforma (`Vincular cuenta` / `Vinculada`) para dejar listo el punto de integracion con OAuth/backend.
+- Se agrego accion `Publicar clip` condicionada a cuenta vinculada como placeholder funcional del flujo futuro centralizado de publicacion.
+- Se mejoro el layout responsive de compartir: el preview de video deja de crecer en exceso en tablet y la columna de redes queda mejor distribuida en desktop sin huecos visuales.
+- Se incorporo `YouTube` al listado de plataformas objetivo para futuros endpoints de publicacion.
+- Se corrigio el 404 de favicon agregando `frontend/src/app/icon.svg` y metadata de iconos en `frontend/src/app/layout.tsx`.
 
 ### Commits de esta rama (frontend)
 
-- `feat(frontend): integrate google oauth login and callback flow`
-- `docs(worklog): update frontend log and add backend handoff notes`
+- `feat(frontend): polish share UI and stage social account linking`
+- `docs(frontend): update worklog for share social linking branch`
 
 ### Validaciones locales
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -15,10 +15,12 @@ Ajustar la vista de compartir clips para preparar vinculacion futura de redes so
 - Se mejoro el layout responsive de compartir: el preview de video deja de crecer en exceso en tablet y la columna de redes queda mejor distribuida en desktop sin huecos visuales.
 - Se incorporo `YouTube` al listado de plataformas objetivo para futuros endpoints de publicacion.
 - Se corrigio el 404 de favicon agregando `frontend/src/app/icon.svg` y metadata de iconos en `frontend/src/app/layout.tsx`.
+- Se aplicaron animaciones coherentes con el resto del dashboard en la pantalla de compartir (`animate-fade-up`, `animate-drift`, stagger por tarjeta y hover refinado) para mejorar continuidad visual.
 
 ### Commits de esta rama (frontend)
 
 - `feat(frontend): polish share UI and stage social account linking`
+- `feat(frontend): add motion polish to clip share experience`
 - `docs(frontend): update worklog for share social linking branch`
 
 ### Validaciones locales

--- a/frontend/src/app/app/share/[clipId]/page.tsx
+++ b/frontend/src/app/app/share/[clipId]/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/src/components/ui/Button";
 import { Panel } from "@/src/components/ui/Panel";
 import { videoApi, type UserClipItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
-import { Facebook, Instagram, MessageCircle, Music2, Share2 } from "lucide-react";
+import { Facebook, Instagram, MessageCircle, Music2, Share2, Youtube } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { type ComponentType, useEffect, useState } from "react";
@@ -19,6 +19,7 @@ const socialTargets: SocialTarget[] = [
   { id: "instagram", label: "Instagram", icon: Instagram },
   { id: "tiktok", label: "TikTok", icon: Music2 },
   { id: "facebook", label: "Facebook", icon: Facebook },
+  { id: "youtube", label: "YouTube", icon: Youtube },
   { id: "x", label: "X", icon: Share2 },
   { id: "whatsapp", label: "WhatsApp", icon: MessageCircle }
 ];
@@ -42,6 +43,7 @@ export default function ShareClipPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
+  const [linkedTargets, setLinkedTargets] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     if (!token) {
@@ -106,12 +108,17 @@ export default function ShareClipPage() {
         ) : null}
 
         {!isLoading && !error && clip ? (
-          <div className="mt-5 grid gap-5 xl:grid-cols-[1.1fr_0.9fr]">
+          <div className="mt-5 grid gap-5 lg:grid-cols-[1.05fr_0.95fr]">
             <div className="rounded-2xl border border-white/10 bg-night-900/70 p-4">
               {clip.output_path ? (
-                <video controls preload="metadata" className="aspect-[9/13] w-full rounded-xl border border-white/10 object-cover" src={clip.output_path} />
+                <video
+                  controls
+                  preload="metadata"
+                  className="mx-auto aspect-[9/13] w-full max-w-[320px] rounded-xl border border-white/10 object-cover sm:max-w-[380px] lg:max-w-none"
+                  src={clip.output_path}
+                />
               ) : (
-                <div className="grid aspect-[9/13] place-items-center rounded-xl border border-white/10 bg-night-800/80 text-sm text-white/65">
+                <div className="mx-auto grid aspect-[9/13] w-full max-w-[320px] place-items-center rounded-xl border border-white/10 bg-night-800/80 text-sm text-white/65 sm:max-w-[380px] lg:max-w-none">
                   El clip todavia no tiene preview disponible.
                 </div>
               )}
@@ -126,19 +133,46 @@ export default function ShareClipPage() {
             <div className="space-y-3">
               {socialTargets.map((target) => {
                 const Icon = target.icon;
+                const isLinked = Boolean(linkedTargets[target.id]);
                 return (
                   <div key={target.id} className="rounded-xl border border-white/12 bg-white/5 p-3">
-                    <div className="flex items-center justify-between gap-3">
-                      <p className="inline-flex items-center gap-2 text-sm font-semibold text-white">
-                        <Icon size={16} className="text-neon-mint" />
-                        {target.label}
-                      </p>
-                      <Button
-                        className="w-auto px-3 py-2 text-xs"
-                        onClick={() => setInfo(`Flujo de subida a ${target.label} preparado. Integramos API en el siguiente paso.`)}
-                      >
-                        Subir
-                      </Button>
+                    <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
+                      <div>
+                        <p className="inline-flex items-center gap-2 text-sm font-semibold text-white">
+                          <Icon size={16} className="text-neon-mint" />
+                          {target.label}
+                        </p>
+                        <p className="mt-1 text-xs text-white/65">{isLinked ? "Cuenta vinculada" : "Cuenta pendiente de vincular"}</p>
+                      </div>
+                      <div className="grid grid-cols-2 gap-2 sm:min-w-[260px]">
+                        <Button
+                          className="h-9 px-3 py-2 text-xs"
+                          variant={isLinked ? "neutral" : "violet"}
+                          onClick={() => {
+                            if (isLinked) {
+                              setInfo(`Tu cuenta de ${target.label} ya esta vinculada en este entorno de demo.`);
+                              return;
+                            }
+
+                            setLinkedTargets((previous) => ({
+                              ...previous,
+                              [target.id]: true
+                            }));
+                            setInfo(
+                              `Marcamos ${target.label} como vinculada. Cuando backend exponga endpoints, este boton abrira OAuth real para conectar la cuenta.`
+                            );
+                          }}
+                        >
+                          {isLinked ? "Vinculada" : "Vincular cuenta"}
+                        </Button>
+                        <Button
+                          className="h-9 px-3 py-2 text-xs"
+                          disabled={!isLinked}
+                          onClick={() => setInfo(`Publicacion en ${target.label} preparada. En cuanto tengamos endpoint, esta accion publicara el clip.`)}
+                        >
+                          Publicar clip
+                        </Button>
+                      </div>
                     </div>
                   </div>
                 );

--- a/frontend/src/app/app/share/[clipId]/page.tsx
+++ b/frontend/src/app/app/share/[clipId]/page.tsx
@@ -94,12 +94,17 @@ export default function ShareClipPage() {
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-      <Panel className="border-neon-mint/25 bg-gradient-to-r from-night-900 via-night-800/80 to-night-900 p-5 sm:p-6">
-        <p className="text-xs uppercase tracking-[0.25em] text-neon-mint/75">compartir clip</p>
-        <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Publicacion por red social</h1>
-        <p className="mt-2 text-sm text-white/70">
-          Desde esta pantalla podras conectar la subida individual de un clip para cada red. Por ahora dejamos el flujo preparado.
-        </p>
+      <Panel className="relative overflow-hidden border-neon-mint/25 bg-gradient-to-r from-night-900 via-night-800/80 to-night-900 p-5 sm:p-6">
+        <div className="pointer-events-none absolute -right-14 -top-20 h-52 w-52 animate-drift rounded-full bg-neon-cyan/12 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-20 -left-10 h-52 w-52 animate-drift rounded-full bg-neon-violet/12 blur-3xl [animation-delay:400ms]" />
+
+        <div className="relative animate-fade-up">
+          <p className="text-xs uppercase tracking-[0.25em] text-neon-mint/75">compartir clip</p>
+          <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Publicacion por red social</h1>
+          <p className="mt-2 text-sm text-white/70">
+            Desde esta pantalla podras conectar la subida individual de un clip para cada red. Por ahora dejamos el flujo preparado.
+          </p>
+        </div>
 
         {isLoading ? <p className="mt-4 text-sm text-white/70">Cargando clip...</p> : null}
 
@@ -109,7 +114,7 @@ export default function ShareClipPage() {
 
         {!isLoading && !error && clip ? (
           <div className="mt-5 grid gap-5 lg:grid-cols-[1.05fr_0.95fr]">
-            <div className="rounded-2xl border border-white/10 bg-night-900/70 p-4">
+            <div className="animate-fade-up rounded-2xl border border-white/10 bg-night-900/70 p-4 [animation-delay:90ms]">
               {clip.output_path ? (
                 <video
                   controls
@@ -131,11 +136,15 @@ export default function ShareClipPage() {
             </div>
 
             <div className="space-y-3">
-              {socialTargets.map((target) => {
+              {socialTargets.map((target, index) => {
                 const Icon = target.icon;
                 const isLinked = Boolean(linkedTargets[target.id]);
                 return (
-                  <div key={target.id} className="rounded-xl border border-white/12 bg-white/5 p-3">
+                  <div
+                    key={target.id}
+                    className="animate-fade-up rounded-xl border border-white/12 bg-white/5 p-3 transition duration-300 hover:border-neon-cyan/30 hover:bg-white/7"
+                    style={{ animationDelay: `${160 + index * 60}ms` }}
+                  >
                     <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
                       <div>
                         <p className="inline-flex items-center gap-2 text-sm font-semibold text-white">
@@ -178,10 +187,14 @@ export default function ShareClipPage() {
                 );
               })}
 
-              {info ? <p className="rounded-xl border border-neon-cyan/35 bg-neon-cyan/10 px-3 py-2 text-xs text-neon-cyan">{info}</p> : null}
+              {info ? (
+                <p className="animate-fade-up rounded-xl border border-neon-cyan/35 bg-neon-cyan/10 px-3 py-2 text-xs text-neon-cyan [animation-delay:260ms]">
+                  {info}
+                </p>
+              ) : null}
               <Link
                 href="/app/library"
-                className="inline-flex items-center gap-2 rounded-lg border border-white/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.15em] text-white/80 transition hover:border-white/40 hover:text-white"
+                className="animate-fade-up inline-flex items-center gap-2 rounded-lg border border-white/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.15em] text-white/80 transition hover:border-white/40 hover:text-white [animation-delay:320ms]"
               >
                 Volver a biblioteca
               </Link>

--- a/frontend/src/app/icon.svg
+++ b/frontend/src/app/icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Hacelo Corto">
+  <defs>
+    <linearGradient id="g1" x1="6" y1="6" x2="58" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#89B4FA" />
+      <stop offset="0.55" stop-color="#89DCEB" />
+      <stop offset="1" stop-color="#CBA6F7" />
+    </linearGradient>
+    <linearGradient id="g2" x1="58" y1="6" x2="6" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F5C2E7" />
+      <stop offset="0.55" stop-color="#89DCEB" />
+      <stop offset="1" stop-color="#A6E3A1" />
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="24" fill="none" stroke="url(#g1)" stroke-width="5" />
+  <path d="M29 23 L29 41 L43 32 Z" fill="url(#g2)" />
+  <path d="M19 45 L45 19" stroke="url(#g1)" stroke-width="4" stroke-linecap="round" />
+  <circle cx="19" cy="45" r="3.5" fill="#1E1E2E" stroke="url(#g2)" stroke-width="2" />
+  <circle cx="45" cy="19" r="3.5" fill="#1E1E2E" stroke="url(#g2)" stroke-width="2" />
+</svg>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,7 +4,10 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Hacelo Corto",
-  description: "Landing publica del equipo frontend"
+  description: "Landing publica del equipo frontend",
+  icons: {
+    icon: "/icon.svg"
+  }
 };
 
 type RootLayoutProps = {


### PR DESCRIPTION
# Frontend PR

Rama de trabajo actual: `feature/frontend-share-social-linking`

## Objetivo

Ajustar la vista de compartir clips para preparar vinculacion futura de redes sociales, mejorar responsive en tablet/desktop y dejar la experiencia lista para integrar endpoints de publicacion.

## Cambios implementados en curso

- Se actualizaron acciones por red en `frontend/src/app/app/share/[clipId]/page.tsx` con estado de vinculacion local por plataforma (`Vincular cuenta` / `Vinculada`) para dejar listo el punto de integracion con OAuth/backend.
- Se agrego accion `Publicar clip` condicionada a cuenta vinculada como placeholder funcional del flujo futuro centralizado de publicacion.
- Se mejoro el layout responsive de compartir: el preview de video deja de crecer en exceso en tablet y la columna de redes queda mejor distribuida en desktop sin huecos visuales.
- Se incorporo `YouTube` al listado de plataformas objetivo para futuros endpoints de publicacion.
- Se corrigio el 404 de favicon agregando `frontend/src/app/icon.svg` y metadata de iconos en `frontend/src/app/layout.tsx`.
- Se aplicaron animaciones coherentes con el resto del dashboard en la pantalla de compartir (`animate-fade-up`, `animate-drift`, stagger por tarjeta y hover refinado) para mejorar continuidad visual.

## Commits de esta rama (frontend)

- `feat(frontend): polish share UI and stage social account linking`
- `feat(frontend): add motion polish to clip share experience`
- `docs(frontend): update worklog for share social linking branch`

## Validaciones locales

Ejecutado en `frontend/`:

- `npm run lint` -> OK