### PR TITLE
fixed timestamp - migra a server_default+timezone

### DIFF
--- a/backend/api/alembic/versions/a2b3c4d5e6f7_timestamp_tz.py
+++ b/backend/api/alembic/versions/a2b3c4d5e6f7_timestamp_tz.py
@@ -1,0 +1,71 @@
+"""Update TimestampMixin to use timezone and server_default
+
+Revision ID: a2b3c4d5e6f7_timestamp_tz
+Revises: e7a3cf1c3a43
+Create Date: 2026-02-28 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import func
+
+
+revision = 'a2b3c4d5e6f7_timestamp_tz'
+down_revision = 'e7a3cf1c3a43'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade: Add timezone support and server defaults to all timestamp columns."""
+    
+    # List of tables that have created_at and updated_at columns
+    tables = ['users', 'profiles', 'videos', 'audios', 'jobs', 'oauth_tokens']
+    
+    for table in tables:
+        # Update created_at column
+        op.alter_column(
+            table, 'created_at',
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=False,
+            server_default=func.now(),
+            existing_server_default=None,
+        )
+        
+        # Update updated_at column
+        op.alter_column(
+            table, 'updated_at',
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=False,
+            server_default=func.now(),
+            existing_server_default=None,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade: Revert timezone support and server defaults."""
+    
+    tables = ['users', 'profiles', 'videos', 'audios', 'jobs', 'oauth_tokens']
+    
+    for table in tables:
+        # Revert created_at column
+        op.alter_column(
+            table, 'created_at',
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=False,
+            existing_server_default=func.now(),
+            server_default=None,
+        )
+        
+        # Revert updated_at column
+        op.alter_column(
+            table, 'updated_at',
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=False,
+            existing_server_default=func.now(),
+            server_default=None,
+        )

--- a/backend/api/app/models/base.py
+++ b/backend/api/app/models/base.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 from uuid import uuid4
 from sqlalchemy import Column, DateTime
+from sqlalchemy.sql import func
 from sqlalchemy.dialects.postgresql import UUID
 
 class UUIDAsPrimaryKeyMixin:
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
 
 class TimestampMixin:
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=datetime.utcnow, nullable=False)


### PR DESCRIPTION
Deuda tecnica punto numero 4:
Uso de TimestampMixin
Solucionado:

server_default=func.now() # ← la DB decide la hora

Ahora:

Todos los campos created_at y updated_at tienen timezone=True
Usan server_default=func.now() (el tiempo lo define la BD, no Python)
Soportan arquitectura distribuida con múltiples contenedores
Evita drift de reloj entre instancias