### PR TITLE
Feat/frontend auto2 audio progress clean

### DIFF
--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from sqlalchemy import String, cast
 from sqlalchemy.orm import Session
 from urllib.parse import unquote, urlparse
@@ -14,7 +14,7 @@ from app.schemas.job import (
     UserClipDetailResponse,
     UserClipsResponse,
     UserClipItem,
-    JobAddAudioResponse
+    JobAddAudioResponse,
 )
 
 from app.services.queue_service import QueueService
@@ -30,15 +30,16 @@ logger = setup_logging()
 
 MIN_VIDEO_DURATION_SECS = 5
 
+
 class JobService:
     """Servicio de Jobs - Persiste un Job, luego envia mensaje a Redis"""
 
-
-    def __init__(self, db: Session, queue: QueueService, storage_service: StorageService):
+    def __init__(
+        self, db: Session, queue: QueueService, storage_service: StorageService
+    ):
         self.db = db
         self.queue = queue
         self.storage = storage_service
-
 
     def _extract_storage_path(self, output_path: str | None) -> str | None:
         if not output_path:
@@ -55,8 +56,35 @@ class JobService:
 
         return f"s3://{unquote(normalized_path)}"
 
-    
-    def _resolve_output_urls(self, output_path: dict[str, str] | None) -> dict[str, str] | None:
+    def _extract_storage_paths(
+        self, output_path: dict[str, Any] | str | None
+    ) -> list[str]:
+        if not output_path:
+            return []
+
+        if isinstance(output_path, str):
+            normalized = self._extract_storage_path(output_path)
+            return [normalized] if normalized else []
+
+        if not isinstance(output_path, dict):
+            return []
+
+        values = [output_path.get("video"), output_path.get("subtitles")]
+        result: list[str] = []
+
+        for value in values:
+            if not isinstance(value, str):
+                continue
+
+            normalized = self._extract_storage_path(value)
+            if normalized:
+                result.append(normalized)
+
+        return list(dict.fromkeys(result))
+
+    def _resolve_output_urls(
+        self, output_path: dict[str, str] | None
+    ) -> dict[str, str] | None:
         """
         Convierte todas las rutas S3 de un output_path JSON a URLs públicas presignadas.
         output_path: dict con keys como "video", "subtitles", etc. y valores S3 paths.
@@ -95,13 +123,14 @@ class JobService:
                 continue
 
             try:
-                resolved[key] = self.storage.get_video_public_url(storage_path, expires_in=3600)
+                resolved[key] = self.storage.get_video_public_url(
+                    storage_path, expires_in=3600
+                )
             except Exception as exc:
                 logger.warning(f"No se pudo generar URL pública para '{key}': {exc}")
                 resolved[key] = value
 
         return resolved
-
 
     def get_job_status(self, job_id: UUID, user_id: UUID) -> JobStatusResponse:
         job = (
@@ -117,7 +146,6 @@ class JobService:
             output_path=self._resolve_output_urls(job.output_path),
         )
 
-
     def _get_user_video(self, video_id: UUID, user_id: UUID) -> Video:
         video = (
             self.db.query(Video)
@@ -129,7 +157,6 @@ class JobService:
             raise NotFoundException("Video not found")
 
         return video
-    
 
     def _get_user_audio(self, audio_id: UUID, user_id: UUID) -> Audio:
         audio = (
@@ -143,11 +170,14 @@ class JobService:
 
         return audio
 
-
     def _validate_time_range(self, start_sec: int, end_sec: int) -> None:
-        if start_sec < 0 or start_sec > end_sec or end_sec <= 0 or (end_sec - start_sec) < MIN_VIDEO_DURATION_SECS:
+        if (
+            start_sec < 0
+            or start_sec > end_sec
+            or end_sec <= 0
+            or (end_sec - start_sec) < MIN_VIDEO_DURATION_SECS
+        ):
             raise JobParameterException()
-
 
     def _create_reframe_job(
         self,
@@ -161,9 +191,9 @@ class JobService:
         content_profile: Literal["auto", "interview", "sports", "music"] = "auto",
         job_type: JobType = JobType.REFRAME,
         watermark: str | None,
-        subtitles: str | None
+        subtitles: str | None,
     ) -> JobReframeResponse:
-        
+
         self._validate_time_range(start_sec, end_sec)
 
         if watermark is None:
@@ -213,7 +243,7 @@ class JobService:
                     output_style=output_style,
                     content_profile=content_profile,
                     watermark=watermark,
-                    subtitles=subtitles
+                    subtitles=subtitles,
                 )
             except Exception as e:
                 existing_job.status = JobStatus.FAILED
@@ -252,7 +282,7 @@ class JobService:
                 output_style=output_style,
                 content_profile=content_profile,
                 watermark=watermark,
-                subtitles=subtitles
+                subtitles=subtitles,
             )
         except Exception as e:
             job.status = JobStatus.FAILED
@@ -270,7 +300,6 @@ class JobService:
             created_at=job.created_at,
         )
 
-
     def _create_auto_reframe_job(
         self,
         *,
@@ -283,9 +312,9 @@ class JobService:
         content_profile: Literal["auto", "interview", "sports", "music"] = "auto",
         job_type: JobType = JobType.AUTO_REFRAME,
         watermark: str | None,
-        subtitles: bool | None
-    ) -> JobReframeResponse:    
-        
+        subtitles: bool | None,
+    ) -> JobReframeResponse:
+
         if not clips_count or clips_count < 1:
             raise JobParameterException("clips_count must be at least 1")
         if clip_duration_sec is not None and clip_duration_sec < 5:
@@ -294,7 +323,7 @@ class JobService:
             watermark = "Hacelo Corto"
         if subtitles is None:
             subtitles = False
-        
+
         job = Job(
             user_id=user_id,
             video_id=video.id,
@@ -315,7 +344,7 @@ class JobService:
                 clip_duration_sec=clip_duration_sec,
                 output_style=output_style,
                 content_profile=content_profile,
-                watermark=watermark
+                watermark=watermark,
             )
         except Exception as e:
             job.status = JobStatus.FAILED
@@ -332,7 +361,6 @@ class JobService:
             created_at=job.created_at,
         )
 
-
     def reframe_video(
         self,
         video_id: UUID,
@@ -347,9 +375,8 @@ class JobService:
         output_style: Literal["vertical", "speaker_split"] = "vertical",
         content_profile: Literal["auto", "interview", "sports", "music"] = "auto",
         watermark: str | None = None,
-        
     ) -> JobReframeResponse:
-        
+
         video = self._get_user_video(video_id, user_id)
 
         self._validate_time_range(start_sec, end_sec)
@@ -366,9 +393,8 @@ class JobService:
             content_profile=content_profile,
             job_type=job_type,
             watermark=watermark,
-            subtitles=subtitles
+            subtitles=subtitles,
         )
-
 
     def auto_reframe_video2(
         self,
@@ -380,12 +406,14 @@ class JobService:
         output_style: Literal["vertical", "speaker_split"] = "vertical",
         content_profile: Literal["auto", "interview", "sports", "music"] = "auto",
         watermark: str | None = None,
-        subtitles: str | None = None
+        subtitles: str | None = None,
     ) -> JobReframeResponse:
-        
+
         video = self._get_user_video(video_id, user_id)
 
-        logger.info(f"AUTO_REFRAME for video: {video_id}, job_type: {JobType.AUTO_REFRAME}")
+        logger.info(
+            f"AUTO_REFRAME for video: {video_id}, job_type: {JobType.AUTO_REFRAME}"
+        )
 
         return self._create_auto_reframe_job(
             video=video,
@@ -397,9 +425,8 @@ class JobService:
             content_profile=content_profile,
             job_type=JobType.AUTO_REFRAME,
             watermark=watermark,
-            subtitles=subtitles
+            subtitles=subtitles,
         )
-
 
     def list_user_clips(
         self, user_id: UUID, limit: int = 20, offset: int = 0, query: str | None = None
@@ -441,7 +468,6 @@ class JobService:
 
         return UserClipsResponse(total=total, limit=limit, offset=offset, clips=clips)
 
-
     def get_user_clip(self, job_id: UUID, user_id: UUID) -> UserClipDetailResponse:
         row = (
             self.db.query(Job, Video)
@@ -468,7 +494,6 @@ class JobService:
         )
         return UserClipDetailResponse(clip=clip)
 
-
     def delete_user_clip(self, job_id: UUID, user_id: UUID) -> None:
         job = (
             self.db.query(Job)
@@ -484,8 +509,8 @@ class JobService:
             raise NotFoundException("Clip no encontrado")
 
         if job.output_path:
-            storage_path = self._extract_storage_path(job.output_path)
-            if storage_path:
+            storage_paths = self._extract_storage_paths(job.output_path)
+            for storage_path in storage_paths:
                 self.storage.delete_video_from_storage(storage_path)
 
         try:
@@ -494,15 +519,14 @@ class JobService:
         except Exception as exc:
             self.db.rollback()
             raise VideoDBException("Error eliminando clip", str(exc))
-        
-    
+
     def update_status(
         self,
         job_id: UUID,
         status: JobStatus,
         error_message: str | None = None,
         video_path: Optional[str] = None,
-        subtitles_path: Optional[str] = None
+        subtitles_path: Optional[str] = None,
     ) -> bool:
         try:
             job = self.db.query(Job).filter(Job.id == job_id).first()
@@ -511,10 +535,11 @@ class JobService:
                 return False
 
             # Crear output_path como dict JSON solo con lo que exista
-            output_path = {k: v for k, v in {
-                "video": video_path,
-                "subtitles": subtitles_path
-            }.items() if v is not None}
+            output_path = {
+                k: v
+                for k, v in {"video": video_path, "subtitles": subtitles_path}.items()
+                if v is not None
+            }
 
             job.status = status
             job.error_message = error_message or None
@@ -526,15 +551,13 @@ class JobService:
         except Exception as exc:
             self.db.rollback()
             logger.error(f"❌ Could not persist state for job {job_id}: {exc}")
-            return False      
-        
+            return False
 
     def get_by_id(self, job_id: UUID) -> Job:
         job = self.db.query(Job).filter(Job.id == job_id).first()
         if not job:
             raise NotFoundException("Job not found")
         return job
-
 
     def add_audio_to_video(
         self,
@@ -544,8 +567,9 @@ class JobService:
         audio_offset_sec: int,
         audio_start_sec: int,
         audio_end_sec: int,
-        audio_volume: float) -> JobAddAudioResponse:
-        
+        audio_volume: float,
+    ) -> JobAddAudioResponse:
+
         self._validate_time_range(audio_start_sec, audio_end_sec)
 
         video = self._get_user_video(video_id, user_id)
@@ -576,7 +600,7 @@ class JobService:
                 filename=video.original_filename,
                 audio_filename=audio.original_filename,
                 audio_volume=audio_volume,
-                created_at=existing_job.created_at
+                created_at=existing_job.created_at,
             )
 
         if existing_job:
@@ -593,7 +617,7 @@ class JobService:
                     audio_offset_sec=audio_offset_sec,
                     audio_start_sec=audio_start_sec,
                     audio_end_sec=audio_end_sec,
-                    audio_volume=audio_volume
+                    audio_volume=audio_volume,
                 )
             except Exception as e:
                 existing_job.status = JobStatus.FAILED
@@ -608,7 +632,7 @@ class JobService:
                 filename=video.original_filename,
                 audio_filename=audio.original_filename,
                 audio_volume=audio_volume,
-                created_at=existing_job.created_at
+                created_at=existing_job.created_at,
             )
 
         job = Job(
@@ -632,7 +656,7 @@ class JobService:
                 audio_offset_sec=audio_offset_sec,
                 audio_start_sec=audio_start_sec,
                 audio_end_sec=audio_end_sec,
-                audio_volume=audio_volume
+                audio_volume=audio_volume,
             )
         except Exception as e:
             job.status = JobStatus.FAILED
@@ -641,11 +665,11 @@ class JobService:
             raise e
 
         return JobAddAudioResponse(
-                job_id=job.id,
-                job_type=job.job_type,
-                status=job.status,
-                filename=video.original_filename,
-                audio_filename=audio.original_filename,
-                audio_volume=audio_volume,
-                created_at=job.created_at
-            )
+            job_id=job.id,
+            job_type=job.job_type,
+            status=job.status,
+            filename=video.original_filename,
+            audio_filename=audio.original_filename,
+            audio_volume=audio_volume,
+            created_at=job.created_at,
+        )

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -17,6 +17,7 @@ Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos
 - Se aplico fix local en `backend/api/app/services/job_service.py` para eliminar clips cuando `output_path` llega como JSON (`video` + `subtitles`) y evitar fallos al borrar assets.
 - Ajuste de frontend: se validan limites de duracion antes de llamar `add-audio` para no enviar segmentos que excedan el largo del video destino.
 - Se consumen desde frontend los endpoints ya disponibles de YouTube (`GET /api/v1/youtube/status`, `POST /api/v1/youtube/publish/{job_id}`) para pasar de modo demo a flujo real de publicacion.
+- Ajuste de consumo frontend: la vista Share ahora usa `GET /api/v1/jobs/{job_id}` para resolver clip puntual y evitar dependencia de filtros en listados.
 
 ### Commits de esta rama (backend)
 

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -16,6 +16,7 @@ Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos
 - Se movio en frontend el uso de `add-audio` hacia una pantalla dedicada `Audio editor` (sin cambios adicionales de backend requeridos).
 - Se aplico fix local en `backend/api/app/services/job_service.py` para eliminar clips cuando `output_path` llega como JSON (`video` + `subtitles`) y evitar fallos al borrar assets.
 - Ajuste de frontend: se validan limites de duracion antes de llamar `add-audio` para no enviar segmentos que excedan el largo del video destino.
+- Se consumen desde frontend los endpoints ya disponibles de YouTube (`GET /api/v1/youtube/status`, `POST /api/v1/youtube/publish/{job_id}`) para pasar de modo demo a flujo real de publicacion.
 
 ### Commits de esta rama (backend)
 

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -18,6 +18,7 @@ Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos
 - Ajuste de frontend: se validan limites de duracion antes de llamar `add-audio` para no enviar segmentos que excedan el largo del video destino.
 - Se consumen desde frontend los endpoints ya disponibles de YouTube (`GET /api/v1/youtube/status`, `POST /api/v1/youtube/publish/{job_id}`) para pasar de modo demo a flujo real de publicacion.
 - Ajuste de consumo frontend: la vista Share ahora usa `GET /api/v1/jobs/{job_id}` para resolver clip puntual y evitar dependencia de filtros en listados.
+- En esta iteracion no hubo cambios de codigo backend; solo se incorporo un asset de demo en frontend para landing.
 
 ### Commits de esta rama (backend)
 

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -6,22 +6,22 @@ Rama de trabajo actual: `feat/frontend-auto2-audio-progress-clean`
 
 ### Objetivo
 
-Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos/watermark y soporte de audios, sin introducir cambios de codigo backend en esta rama.
+Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos/watermark y soporte de audios, incluyendo fix minimo en `delete clip` para contratos `output_path` JSON.
 
 ### Cambios implementados en curso
 
-- No se aplicaron cambios de codigo en `backend/` durante esta rama; el alcance fue frontend.
 - Se valido que el frontend ya no consuma el endpoint eliminado `POST /api/v1/jobs/reframe/{video_id}/auto` y quede alineado con `POST /api/v1/jobs/reframe/{video_id}/auto2`.
-- Se documenta dependencia a confirmar con backend: exponer/estabilizar preview de audios (URL presignada por item) para reducir llamadas cliente-a-cliente cuando crezca la biblioteca.
-- Se documenta dependencia funcional: endpoint `POST /api/v1/jobs/add-audio/{video_id}` aun no esta cableado en el flujo UI (queda para siguiente iteracion front+back).
+- Se cableo en frontend el endpoint `POST /api/v1/jobs/add-audio/{video_id}` para iniciar jobs de mezcla de audio desde Timeline.
+- Se cableo en frontend el endpoint `POST /api/v1/videos/from-job/{job_id}` para importar resultados de jobs como videos editables.
+- Se aplico fix local en `backend/api/app/services/job_service.py` para eliminar clips cuando `output_path` llega como JSON (`video` + `subtitles`) y evitar fallos al borrar assets.
 
 ### Commits de esta rama (backend)
 
-- Sin commits backend en esta rama.
+- `fix(backend): support deleting clips with json output_path`
 
 ### Validaciones locales
 
-No aplica (sin cambios backend).
+- Verificacion manual del flujo `DELETE /api/v1/jobs/{job_id}` con `output_path` JSON (sin excepciones de tipo y borrado correcto de assets asociados).
 
 ## Objetivo
 

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -15,6 +15,7 @@ Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos
 - Se cableo en frontend el endpoint `POST /api/v1/videos/from-job/{job_id}` para importar resultados de jobs como videos editables.
 - Se movio en frontend el uso de `add-audio` hacia una pantalla dedicada `Audio editor` (sin cambios adicionales de backend requeridos).
 - Se aplico fix local en `backend/api/app/services/job_service.py` para eliminar clips cuando `output_path` llega como JSON (`video` + `subtitles`) y evitar fallos al borrar assets.
+- Ajuste de frontend: se validan limites de duracion antes de llamar `add-audio` para no enviar segmentos que excedan el largo del video destino.
 
 ### Commits de esta rama (backend)
 

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -2,7 +2,7 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feat/frontend-auto2-audio-progress`
+Rama de trabajo actual: `feat/frontend-auto2-audio-progress-clean`
 
 ### Objetivo
 

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -13,6 +13,7 @@ Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos
 - Se valido que el frontend ya no consuma el endpoint eliminado `POST /api/v1/jobs/reframe/{video_id}/auto` y quede alineado con `POST /api/v1/jobs/reframe/{video_id}/auto2`.
 - Se cableo en frontend el endpoint `POST /api/v1/jobs/add-audio/{video_id}` para iniciar jobs de mezcla de audio desde Timeline.
 - Se cableo en frontend el endpoint `POST /api/v1/videos/from-job/{job_id}` para importar resultados de jobs como videos editables.
+- Se movio en frontend el uso de `add-audio` hacia una pantalla dedicada `Audio editor` (sin cambios adicionales de backend requeridos).
 - Se aplico fix local en `backend/api/app/services/job_service.py` para eliminar clips cuando `output_path` llega como JSON (`video` + `subtitles`) y evitar fallos al borrar assets.
 
 ### Commits de esta rama (backend)

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -1,5 +1,28 @@
 # Backend PR Worklog
 
+## Seguimiento activo (rama actual)
+
+Rama de trabajo actual: `feat/frontend-auto2-audio-progress`
+
+### Objetivo
+
+Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos/watermark y soporte de audios, sin introducir cambios de codigo backend en esta rama.
+
+### Cambios implementados en curso
+
+- No se aplicaron cambios de codigo en `backend/` durante esta rama; el alcance fue frontend.
+- Se valido que el frontend ya no consuma el endpoint eliminado `POST /api/v1/jobs/reframe/{video_id}/auto` y quede alineado con `POST /api/v1/jobs/reframe/{video_id}/auto2`.
+- Se documenta dependencia a confirmar con backend: exponer/estabilizar preview de audios (URL presignada por item) para reducir llamadas cliente-a-cliente cuando crezca la biblioteca.
+- Se documenta dependencia funcional: endpoint `POST /api/v1/jobs/add-audio/{video_id}` aun no esta cableado en el flujo UI (queda para siguiente iteracion front+back).
+
+### Commits de esta rama (backend)
+
+- Sin commits backend en esta rama.
+
+### Validaciones locales
+
+No aplica (sin cambios backend).
+
 ## Objetivo
 
 Dejar documentado, paso a paso, que cambios necesita backend para que el login con Google funcione estable en local y no rompa el flujo de `/auth/callback` en frontend.

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -28,6 +28,7 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - Ajuste de biblioteca: se removio `Importar a Videos` en cards de clips y se priorizo navegacion directa a `Timeline` + `Audio editor`.
 - Se integro flujo real de YouTube en `frontend/src/app/app/share/[clipId]/page.tsx`: estado de conexion, CTA de conexion OAuth Google y publicacion real por `POST /api/v1/youtube/publish/{job_id}`.
 - Se agregaron en `frontend/src/services/videoApi.ts` los contratos para `GET /api/v1/youtube/status` y `POST /api/v1/youtube/publish/{job_id}`.
+- Hotfix share: se cambio la carga del clip a `GET /api/v1/jobs/{job_id}` (en lugar de busqueda por listado) y se agrego mensaje/reintento explicito para errores de red (`Failed to fetch`).
 
 ### Commits de esta rama (frontend)
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -2,32 +2,33 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feature/frontend-share-social-linking`
+Rama de trabajo actual: `feat/frontend-auto2-audio-progress`
 
 ### Objetivo
 
-Ajustar la vista de compartir clips para preparar vinculacion futura de redes sociales, mejorar responsive en tablet/desktop y dejar la experiencia lista para integrar endpoints de publicacion.
+Alinear el frontend con los cambios recientes de backend: dejar de usar el endpoint legacy `/auto`, exponer opciones nuevas de subtitulos/watermark, mostrar progreso real de creacion de clips y agregar soporte inicial de audios en Home + Library.
 
 ### Cambios implementados en curso
 
-- Se actualizaron acciones por red en `frontend/src/app/app/share/[clipId]/page.tsx` con estado de vinculacion local por plataforma (`Vincular cuenta` / `Vinculada`) para dejar listo el punto de integracion con OAuth/backend.
-- Se agrego accion `Publicar clip` condicionada a cuenta vinculada como placeholder funcional del flujo futuro centralizado de publicacion.
-- Se mejoro el layout responsive de compartir: el preview de video deja de crecer en exceso en tablet y la columna de redes queda mejor distribuida en desktop sin huecos visuales.
-- Se incorporo `YouTube` al listado de plataformas objetivo para futuros endpoints de publicacion.
-- Se corrigio el 404 de favicon agregando `frontend/src/app/icon.svg` y metadata de iconos en `frontend/src/app/layout.tsx`.
-- Se aplicaron animaciones coherentes con el resto del dashboard en la pantalla de compartir (`animate-fade-up`, `animate-drift`, stagger por tarjeta y hover refinado) para mejorar continuidad visual.
+- Se actualizo `frontend/src/services/videoApi.ts` para eliminar el fallback al endpoint removido `/api/v1/jobs/reframe/{video_id}/auto`; ahora Home usa solo `POST /auto2`.
+- Se ampliaron los payloads de jobs (auto y manual) para soportar `subtitles` y `watermark`, con UI de configuracion en Home y Timeline.
+- Se agrego seguimiento de avance real en Home (`ProjectStatusPanel`), mostrando porcentaje y conteo de jobs listos/en proceso/error durante la generacion de clips.
+- Se extendio la carga inicial para aceptar archivos de audio (`video/*,audio/*`) y se incorporaron endpoints de audios en `videoApi` (`upload`, `list`, `url`, `delete`).
+- Se agrego vista de `Audios` en `frontend/src/app/app/library/page.tsx` con busqueda, preview bajo demanda y eliminacion.
+- Se ajustaron mensajes de estado para diferenciar uploads de video/audio sin romper la experiencia de clips.
 
 ### Commits de esta rama (frontend)
 
-- `feat(frontend): polish share UI and stage social account linking`
-- `feat(frontend): add motion polish to clip share experience`
-- `docs(frontend): update worklog for share social linking branch`
+- `feat(frontend): sync auto2 flow, clip progress and audio library support`
+- `docs(frontend): log auto2 and audio frontend refresh`
 
 ### Validaciones locales
 
 Ejecutado en `frontend/`:
 
 - `npm run lint` -> OK
+- `npm run build` -> OK
+- `npm run test -- --run` -> OK
 
 ## Objetivo de la rama
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -24,6 +24,7 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - Se integro `POST /api/v1/videos/from-job/{job_id}` en `frontend/src/app/app/library/page.tsx` para importar clips como videos reeditables desde la biblioteca.
 - Se movio el flujo de mezcla a una nueva ruta dedicada `frontend/src/app/app/audio_editor/page.tsx` (selector de video + audio, parametros y visual de pistas), y Timeline ahora solo enlaza al nuevo editor.
 - Se agrego acceso directo desde biblioteca de clips a `Audio editor` con query params (`videoId`, `clipId`) para abrir el video correcto.
+- Fix UX: se acotaron pistas y campos del `Audio editor` a la duracion real del video/audio para evitar que el track se desborde visualmente o exceda el largo maximo permitido.
 
 ### Commits de esta rama (frontend)
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -29,6 +29,7 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - Se integro flujo real de YouTube en `frontend/src/app/app/share/[clipId]/page.tsx`: estado de conexion, CTA de conexion OAuth Google y publicacion real por `POST /api/v1/youtube/publish/{job_id}`.
 - Se agregaron en `frontend/src/services/videoApi.ts` los contratos para `GET /api/v1/youtube/status` y `POST /api/v1/youtube/publish/{job_id}`.
 - Hotfix share: se cambio la carga del clip a `GET /api/v1/jobs/{job_id}` (en lugar de busqueda por listado) y se agrego mensaje/reintento explicito para errores de red (`Failed to fetch`).
+- Se agrego asset de demo para landing en `frontend/public/landing-demos/video2_entrevista.mp4` para habilitar preview real en Home (`/landing-demos/video2_entrevista.mp4`).
 
 ### Commits de esta rama (frontend)
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -16,11 +16,19 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - Se extendio la carga inicial para aceptar archivos de audio (`video/*,audio/*`) y se incorporaron endpoints de audios en `videoApi` (`upload`, `list`, `url`, `delete`).
 - Se agrego vista de `Audios` en `frontend/src/app/app/library/page.tsx` con busqueda, preview bajo demanda y eliminacion.
 - Se ajustaron mensajes de estado para diferenciar uploads de video/audio sin romper la experiencia de clips.
+- Hotfix: se restauro normalizacion de `output_path` (cuando backend responde JSON) en `frontend/src/services/videoApi.ts` para evitar previews rotos con `src="[object Object]"`.
+- Se agrego en `frontend/src/app/app/timeline/page.tsx` el flujo de mezcla de audio sobre video: seleccion de audio, preview, parametros (`offset`, `start/end`, `volume`) y envio de job a `POST /api/v1/jobs/add-audio/{video_id}`.
+- Se incorporo polling de estado para jobs de mezcla de audio en Timeline y preview del output final cuando el backend devuelve `output_path`.
+- Se reforzo la visualizacion de avance en `frontend/src/components/home/ProjectStatusPanel.tsx` con barra segmentada por estados (listo/error/pendiente) y colores diferenciados.
+- Se rediseño la card de audio en `frontend/src/app/app/library/page.tsx` para que tenga look catppuccin (gradientes violeta/rosa, onda visual y reproductor de preview mas integrado al estilo actual).
+- Se integro `POST /api/v1/videos/from-job/{job_id}` en `frontend/src/app/app/library/page.tsx` para importar clips como videos reeditables desde la biblioteca.
 
 ### Commits de esta rama (frontend)
 
 - `feat(frontend): sync auto2 flow, clip progress and audio library support`
 - `docs(frontend): log auto2 and audio frontend refresh`
+- `feat(frontend): add timeline audio-mix workflow and segmented clip progress`
+- `feat(frontend): add import-from-job action in clips library`
 
 ### Validaciones locales
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -22,6 +22,8 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - Se reforzo la visualizacion de avance en `frontend/src/components/home/ProjectStatusPanel.tsx` con barra segmentada por estados (listo/error/pendiente) y colores diferenciados.
 - Se rediseño la card de audio en `frontend/src/app/app/library/page.tsx` para que tenga look catppuccin (gradientes violeta/rosa, onda visual y reproductor de preview mas integrado al estilo actual).
 - Se integro `POST /api/v1/videos/from-job/{job_id}` en `frontend/src/app/app/library/page.tsx` para importar clips como videos reeditables desde la biblioteca.
+- Se movio el flujo de mezcla a una nueva ruta dedicada `frontend/src/app/app/audio_editor/page.tsx` (selector de video + audio, parametros y visual de pistas), y Timeline ahora solo enlaza al nuevo editor.
+- Se agrego acceso directo desde biblioteca de clips a `Audio editor` con query params (`videoId`, `clipId`) para abrir el video correcto.
 
 ### Commits de esta rama (frontend)
 
@@ -29,6 +31,7 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - `docs(frontend): log auto2 and audio frontend refresh`
 - `feat(frontend): add timeline audio-mix workflow and segmented clip progress`
 - `feat(frontend): add import-from-job action in clips library`
+- `feat(frontend): move audio workflow into dedicated audio editor route`
 
 ### Validaciones locales
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -2,7 +2,7 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feat/frontend-auto2-audio-progress`
+Rama de trabajo actual: `feat/frontend-auto2-audio-progress-clean`
 
 ### Objetivo
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -26,6 +26,8 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - Se agrego acceso directo desde biblioteca de clips a `Audio editor` con query params (`videoId`, `clipId`) para abrir el video correcto.
 - Fix UX: se acotaron pistas y campos del `Audio editor` a la duracion real del video/audio para evitar que el track se desborde visualmente o exceda el largo maximo permitido.
 - Ajuste de biblioteca: se removio `Importar a Videos` en cards de clips y se priorizo navegacion directa a `Timeline` + `Audio editor`.
+- Se integro flujo real de YouTube en `frontend/src/app/app/share/[clipId]/page.tsx`: estado de conexion, CTA de conexion OAuth Google y publicacion real por `POST /api/v1/youtube/publish/{job_id}`.
+- Se agregaron en `frontend/src/services/videoApi.ts` los contratos para `GET /api/v1/youtube/status` y `POST /api/v1/youtube/publish/{job_id}`.
 
 ### Commits de esta rama (frontend)
 
@@ -34,6 +36,7 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - `feat(frontend): add timeline audio-mix workflow and segmented clip progress`
 - `feat(frontend): add import-from-job action in clips library`
 - `feat(frontend): move audio workflow into dedicated audio editor route`
+- `feat(frontend): connect share screen to real youtube publish endpoints`
 
 ### Validaciones locales
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -25,6 +25,7 @@ Alinear el frontend con los cambios recientes de backend: dejar de usar el endpo
 - Se movio el flujo de mezcla a una nueva ruta dedicada `frontend/src/app/app/audio_editor/page.tsx` (selector de video + audio, parametros y visual de pistas), y Timeline ahora solo enlaza al nuevo editor.
 - Se agrego acceso directo desde biblioteca de clips a `Audio editor` con query params (`videoId`, `clipId`) para abrir el video correcto.
 - Fix UX: se acotaron pistas y campos del `Audio editor` a la duracion real del video/audio para evitar que el track se desborde visualmente o exceda el largo maximo permitido.
+- Ajuste de biblioteca: se removio `Importar a Videos` en cards de clips y se priorizo navegacion directa a `Timeline` + `Audio editor`.
 
 ### Commits de esta rama (frontend)
 

--- a/frontend/src/app/app/audio_editor/page.tsx
+++ b/frontend/src/app/app/audio_editor/page.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
+import { Panel } from "@/src/components/ui/Panel";
+import { videoApi, type UserAudioItem, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
+import { useAuthStore } from "@/src/store/useAuthStore";
+import { Music2, Search } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+const PAGE_SIZE = 10;
+
+function normalizeVideoError(error: unknown, fallbackMessage: string) {
+  if (error instanceof VideoApiError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return fallbackMessage;
+}
+
+function isTerminalStatus(status: string) {
+  const normalized = status.toLowerCase();
+  return normalized === "done" || normalized === "completed" || normalized === "failed" || normalized === "error";
+}
+
+function isDoneStatus(status: string) {
+  const normalized = status.toLowerCase();
+  return normalized === "done" || normalized === "completed";
+}
+
+function toTimeLabel(seconds: number) {
+  const min = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const sec = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${min}:${sec}`;
+}
+
+export default function AudioEditorPage() {
+  const searchParams = useSearchParams();
+  const preferredVideoId = searchParams.get("videoId")?.trim() ?? "";
+  const preferredClipId = searchParams.get("clipId")?.trim() ?? "";
+  const token = useAuthStore((state) => state.token);
+
+  const [videos, setVideos] = useState<UserVideoItem[]>([]);
+  const [totalVideos, setTotalVideos] = useState(0);
+  const [page, setPage] = useState(1);
+  const [query, setQuery] = useState("");
+  const [isLoadingVideos, setIsLoadingVideos] = useState(true);
+  const [videoError, setVideoError] = useState<string | null>(null);
+  const [selectedVideoId, setSelectedVideoId] = useState<string | null>(null);
+  const [focusedClip, setFocusedClip] = useState<UserClipItem | null>(null);
+
+  const [audios, setAudios] = useState<UserAudioItem[]>([]);
+  const [isLoadingAudios, setIsLoadingAudios] = useState(false);
+  const [audioError, setAudioError] = useState<string | null>(null);
+  const [selectedAudioId, setSelectedAudioId] = useState<string | null>(null);
+  const [selectedAudioUrl, setSelectedAudioUrl] = useState<string | null>(null);
+
+  const [audioOffsetSec, setAudioOffsetSec] = useState(0);
+  const [audioStartSec, setAudioStartSec] = useState(0);
+  const [audioEndSec, setAudioEndSec] = useState(15);
+  const [audioVolume, setAudioVolume] = useState(1);
+
+  const [isSubmittingAudio, setIsSubmittingAudio] = useState(false);
+  const [audioSubmitInfo, setAudioSubmitInfo] = useState<string | null>(null);
+  const [audioSubmitError, setAudioSubmitError] = useState<string | null>(null);
+  const [audioJobId, setAudioJobId] = useState<string | null>(null);
+  const [isPollingAudioJob, setIsPollingAudioJob] = useState(false);
+  const [mixedVideoUrl, setMixedVideoUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setIsLoadingVideos(false);
+      setVideoError("No encontramos una sesion activa para cargar videos.");
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadVideos = async () => {
+      setIsLoadingVideos(true);
+      setVideoError(null);
+      try {
+        let selectedClip: UserClipItem | null = null;
+        let preferredVideoFromQuery = preferredVideoId;
+
+        if (preferredClipId) {
+          try {
+            const clipResponse = await videoApi.getMyClipById(preferredClipId, token);
+            selectedClip = clipResponse.clip;
+            if (selectedClip && !preferredVideoFromQuery) {
+              preferredVideoFromQuery = selectedClip.video_id;
+            }
+          } catch {
+            selectedClip = null;
+          }
+        }
+
+        const response = await videoApi.getMyVideos(token, {
+          limit: PAGE_SIZE,
+          offset: (page - 1) * PAGE_SIZE,
+          query
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        let nextVideos = response.videos;
+        if (preferredVideoFromQuery && !response.videos.some((video) => video.video_id === preferredVideoFromQuery)) {
+          try {
+            const preferredVideo = await videoApi.getMyVideoById(preferredVideoFromQuery, token);
+            nextVideos = [
+              {
+                video_id: preferredVideo.video_id,
+                filename: preferredVideo.filename,
+                status: preferredVideo.status,
+                uploaded_at: preferredVideo.uploaded_at,
+                preview_url: preferredVideo.preview_url
+              },
+              ...response.videos.filter((video) => video.video_id !== preferredVideo.video_id)
+            ];
+          } catch {
+            nextVideos = response.videos;
+          }
+        }
+
+        setVideos(nextVideos);
+        setFocusedClip(selectedClip);
+        setTotalVideos(response.total);
+        setSelectedVideoId((prev) => {
+          if (preferredVideoFromQuery && nextVideos.some((video) => video.video_id === preferredVideoFromQuery)) {
+            return preferredVideoFromQuery;
+          }
+          if (prev && nextVideos.some((video) => video.video_id === prev)) {
+            return prev;
+          }
+          return nextVideos[0]?.video_id ?? null;
+        });
+      } catch (loadError) {
+        if (!cancelled) {
+          setVideoError(normalizeVideoError(loadError, "No pudimos cargar tus videos."));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingVideos(false);
+        }
+      }
+    };
+
+    void loadVideos();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, page, preferredClipId, preferredVideoId, query]);
+
+  useEffect(() => {
+    if (!token) {
+      setAudios([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadAudios = async () => {
+      setIsLoadingAudios(true);
+      setAudioError(null);
+      try {
+        const response = await videoApi.getMyAudios(token, { limit: 50, offset: 0 });
+        if (cancelled) {
+          return;
+        }
+
+        setAudios(response.audios);
+        setSelectedAudioId((prev) => {
+          if (prev && response.audios.some((audio) => audio.audio_id === prev)) {
+            return prev;
+          }
+          return response.audios[0]?.audio_id ?? null;
+        });
+      } catch (loadError) {
+        if (!cancelled) {
+          setAudioError(normalizeVideoError(loadError, "No pudimos cargar tus audios."));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingAudios(false);
+        }
+      }
+    };
+
+    void loadAudios();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    if (!token || !selectedAudioId) {
+      setSelectedAudioUrl(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const resolveAudioUrl = async () => {
+      try {
+        const response = await videoApi.getAudioUrl(selectedAudioId, token);
+        if (!cancelled) {
+          setSelectedAudioUrl(response.url);
+        }
+      } catch {
+        if (!cancelled) {
+          setSelectedAudioUrl(null);
+        }
+      }
+    };
+
+    void resolveAudioUrl();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAudioId, token]);
+
+  useEffect(() => {
+    if (!token || !audioJobId) {
+      setIsPollingAudioJob(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const syncAudioJob = async () => {
+      try {
+        const status = await videoApi.getJobStatus(audioJobId, token);
+        if (cancelled) {
+          return;
+        }
+
+        if (status.output_path) {
+          setMixedVideoUrl(status.output_path);
+        }
+
+        if (isDoneStatus(status.status)) {
+          setAudioSubmitInfo(`Mezcla de audio lista. Job ${audioJobId.slice(0, 8)} finalizado.`);
+        }
+
+        if (isTerminalStatus(status.status) && (status.output_path || !isDoneStatus(status.status))) {
+          window.clearInterval(intervalId);
+          setIsPollingAudioJob(false);
+
+          if (!isDoneStatus(status.status)) {
+            setAudioSubmitError(`La mezcla termino con estado ${status.status}.`);
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setAudioSubmitError("No pudimos actualizar el estado del job de mezcla.");
+        }
+      }
+    };
+
+    setIsPollingAudioJob(true);
+    const intervalId = window.setInterval(() => {
+      void syncAudioJob();
+    }, 4000);
+
+    void syncAudioJob();
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      setIsPollingAudioJob(false);
+    };
+  }, [audioJobId, token]);
+
+  const totalPages = Math.max(1, Math.ceil(totalVideos / PAGE_SIZE));
+  const selectedVideo = useMemo(() => videos.find((video) => video.video_id === selectedVideoId) ?? null, [videos, selectedVideoId]);
+  const previewUrl = mixedVideoUrl ?? focusedClip?.output_path ?? selectedVideo?.preview_url ?? null;
+
+  const handleAddAudioToVideo = async () => {
+    if (!token || !selectedVideoId || !selectedAudioId) {
+      setAudioSubmitError("Selecciona video y audio para iniciar la mezcla.");
+      return;
+    }
+
+    if (audioEndSec <= audioStartSec) {
+      setAudioSubmitError("El fin del segmento de audio debe ser mayor al inicio.");
+      return;
+    }
+
+    setIsSubmittingAudio(true);
+    setAudioSubmitError(null);
+    setAudioSubmitInfo(null);
+    setMixedVideoUrl(null);
+
+    try {
+      const response = await videoApi.addAudioToVideo(selectedVideoId, token, {
+        audio_id: selectedAudioId,
+        audio_offset_sec: Math.max(0, Math.floor(audioOffsetSec)),
+        audio_start_sec: Math.max(0, Math.floor(audioStartSec)),
+        audio_end_sec: Math.max(1, Math.ceil(audioEndSec)),
+        audio_volume: Math.min(2, Math.max(0.1, Number(audioVolume.toFixed(2))))
+      });
+
+      setAudioJobId(response.job_id);
+      setAudioSubmitInfo(`Mezcla enviada a cola. Job ${response.job_id.slice(0, 8)} en estado ${response.status}.`);
+    } catch (mixError) {
+      setAudioSubmitError(normalizeVideoError(mixError, "No pudimos enviar el job para mezclar audio."));
+    } finally {
+      setIsSubmittingAudio(false);
+    }
+  };
+
+  return (
+    <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="grid gap-5 xl:grid-cols-[1.5fr_1fr]">
+        <Panel>
+          <p className="text-xs uppercase tracking-[0.22em] text-white/65">audio editor</p>
+          <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Video + pista de audio</h3>
+
+          <label className="mt-3 flex items-center gap-2 rounded-xl border border-white/12 bg-white/5 px-3 py-2 text-sm text-white/80 transition hover:border-neon-violet/40">
+            <Search size={14} className="text-neon-violet/80" />
+            <input
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setPage(1);
+              }}
+              placeholder="Buscar video por id o archivo..."
+              className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/40"
+            />
+          </label>
+
+          {isLoadingVideos ? (
+            <p className="mt-4 text-sm text-white/70">Cargando videos...</p>
+          ) : videoError ? (
+            <p className="mt-4 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{videoError}</p>
+          ) : previewUrl ? (
+            <VideoPreview videoPreviewUrl={previewUrl} onTrimChange={() => {}} />
+          ) : (
+            <p className="mt-4 text-sm text-white/70">Selecciona un video con preview disponible.</p>
+          )}
+
+          <div className="mt-4 rounded-xl border border-neon-violet/30 bg-neon-violet/5 p-3">
+            <p className="text-xs uppercase tracking-[0.16em] text-neon-violet/85">Pistas</p>
+            <div className="mt-2 grid gap-2">
+              <div className="rounded-lg border border-white/10 bg-night-900/80 p-2">
+                <p className="text-[11px] text-white/65">Track video</p>
+                <div className="mt-2 h-6 rounded bg-gradient-to-r from-sky-400/25 to-sky-300/60" />
+              </div>
+              <div className="rounded-lg border border-white/10 bg-night-900/80 p-2">
+                <div className="flex items-center justify-between text-[11px] text-white/65">
+                  <span>Track audio</span>
+                  <span>
+                    {toTimeLabel(audioStartSec)} - {toTimeLabel(audioEndSec)}
+                  </span>
+                </div>
+                <div className="mt-2 h-6 overflow-hidden rounded bg-night-950/90">
+                  <div
+                    className="h-full rounded bg-gradient-to-r from-neon-violet/65 to-neon-magenta/75"
+                    style={{
+                      marginLeft: `${Math.min(audioOffsetSec * 2, 80)}px`,
+                      width: `${Math.max((audioEndSec - audioStartSec) * 5, 24)}px`
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-2 sm:grid-cols-2">
+            {videos.map((video) => (
+              <button
+                type="button"
+                key={video.video_id}
+                onClick={() => {
+                  setSelectedVideoId(video.video_id);
+                  setMixedVideoUrl(null);
+                }}
+                className={[
+                  "rounded-xl border px-3 py-2 text-left text-sm transition",
+                  selectedVideoId === video.video_id
+                    ? "border-neon-violet/45 bg-neon-violet/10 text-white"
+                    : "border-white/10 bg-white/5 text-white/75 hover:border-white/20 hover:text-white"
+                ].join(" ")}
+              >
+                <p className="font-semibold">Video {video.video_id.slice(0, 8)}</p>
+                <p className="mt-1 text-xs text-white/60">Archivo: {video.filename}</p>
+              </button>
+            ))}
+          </div>
+
+          {totalPages > 1 ? (
+            <div className="mt-4 flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/80">
+              <span>Pagina {page} de {totalPages}</span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:opacity-40"
+                  disabled={page <= 1 || isLoadingVideos}
+                  onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                >
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:opacity-40"
+                  disabled={page >= totalPages || isLoadingVideos}
+                  onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </Panel>
+
+        <Panel>
+          <p className="text-xs uppercase tracking-[0.22em] text-white/65">mezcla</p>
+          <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Ajustes de audio</h3>
+
+          {isLoadingAudios ? <p className="mt-3 text-sm text-white/70">Cargando audios...</p> : null}
+          {audioError ? <p className="mt-3 text-sm text-rose-200">{audioError}</p> : null}
+
+          {!isLoadingAudios && audios.length > 0 ? (
+            <>
+              <label className="mt-3 block text-xs text-white/75">
+                Audio de biblioteca
+                <select
+                  value={selectedAudioId ?? ""}
+                  onChange={(event) => setSelectedAudioId(event.target.value || null)}
+                  className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
+                >
+                  {audios.map((audio) => (
+                    <option key={audio.audio_id} value={audio.audio_id}>
+                      {audio.filename}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {selectedAudioUrl ? (
+                <audio controls preload="metadata" className="mt-3 w-full rounded-lg [accent-color:#cba6f7]" src={selectedAudioUrl} />
+              ) : null}
+
+              <div className="mt-3 rounded-xl border border-white/12 bg-white/5 p-3 text-xs text-white/80">
+                <p className="text-neon-violet">Referencia rapida</p>
+                <p className="mt-1">- `offset en video`: segundo del video donde empieza a sonar el audio.</p>
+                <p>- `inicio audio`: desde que segundo del archivo de audio recortas.</p>
+                <p>- `fin audio`: hasta que segundo del archivo de audio usas.</p>
+                <p>- `volumen`: ganancia del audio agregado (1.0 = normal).</p>
+              </div>
+
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                <label className="text-xs text-white/75">
+                  Offset en video (seg)
+                  <input
+                    type="number"
+                    min={0}
+                    value={audioOffsetSec}
+                    onChange={(event) => setAudioOffsetSec(Number(event.target.value || 0))}
+                    className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
+                  />
+                </label>
+                <label className="text-xs text-white/75">
+                  Volumen (0.1 - 2.0)
+                  <input
+                    type="number"
+                    min={0.1}
+                    max={2}
+                    step={0.1}
+                    value={audioVolume}
+                    onChange={(event) => setAudioVolume(Number(event.target.value || 1))}
+                    className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
+                  />
+                </label>
+                <label className="text-xs text-white/75">
+                  Inicio audio (seg)
+                  <input
+                    type="number"
+                    min={0}
+                    value={audioStartSec}
+                    onChange={(event) => setAudioStartSec(Number(event.target.value || 0))}
+                    className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
+                  />
+                </label>
+                <label className="text-xs text-white/75">
+                  Fin audio (seg)
+                  <input
+                    type="number"
+                    min={1}
+                    value={audioEndSec}
+                    onChange={(event) => setAudioEndSec(Number(event.target.value || 1))}
+                    className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
+                  />
+                </label>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => void handleAddAudioToVideo()}
+                disabled={!selectedVideoId || !selectedAudioId || isSubmittingAudio}
+                className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-violet/45 bg-neon-violet/15 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neon-violet transition hover:bg-neon-violet/20 disabled:opacity-40"
+              >
+                <Music2 size={14} /> {isSubmittingAudio ? "Encolando..." : "Aplicar audio al video"}
+              </button>
+
+              {audioSubmitInfo ? <p className="mt-2 text-xs text-neon-mint">{audioSubmitInfo}</p> : null}
+              {audioSubmitError ? <p className="mt-2 text-xs text-rose-200">{audioSubmitError}</p> : null}
+              {isPollingAudioJob ? <p className="mt-2 text-xs text-white/65">Procesando mezcla de audio...</p> : null}
+            </>
+          ) : null}
+
+          {!isLoadingAudios && audios.length === 0 ? (
+            <p className="mt-3 text-sm text-white/70">No hay audios cargados. Subi uno desde Home para mezclarlo aca.</p>
+          ) : null}
+        </Panel>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/app/audio_editor/page.tsx
+++ b/frontend/src/app/app/audio_editor/page.tsx
@@ -9,6 +9,7 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 const PAGE_SIZE = 10;
+const MIN_AUDIO_SEGMENT_SECONDS = 5;
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
   if (error instanceof VideoApiError) {
@@ -42,6 +43,13 @@ function toTimeLabel(seconds: number) {
   return `${min}:${sec}`;
 }
 
+function clamp(value: number, min: number, max: number) {
+  if (Number.isNaN(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
 export default function AudioEditorPage() {
   const searchParams = useSearchParams();
   const preferredVideoId = searchParams.get("videoId")?.trim() ?? "";
@@ -67,6 +75,8 @@ export default function AudioEditorPage() {
   const [audioStartSec, setAudioStartSec] = useState(0);
   const [audioEndSec, setAudioEndSec] = useState(15);
   const [audioVolume, setAudioVolume] = useState(1);
+  const [videoDurationSec, setVideoDurationSec] = useState(0);
+  const [audioDurationSec, setAudioDurationSec] = useState(0);
 
   const [isSubmittingAudio, setIsSubmittingAudio] = useState(false);
   const [audioSubmitInfo, setAudioSubmitInfo] = useState<string | null>(null);
@@ -207,10 +217,12 @@ export default function AudioEditorPage() {
   useEffect(() => {
     if (!token || !selectedAudioId) {
       setSelectedAudioUrl(null);
+      setAudioDurationSec(0);
       return;
     }
 
     let cancelled = false;
+    setAudioDurationSec(0);
 
     const resolveAudioUrl = async () => {
       try {
@@ -221,6 +233,7 @@ export default function AudioEditorPage() {
       } catch {
         if (!cancelled) {
           setSelectedAudioUrl(null);
+          setAudioDurationSec(0);
         }
       }
     };
@@ -288,14 +301,98 @@ export default function AudioEditorPage() {
   const selectedVideo = useMemo(() => videos.find((video) => video.video_id === selectedVideoId) ?? null, [videos, selectedVideoId]);
   const previewUrl = mixedVideoUrl ?? focusedClip?.output_path ?? selectedVideo?.preview_url ?? null;
 
+  useEffect(() => {
+    if (!previewUrl) {
+      setVideoDurationSec(0);
+      return;
+    }
+
+    const video = document.createElement("video");
+    const onLoaded = () => {
+      setVideoDurationSec(Number.isFinite(video.duration) ? video.duration : 0);
+    };
+    const onError = () => {
+      setVideoDurationSec(0);
+    };
+
+    video.preload = "metadata";
+    video.src = previewUrl;
+    video.addEventListener("loadedmetadata", onLoaded);
+    video.addEventListener("error", onError);
+
+    return () => {
+      video.removeEventListener("loadedmetadata", onLoaded);
+      video.removeEventListener("error", onError);
+      video.src = "";
+    };
+  }, [previewUrl]);
+
+  const maxOffsetSec = useMemo(() => {
+    if (videoDurationSec <= 0) {
+      return 0;
+    }
+    return Math.max(Math.floor(videoDurationSec) - MIN_AUDIO_SEGMENT_SECONDS, 0);
+  }, [videoDurationSec]);
+
+  const maxAudioStartSec = useMemo(() => {
+    if (audioDurationSec <= 0) {
+      return 0;
+    }
+    return Math.max(Math.floor(audioDurationSec) - MIN_AUDIO_SEGMENT_SECONDS, 0);
+  }, [audioDurationSec]);
+
+  const maxAudioEndSec = useMemo(() => {
+    const byAudio = audioDurationSec > 0 ? Math.floor(audioDurationSec) : Number.POSITIVE_INFINITY;
+    const byVideo = videoDurationSec > 0 ? Math.floor(videoDurationSec) : Number.POSITIVE_INFINITY;
+    return Math.min(byAudio, byVideo);
+  }, [audioDurationSec, videoDurationSec]);
+
+  useEffect(() => {
+    const nextOffset = clamp(audioOffsetSec, 0, maxOffsetSec);
+    const nextStart = clamp(audioStartSec, 0, maxAudioStartSec);
+
+    const availableByAudio = audioDurationSec > 0 ? Math.max(Math.floor(audioDurationSec) - nextStart, 0) : Number.POSITIVE_INFINITY;
+    const availableByVideo = videoDurationSec > 0 ? Math.max(Math.floor(videoDurationSec) - nextOffset, 0) : Number.POSITIVE_INFINITY;
+    const maxSegment = Math.max(Math.min(availableByAudio, availableByVideo), 0);
+    const minEnd = nextStart + Math.min(MIN_AUDIO_SEGMENT_SECONDS, maxSegment);
+    const maxEnd = nextStart + maxSegment;
+
+    const nextEnd = clamp(audioEndSec, minEnd, maxEnd || minEnd);
+
+    if (nextOffset !== audioOffsetSec) {
+      setAudioOffsetSec(nextOffset);
+    }
+    if (nextStart !== audioStartSec) {
+      setAudioStartSec(nextStart);
+    }
+    if (nextEnd !== audioEndSec) {
+      setAudioEndSec(nextEnd);
+    }
+  }, [audioDurationSec, audioEndSec, audioOffsetSec, audioStartSec, maxAudioStartSec, maxOffsetSec, videoDurationSec]);
+
+  const selectedSegmentDurationSec = Math.max(audioEndSec - audioStartSec, 0);
+  const canSubmitAudioJob =
+    Boolean(selectedVideoId) &&
+    Boolean(selectedAudioId) &&
+    selectedSegmentDurationSec >= MIN_AUDIO_SEGMENT_SECONDS &&
+    (videoDurationSec <= 0 || audioOffsetSec + selectedSegmentDurationSec <= Math.floor(videoDurationSec));
+
+  const audioOffsetPct = videoDurationSec > 0 ? Math.min((audioOffsetSec / videoDurationSec) * 100, 100) : 0;
+  const audioWidthPct = videoDurationSec > 0 ? Math.min((selectedSegmentDurationSec / videoDurationSec) * 100, 100 - audioOffsetPct) : 0;
+
   const handleAddAudioToVideo = async () => {
     if (!token || !selectedVideoId || !selectedAudioId) {
       setAudioSubmitError("Selecciona video y audio para iniciar la mezcla.");
       return;
     }
 
-    if (audioEndSec <= audioStartSec) {
-      setAudioSubmitError("El fin del segmento de audio debe ser mayor al inicio.");
+    if (selectedSegmentDurationSec < MIN_AUDIO_SEGMENT_SECONDS) {
+      setAudioSubmitError(`El segmento de audio debe durar al menos ${MIN_AUDIO_SEGMENT_SECONDS} segundos.`);
+      return;
+    }
+
+    if (videoDurationSec > 0 && audioOffsetSec + selectedSegmentDurationSec > Math.floor(videoDurationSec)) {
+      setAudioSubmitError("La pista de audio no puede exceder la duracion total del video.");
       return;
     }
 
@@ -309,7 +406,7 @@ export default function AudioEditorPage() {
         audio_id: selectedAudioId,
         audio_offset_sec: Math.max(0, Math.floor(audioOffsetSec)),
         audio_start_sec: Math.max(0, Math.floor(audioStartSec)),
-        audio_end_sec: Math.max(1, Math.ceil(audioEndSec)),
+        audio_end_sec: Math.max(MIN_AUDIO_SEGMENT_SECONDS, Math.ceil(audioEndSec)),
         audio_volume: Math.min(2, Math.max(0.1, Number(audioVolume.toFixed(2))))
       });
 
@@ -370,8 +467,8 @@ export default function AudioEditorPage() {
                   <div
                     className="h-full rounded bg-gradient-to-r from-neon-violet/65 to-neon-magenta/75"
                     style={{
-                      marginLeft: `${Math.min(audioOffsetSec * 2, 80)}px`,
-                      width: `${Math.max((audioEndSec - audioStartSec) * 5, 24)}px`
+                      marginLeft: `${audioOffsetPct}%`,
+                      width: `${Math.max(audioWidthPct, 2)}%`
                     }}
                   />
                 </div>
@@ -451,8 +548,21 @@ export default function AudioEditorPage() {
               </label>
 
               {selectedAudioUrl ? (
-                <audio controls preload="metadata" className="mt-3 w-full rounded-lg [accent-color:#cba6f7]" src={selectedAudioUrl} />
+                <audio
+                  controls
+                  preload="metadata"
+                  className="mt-3 w-full rounded-lg [accent-color:#cba6f7]"
+                  src={selectedAudioUrl}
+                  onLoadedMetadata={(event) => {
+                    const duration = event.currentTarget.duration;
+                    setAudioDurationSec(Number.isFinite(duration) ? duration : 0);
+                  }}
+                />
               ) : null}
+
+              <p className="mt-2 text-[11px] text-white/65">
+                Duracion de video: {videoDurationSec > 0 ? toTimeLabel(videoDurationSec) : "-"} · Duracion de audio: {audioDurationSec > 0 ? toTimeLabel(audioDurationSec) : "-"}
+              </p>
 
               <div className="mt-3 rounded-xl border border-white/12 bg-white/5 p-3 text-xs text-white/80">
                 <p className="text-neon-violet">Referencia rapida</p>
@@ -468,8 +578,9 @@ export default function AudioEditorPage() {
                   <input
                     type="number"
                     min={0}
+                    max={maxOffsetSec}
                     value={audioOffsetSec}
-                    onChange={(event) => setAudioOffsetSec(Number(event.target.value || 0))}
+                    onChange={(event) => setAudioOffsetSec(clamp(Number(event.target.value || 0), 0, maxOffsetSec))}
                     className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
                   />
                 </label>
@@ -490,8 +601,9 @@ export default function AudioEditorPage() {
                   <input
                     type="number"
                     min={0}
+                    max={maxAudioStartSec}
                     value={audioStartSec}
-                    onChange={(event) => setAudioStartSec(Number(event.target.value || 0))}
+                    onChange={(event) => setAudioStartSec(clamp(Number(event.target.value || 0), 0, maxAudioStartSec))}
                     className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
                   />
                 </label>
@@ -499,18 +611,33 @@ export default function AudioEditorPage() {
                   Fin audio (seg)
                   <input
                     type="number"
-                    min={1}
+                    min={audioStartSec + MIN_AUDIO_SEGMENT_SECONDS}
+                    max={Math.max(audioStartSec + MIN_AUDIO_SEGMENT_SECONDS, maxAudioEndSec)}
                     value={audioEndSec}
-                    onChange={(event) => setAudioEndSec(Number(event.target.value || 1))}
+                    onChange={(event) =>
+                      setAudioEndSec(
+                        clamp(
+                          Number(event.target.value || audioStartSec + MIN_AUDIO_SEGMENT_SECONDS),
+                          audioStartSec + MIN_AUDIO_SEGMENT_SECONDS,
+                          Math.max(audioStartSec + MIN_AUDIO_SEGMENT_SECONDS, maxAudioEndSec)
+                        )
+                      )
+                    }
                     className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
                   />
                 </label>
               </div>
 
+              {!canSubmitAudioJob ? (
+                <p className="mt-2 text-xs text-amber-200">
+                  Ajusta la pista para que no exceda la duracion del video y tenga al menos {MIN_AUDIO_SEGMENT_SECONDS}s.
+                </p>
+              ) : null}
+
               <button
                 type="button"
                 onClick={() => void handleAddAudioToVideo()}
-                disabled={!selectedVideoId || !selectedAudioId || isSubmittingAudio}
+                disabled={!canSubmitAudioJob || isSubmittingAudio}
                 className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-violet/45 bg-neon-violet/15 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neon-violet transition hover:bg-neon-violet/20 disabled:opacity-40"
               >
                 <Music2 size={14} /> {isSubmittingAudio ? "Encolando..." : "Aplicar audio al video"}

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -42,11 +42,13 @@ export default function LibraryPage() {
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
   const [editingVideoId, setEditingVideoId] = useState<string | null>(null);
   const [draftFilename, setDraftFilename] = useState("");
   const [isSavingVideo, setIsSavingVideo] = useState(false);
   const [deletingVideoId, setDeletingVideoId] = useState<string | null>(null);
   const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
+  const [importingClipId, setImportingClipId] = useState<string | null>(null);
   const [deletingAudioId, setDeletingAudioId] = useState<string | null>(null);
   const [audioUrlMap, setAudioUrlMap] = useState<Record<string, string>>({});
   const [loadingAudioId, setLoadingAudioId] = useState<string | null>(null);
@@ -63,6 +65,7 @@ export default function LibraryPage() {
     const loadData = async () => {
       setIsLoading(true);
       setError(null);
+      setInfo(null);
       try {
         if (view === "clips") {
           const response = await videoApi.getMyClips(token, {
@@ -215,6 +218,27 @@ export default function LibraryPage() {
     }
   };
 
+  const handleImportClipAsVideo = async (clip: UserClipItem) => {
+    if (!token || importingClipId) {
+      return;
+    }
+
+    setImportingClipId(clip.job_id);
+    setError(null);
+    setInfo(null);
+
+    try {
+      const imported = await videoApi.createVideoFromJob(clip.job_id, token);
+      setInfo(`Clip ${clip.job_id.slice(0, 8)} importado como video ${imported.video_id.slice(0, 8)}.`);
+      setView("videos");
+      setPage(1);
+    } catch (importError) {
+      setError(importError instanceof Error ? importError.message : "No pudimos importar el clip como video.");
+    } finally {
+      setImportingClipId(null);
+    }
+  };
+
   const handleResolveAudioUrl = async (audioId: string) => {
     if (!token || loadingAudioId) {
       return;
@@ -358,6 +382,12 @@ export default function LibraryPage() {
         </Panel>
       ) : null}
 
+      {info ? (
+        <Panel className="mt-5">
+          <p className="rounded-xl border border-neon-mint/35 bg-neon-mint/10 px-3 py-2 text-sm text-neon-mint">{info}</p>
+        </Panel>
+      ) : null}
+
       {isLoading ? (
         <Panel className="mt-5">
           <p className="text-sm text-white/70">Cargando elementos de biblioteca...</p>
@@ -441,7 +471,7 @@ export default function LibraryPage() {
               )}
             </div>
 
-            <div className="mt-2 grid grid-cols-3 gap-2">
+            <div className="mt-2 grid grid-cols-2 gap-2">
               <Link
                 href={`/app/timeline?videoId=${clip.video_id}&clipId=${clip.job_id}`}
                 className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-cyan/40 hover:text-neon-cyan"
@@ -461,6 +491,14 @@ export default function LibraryPage() {
                 onClick={() => void handleDeleteClip(clip)}
               >
                 <Trash2 size={12} /> {deletingClipId === clip.job_id ? "Eliminando..." : "Eliminar"}
+              </button>
+              <button
+                type="button"
+                className="col-span-2 inline-flex items-center justify-center gap-1 rounded-lg border border-neon-violet/45 bg-neon-violet/15 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-neon-violet transition hover:bg-neon-violet/20 disabled:opacity-40"
+                disabled={importingClipId === clip.job_id}
+                onClick={() => void handleImportClipAsVideo(clip)}
+              >
+                <Download size={12} /> {importingClipId === clip.job_id ? "Importando..." : "Importar a Videos"}
               </button>
             </div>
           </article>
@@ -571,27 +609,51 @@ export default function LibraryPage() {
             return (
               <article
                 key={audio.audio_id}
-                className="group animate-fade-up rounded-2xl border border-white/10 bg-gradient-to-b from-night-800/80 to-night-900/80 p-4 shadow-panel transition duration-300 hover:-translate-y-1 hover:border-neon-cyan/40"
+                className="group animate-fade-up rounded-2xl border border-white/10 bg-gradient-to-b from-night-800/80 via-night-800/75 to-night-900/85 p-4 shadow-panel transition duration-300 hover:-translate-y-1 hover:border-neon-violet/45"
                 style={{ animationDelay: `${index * 90}ms` }}
               >
-                <div className="relative mb-3 grid aspect-[16/9] place-items-center overflow-hidden rounded-xl border border-white/10 bg-[radial-gradient(circle_at_25%_20%,rgba(53,208,255,0.25),transparent_45%),radial-gradient(circle_at_75%_80%,rgba(73,255,163,0.22),transparent_48%),#0d1630]">
-                  <div className="inline-flex items-center gap-2 rounded-full border border-neon-mint/40 bg-neon-mint/10 px-3 py-1 text-xs text-neon-mint">
+                <div className="relative mb-3 overflow-hidden rounded-xl border border-white/10 bg-[radial-gradient(circle_at_25%_20%,rgba(203,166,247,0.35),transparent_45%),radial-gradient(circle_at_80%_85%,rgba(245,194,231,0.26),transparent_48%),#1b1b2a]">
+                  <div className="absolute -right-8 -top-8 h-24 w-24 rounded-full bg-neon-violet/20 blur-2xl" />
+                  <div className="absolute -bottom-9 left-6 h-20 w-20 rounded-full bg-neon-magenta/20 blur-2xl" />
+                  <div className="relative z-10 p-4">
+                    <div className="inline-flex items-center gap-2 rounded-full border border-neon-violet/40 bg-neon-violet/15 px-3 py-1 text-xs text-neon-violet">
                     <AudioLines size={13} /> Audio
+                    </div>
+                    <div className="mt-4 flex h-16 items-end gap-1.5">
+                      {Array.from({ length: 18 }).map((_, barIndex) => {
+                        const height = 20 + ((barIndex * 7 + index * 11) % 40);
+                        return (
+                          <span
+                            key={`${audio.audio_id}-${barIndex}`}
+                            className="w-1.5 rounded-full bg-gradient-to-t from-neon-violet/30 to-neon-magenta/80"
+                            style={{ height: `${height}%` }}
+                          />
+                        );
+                      })}
+                    </div>
                   </div>
                 </div>
 
                 <h2 className="font-display text-lg text-white">Audio {audio.audio_id.slice(0, 8)}</h2>
                 <p className="mt-2 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-xs text-white/70">{audio.filename}</p>
-                <p className="mt-2 inline-flex rounded-full border border-neon-cyan/35 bg-neon-cyan/10 px-2 py-1 text-xs text-neon-cyan">
+                <p className="mt-2 inline-flex rounded-full border border-neon-violet/35 bg-neon-violet/10 px-2 py-1 text-xs text-neon-violet">
                   Estado: {audio.status ?? "uploaded"}
                 </p>
 
                 {audioUrl ? (
-                  <audio controls preload="metadata" className="mt-4 w-full" src={audioUrl} />
+                  <div className="mt-4 rounded-xl border border-white/12 bg-night-900/70 p-3">
+                    <p className="text-[11px] uppercase tracking-[0.16em] text-white/60">Preview</p>
+                    <audio
+                      controls
+                      preload="metadata"
+                      className="mt-2 w-full rounded-lg [accent-color:#cba6f7]"
+                      src={audioUrl}
+                    />
+                  </div>
                 ) : (
                   <button
                     type="button"
-                    className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-mint/40 bg-neon-mint/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-neon-mint transition hover:bg-neon-mint/20 disabled:opacity-40"
+                    className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-violet/45 bg-neon-violet/15 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-neon-violet transition hover:bg-neon-violet/20 disabled:opacity-40"
                     disabled={loadingAudioId === audio.audio_id}
                     onClick={() => void handleResolveAudioUrl(audio.audio_id)}
                   >
@@ -602,7 +664,7 @@ export default function LibraryPage() {
                 <div className="mt-2 grid grid-cols-2 gap-2">
                   <button
                     type="button"
-                    className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-cyan/40 hover:text-neon-cyan disabled:opacity-40"
+                    className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-violet/40 hover:text-neon-violet disabled:opacity-40"
                     disabled={!audioUrl}
                     onClick={() => {
                       if (audioUrl) {

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { Panel } from "@/src/components/ui/Panel";
-import { videoApi, type UserClipItem, type UserVideoItem } from "@/src/services/videoApi";
+import { videoApi, type UserAudioItem, type UserClipItem, type UserVideoItem } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
-import { Check, Clock3, Download, PencilLine, Search, Share2, Tag, Trash2, X } from "lucide-react";
+import { AudioLines, Check, Clock3, Download, PencilLine, Search, Share2, Tag, Trash2, X } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
 const PAGE_SIZE = 12;
-type LibraryView = "clips" | "videos";
+type LibraryView = "clips" | "videos" | "audios";
 
 type VisualStatus = "listo" | "revision" | "render";
 
@@ -34,8 +34,10 @@ export default function LibraryPage() {
   const [view, setView] = useState<LibraryView>("clips");
   const [clips, setClips] = useState<UserClipItem[]>([]);
   const [videos, setVideos] = useState<UserVideoItem[]>([]);
+  const [audios, setAudios] = useState<UserAudioItem[]>([]);
   const [totalClips, setTotalClips] = useState(0);
   const [totalVideos, setTotalVideos] = useState(0);
+  const [totalAudios, setTotalAudios] = useState(0);
   const [page, setPage] = useState(1);
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -45,6 +47,9 @@ export default function LibraryPage() {
   const [isSavingVideo, setIsSavingVideo] = useState(false);
   const [deletingVideoId, setDeletingVideoId] = useState<string | null>(null);
   const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
+  const [deletingAudioId, setDeletingAudioId] = useState<string | null>(null);
+  const [audioUrlMap, setAudioUrlMap] = useState<Record<string, string>>({});
+  const [loadingAudioId, setLoadingAudioId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!token) {
@@ -69,7 +74,7 @@ export default function LibraryPage() {
             setClips(response.clips);
             setTotalClips(response.total);
           }
-        } else {
+        } else if (view === "videos") {
           const response = await videoApi.getMyVideos(token, {
             limit: PAGE_SIZE,
             offset: (page - 1) * PAGE_SIZE,
@@ -78,6 +83,16 @@ export default function LibraryPage() {
           if (!cancelled) {
             setVideos(response.videos);
             setTotalVideos(response.total);
+          }
+        } else {
+          const response = await videoApi.getMyAudios(token, {
+            limit: PAGE_SIZE,
+            offset: (page - 1) * PAGE_SIZE,
+            query
+          });
+          if (!cancelled) {
+            setAudios(response.audios);
+            setTotalAudios(response.total);
           }
         }
       } catch (loadError) {
@@ -98,7 +113,8 @@ export default function LibraryPage() {
     };
   }, [token, page, query, view]);
 
-  const totalPages = Math.max(1, Math.ceil((view === "clips" ? totalClips : totalVideos) / PAGE_SIZE));
+  const totalItems = view === "clips" ? totalClips : view === "videos" ? totalVideos : totalAudios;
+  const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
 
   const handleStartRename = (video: UserVideoItem) => {
     setEditingVideoId(video.video_id);
@@ -199,6 +215,65 @@ export default function LibraryPage() {
     }
   };
 
+  const handleResolveAudioUrl = async (audioId: string) => {
+    if (!token || loadingAudioId) {
+      return;
+    }
+
+    if (audioUrlMap[audioId]) {
+      return;
+    }
+
+    setLoadingAudioId(audioId);
+    setError(null);
+
+    try {
+      const response = await videoApi.getAudioUrl(audioId, token);
+      setAudioUrlMap((prev) => ({ ...prev, [audioId]: response.url }));
+    } catch (resolveError) {
+      setError(resolveError instanceof Error ? resolveError.message : "No pudimos cargar la URL del audio.");
+    } finally {
+      setLoadingAudioId(null);
+    }
+  };
+
+  const handleDeleteAudio = async (audio: UserAudioItem) => {
+    if (!token || deletingAudioId) {
+      return;
+    }
+
+    const confirmed = window.confirm(`Vas a eliminar ${audio.filename}. Esta accion no se puede deshacer.`);
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingAudioId(audio.audio_id);
+    setError(null);
+
+    try {
+      await videoApi.deleteMyAudio(audio.audio_id, token);
+      let shouldStepBackPage = false;
+      setAudios((prev) => {
+        shouldStepBackPage = prev.length === 1;
+        return prev.filter((item) => item.audio_id !== audio.audio_id);
+      });
+      setAudioUrlMap((prev) => {
+        const next = { ...prev };
+        delete next[audio.audio_id];
+        return next;
+      });
+      setTotalAudios((prev) => Math.max(0, prev - 1));
+
+      if (shouldStepBackPage && page > 1) {
+        setPage((prev) => Math.max(1, prev - 1));
+      }
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : "No pudimos eliminar el audio.");
+    } finally {
+      setDeletingAudioId(null);
+    }
+  };
+
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
       <Panel className="relative overflow-hidden border-neon-cyan/25 bg-gradient-to-r from-night-900 via-night-800/85 to-night-900 p-5 sm:p-6">
@@ -207,9 +282,9 @@ export default function LibraryPage() {
 
         <div className="relative animate-fade-up">
           <p className="text-xs uppercase tracking-[0.25em] text-neon-cyan/80">biblioteca</p>
-          <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Tus clips y videos originales</h1>
+          <h1 className="mt-2 font-display text-2xl text-white sm:text-3xl">Tus clips, videos y audios</h1>
           <p className="mt-2 max-w-2xl text-sm text-white/70">
-            Cambia entre clips generados y videos subidos originales. La busqueda se hace en backend por nombre o ID.
+            Cambia entre clips generados, videos subidos y audios. La busqueda se hace en backend por nombre o ID.
           </p>
         </div>
 
@@ -240,13 +315,32 @@ export default function LibraryPage() {
           >
             Videos originales
           </button>
+          <button
+            type="button"
+            className={[
+              "rounded-lg px-3 py-1.5 transition",
+              view === "audios" ? "bg-neon-cyan/20 text-neon-cyan" : "text-white/70 hover:text-white"
+            ].join(" ")}
+            onClick={() => {
+              setView("audios");
+              setPage(1);
+            }}
+          >
+            Audios
+          </button>
         </div>
 
         <div className="relative mt-5 grid gap-3 sm:grid-cols-1">
           <label className="group flex items-center gap-3 rounded-xl border border-white/12 bg-white/5 px-3 py-2 transition hover:border-neon-cyan/40">
             <Search size={15} className="text-neon-cyan/80" />
             <input
-              placeholder={view === "clips" ? "Buscar por id de job o archivo fuente..." : "Buscar por id de video o archivo subido..."}
+              placeholder={
+                view === "clips"
+                  ? "Buscar por id de job o archivo fuente..."
+                  : view === "videos"
+                    ? "Buscar por id de video o archivo subido..."
+                    : "Buscar por id de audio o nombre de archivo..."
+              }
               className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/40"
               value={query}
               onChange={(event) => {
@@ -266,7 +360,7 @@ export default function LibraryPage() {
 
       {isLoading ? (
         <Panel className="mt-5">
-          <p className="text-sm text-white/70">Cargando clips de biblioteca...</p>
+          <p className="text-sm text-white/70">Cargando elementos de biblioteca...</p>
         </Panel>
       ) : null}
 
@@ -279,6 +373,12 @@ export default function LibraryPage() {
       {!isLoading && !error && view === "videos" && videos.length === 0 ? (
         <Panel className="mt-5">
           <p className="text-sm text-white/70">No encontramos videos subidos para esa busqueda.</p>
+        </Panel>
+      ) : null}
+
+      {!isLoading && !error && view === "audios" && audios.length === 0 ? (
+        <Panel className="mt-5">
+          <p className="text-sm text-white/70">No encontramos audios subidos para esa busqueda.</p>
         </Panel>
       ) : null}
 
@@ -367,7 +467,7 @@ export default function LibraryPage() {
           );
           })}
         </div>
-      ) : (
+      ) : view === "videos" ? (
         <div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {videos.map((video, index) => (
             <article
@@ -462,6 +562,68 @@ export default function LibraryPage() {
               ) : null}
             </article>
           ))}
+        </div>
+      ) : (
+        <div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {audios.map((audio, index) => {
+            const audioUrl = audioUrlMap[audio.audio_id] ?? null;
+
+            return (
+              <article
+                key={audio.audio_id}
+                className="group animate-fade-up rounded-2xl border border-white/10 bg-gradient-to-b from-night-800/80 to-night-900/80 p-4 shadow-panel transition duration-300 hover:-translate-y-1 hover:border-neon-cyan/40"
+                style={{ animationDelay: `${index * 90}ms` }}
+              >
+                <div className="relative mb-3 grid aspect-[16/9] place-items-center overflow-hidden rounded-xl border border-white/10 bg-[radial-gradient(circle_at_25%_20%,rgba(53,208,255,0.25),transparent_45%),radial-gradient(circle_at_75%_80%,rgba(73,255,163,0.22),transparent_48%),#0d1630]">
+                  <div className="inline-flex items-center gap-2 rounded-full border border-neon-mint/40 bg-neon-mint/10 px-3 py-1 text-xs text-neon-mint">
+                    <AudioLines size={13} /> Audio
+                  </div>
+                </div>
+
+                <h2 className="font-display text-lg text-white">Audio {audio.audio_id.slice(0, 8)}</h2>
+                <p className="mt-2 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-xs text-white/70">{audio.filename}</p>
+                <p className="mt-2 inline-flex rounded-full border border-neon-cyan/35 bg-neon-cyan/10 px-2 py-1 text-xs text-neon-cyan">
+                  Estado: {audio.status ?? "uploaded"}
+                </p>
+
+                {audioUrl ? (
+                  <audio controls preload="metadata" className="mt-4 w-full" src={audioUrl} />
+                ) : (
+                  <button
+                    type="button"
+                    className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-mint/40 bg-neon-mint/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-neon-mint transition hover:bg-neon-mint/20 disabled:opacity-40"
+                    disabled={loadingAudioId === audio.audio_id}
+                    onClick={() => void handleResolveAudioUrl(audio.audio_id)}
+                  >
+                    <Download size={13} /> {loadingAudioId === audio.audio_id ? "Cargando..." : "Cargar preview"}
+                  </button>
+                )}
+
+                <div className="mt-2 grid grid-cols-2 gap-2">
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-cyan/40 hover:text-neon-cyan disabled:opacity-40"
+                    disabled={!audioUrl}
+                    onClick={() => {
+                      if (audioUrl) {
+                        window.open(audioUrl, "_blank", "noopener,noreferrer");
+                      }
+                    }}
+                  >
+                    <Download size={12} /> Abrir
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center gap-1 rounded-lg border border-rose-300/45 bg-rose-300/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-rose-200 transition hover:bg-rose-300/20 disabled:opacity-40"
+                    disabled={deletingAudioId === audio.audio_id}
+                    onClick={() => void handleDeleteAudio(audio)}
+                  >
+                    <Trash2 size={12} /> {deletingAudioId === audio.audio_id ? "Eliminando..." : "Eliminar"}
+                  </button>
+                </div>
+              </article>
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -42,13 +42,11 @@ export default function LibraryPage() {
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [info, setInfo] = useState<string | null>(null);
   const [editingVideoId, setEditingVideoId] = useState<string | null>(null);
   const [draftFilename, setDraftFilename] = useState("");
   const [isSavingVideo, setIsSavingVideo] = useState(false);
   const [deletingVideoId, setDeletingVideoId] = useState<string | null>(null);
   const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
-  const [importingClipId, setImportingClipId] = useState<string | null>(null);
   const [deletingAudioId, setDeletingAudioId] = useState<string | null>(null);
   const [audioUrlMap, setAudioUrlMap] = useState<Record<string, string>>({});
   const [loadingAudioId, setLoadingAudioId] = useState<string | null>(null);
@@ -65,7 +63,6 @@ export default function LibraryPage() {
     const loadData = async () => {
       setIsLoading(true);
       setError(null);
-      setInfo(null);
       try {
         if (view === "clips") {
           const response = await videoApi.getMyClips(token, {
@@ -218,27 +215,6 @@ export default function LibraryPage() {
     }
   };
 
-  const handleImportClipAsVideo = async (clip: UserClipItem) => {
-    if (!token || importingClipId) {
-      return;
-    }
-
-    setImportingClipId(clip.job_id);
-    setError(null);
-    setInfo(null);
-
-    try {
-      const imported = await videoApi.createVideoFromJob(clip.job_id, token);
-      setInfo(`Clip ${clip.job_id.slice(0, 8)} importado como video ${imported.video_id.slice(0, 8)}.`);
-      setView("videos");
-      setPage(1);
-    } catch (importError) {
-      setError(importError instanceof Error ? importError.message : "No pudimos importar el clip como video.");
-    } finally {
-      setImportingClipId(null);
-    }
-  };
-
   const handleResolveAudioUrl = async (audioId: string) => {
     if (!token || loadingAudioId) {
       return;
@@ -382,12 +358,6 @@ export default function LibraryPage() {
         </Panel>
       ) : null}
 
-      {info ? (
-        <Panel className="mt-5">
-          <p className="rounded-xl border border-neon-mint/35 bg-neon-mint/10 px-3 py-2 text-sm text-neon-mint">{info}</p>
-        </Panel>
-      ) : null}
-
       {isLoading ? (
         <Panel className="mt-5">
           <p className="text-sm text-white/70">Cargando elementos de biblioteca...</p>
@@ -476,7 +446,7 @@ export default function LibraryPage() {
                 href={`/app/timeline?videoId=${clip.video_id}&clipId=${clip.job_id}`}
                 className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-cyan/40 hover:text-neon-cyan"
               >
-                <PencilLine size={12} /> Editar
+                <PencilLine size={12} /> Abrir Timeline
               </Link>
               <Link
                 href={`/app/share/${clip.job_id}`}
@@ -491,14 +461,6 @@ export default function LibraryPage() {
                 onClick={() => void handleDeleteClip(clip)}
               >
                 <Trash2 size={12} /> {deletingClipId === clip.job_id ? "Eliminando..." : "Eliminar"}
-              </button>
-              <button
-                type="button"
-                className="col-span-2 inline-flex items-center justify-center gap-1 rounded-lg border border-neon-violet/45 bg-neon-violet/15 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-neon-violet transition hover:bg-neon-violet/20 disabled:opacity-40"
-                disabled={importingClipId === clip.job_id}
-                onClick={() => void handleImportClipAsVideo(clip)}
-              >
-                <Download size={12} /> {importingClipId === clip.job_id ? "Importando..." : "Importar a Videos"}
               </button>
               <Link
                 href={`/app/audio_editor?videoId=${clip.video_id}&clipId=${clip.job_id}`}

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -500,6 +500,12 @@ export default function LibraryPage() {
               >
                 <Download size={12} /> {importingClipId === clip.job_id ? "Importando..." : "Importar a Videos"}
               </button>
+              <Link
+                href={`/app/audio_editor?videoId=${clip.video_id}&clipId=${clip.job_id}`}
+                className="col-span-2 inline-flex items-center justify-center gap-1 rounded-lg border border-neon-mint/40 bg-neon-mint/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-neon-mint transition hover:bg-neon-mint/20"
+              >
+                <AudioLines size={12} /> Abrir en Audio Editor
+              </Link>
             </div>
           </article>
           );

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -5,6 +5,7 @@ import { ProjectStatusPanel } from "@/src/components/home/ProjectStatusPanel";
 import { UploadDropzone } from "@/src/components/home/UploadDropzone";
 import { Panel } from "@/src/components/ui/Panel";
 import {
+  type AudioUploadResponse,
   VideoApiError,
   type AutoReframeJobItem,
   type UserClipItem,
@@ -17,6 +18,7 @@ import { useEffect, useMemo, useState } from "react";
 const HOME_DRAFT_KEY = "home:uploaded-video-draft";
 type ClipOutputStyle = "vertical" | "speaker_split";
 type ClipContentProfile = "auto" | "interview" | "sports" | "music";
+type UploadedMediaType = "video" | "audio";
 
 function toTimeLabel(seconds: number) {
   const min = Math.floor(seconds / 60)
@@ -94,10 +96,29 @@ function isTerminalStatus(status: string) {
   return normalized === "done" || normalized === "completed" || normalized === "failed" || normalized === "error";
 }
 
+function isDoneStatus(status: string) {
+  const normalized = status.toLowerCase();
+  return normalized === "done" || normalized === "completed";
+}
+
+function isFailedStatus(status: string) {
+  const normalized = status.toLowerCase();
+  return normalized === "failed" || normalized === "error";
+}
+
+function isAudioFile(file: File) {
+  if (file.type.toLowerCase().startsWith("audio/")) {
+    return true;
+  }
+
+  const lowerName = file.name.toLowerCase();
+  return [".mp3", ".wav", ".aac", ".flac", ".ogg", ".m4a", ".wma", ".opus"].some((ext) => lowerName.endsWith(ext));
+}
+
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
   if (error instanceof VideoApiError) {
     if (error.status === 400) {
-      return error.message || "El archivo de video es invalido o no cumple los requisitos.";
+      return error.message || "El archivo es invalido o no cumple los requisitos.";
     }
 
     if (error.status === 401) {
@@ -125,6 +146,8 @@ export default function AppHomePage() {
   const [isCreatingJobs, setIsCreatingJobs] = useState(false);
   const [isPollingStatuses, setIsPollingStatuses] = useState(false);
   const [uploadedVideo, setUploadedVideo] = useState<VideoUploadResponse | null>(null);
+  const [uploadedAudio, setUploadedAudio] = useState<AudioUploadResponse | null>(null);
+  const [uploadedMediaType, setUploadedMediaType] = useState<UploadedMediaType | null>(null);
   const [autoJobCount, setAutoJobCount] = useState(0);
   const [createdJobs, setCreatedJobs] = useState<AutoReframeJobItem[]>([]);
   const [jobStatusMap, setJobStatusMap] = useState<Record<string, { status: string; outputPath: string | null }>>({});
@@ -133,15 +156,48 @@ export default function AppHomePage() {
   const [isHydratingClips, setIsHydratingClips] = useState(false);
   const [outputStyle, setOutputStyle] = useState<ClipOutputStyle>("vertical");
   const [contentProfile, setContentProfile] = useState<ClipContentProfile>("auto");
+  const [withSubtitles, setWithSubtitles] = useState(false);
+  const [watermark, setWatermark] = useState("Hacelo Corto");
   const [fallbackClips, setFallbackClips] = useState<UserClipItem[]>([]);
 
   const hasVideo = Boolean(uploadedVideo);
+  const hasAudio = Boolean(uploadedAudio);
   const visibleClips = useMemo(() => {
     if (createdJobs.length > 0) {
       return mapJobsToClips(createdJobs, jobStatusMap, fallbackClips);
     }
     return mapUserClipsToCards(fallbackClips);
   }, [createdJobs, jobStatusMap, fallbackClips]);
+
+  const clipProgress = useMemo(() => {
+    const statusByJob = new Map<string, string>();
+
+    createdJobs.forEach((job) => {
+      const status = jobStatusMap[job.job_id]?.status ?? job.status;
+      statusByJob.set(job.job_id, status);
+    });
+
+    fallbackClips.forEach((clip) => {
+      if (!statusByJob.has(clip.job_id)) {
+        statusByJob.set(clip.job_id, clip.status);
+      }
+    });
+
+    const statuses = Array.from(statusByJob.values());
+    const done = statuses.filter((status) => isDoneStatus(status)).length;
+    const failed = statuses.filter((status) => isFailedStatus(status)).length;
+    const total = autoJobCount > 0 ? autoJobCount : statuses.length;
+    const pending = Math.max(total - done - failed, 0);
+    const percent = total > 0 ? Math.round(((done + failed) / total) * 100) : 0;
+
+    return {
+      done,
+      failed,
+      pending,
+      total,
+      percent
+    };
+  }, [autoJobCount, createdJobs, fallbackClips, jobStatusMap]);
 
   useEffect(() => {
     try {
@@ -152,14 +208,24 @@ export default function AppHomePage() {
 
       const parsed = JSON.parse(raw) as {
         uploadedVideo: VideoUploadResponse | null;
+        uploadedAudio?: AudioUploadResponse | null;
+        uploadedMediaType?: UploadedMediaType | null;
         createdJobs: AutoReframeJobItem[];
         autoJobCount: number;
         outputStyle?: ClipOutputStyle;
         contentProfile?: ClipContentProfile;
+        withSubtitles?: boolean;
+        watermark?: string;
       };
 
       if (parsed.uploadedVideo) {
         setUploadedVideo(parsed.uploadedVideo);
+      }
+      if (parsed.uploadedAudio) {
+        setUploadedAudio(parsed.uploadedAudio);
+      }
+      if (parsed.uploadedMediaType === "video" || parsed.uploadedMediaType === "audio") {
+        setUploadedMediaType(parsed.uploadedMediaType);
       }
       if (Array.isArray(parsed.createdJobs)) {
         setCreatedJobs(parsed.createdJobs);
@@ -178,6 +244,12 @@ export default function AppHomePage() {
       ) {
         setContentProfile(parsed.contentProfile);
       }
+      if (typeof parsed.withSubtitles === "boolean") {
+        setWithSubtitles(parsed.withSubtitles);
+      }
+      if (typeof parsed.watermark === "string") {
+        setWatermark(parsed.watermark);
+      }
     } catch {
       window.localStorage.removeItem(HOME_DRAFT_KEY);
     }
@@ -191,14 +263,18 @@ export default function AppHomePage() {
 
     const payload = {
       uploadedVideo,
+      uploadedAudio,
+      uploadedMediaType,
       createdJobs,
       autoJobCount,
       outputStyle,
-      contentProfile
+      contentProfile,
+      withSubtitles,
+      watermark
     };
 
     window.localStorage.setItem(HOME_DRAFT_KEY, JSON.stringify(payload));
-  }, [uploadedVideo, createdJobs, autoJobCount, outputStyle, contentProfile]);
+  }, [uploadedVideo, uploadedAudio, uploadedMediaType, createdJobs, autoJobCount, outputStyle, contentProfile, withSubtitles, watermark]);
 
   useEffect(() => {
     if (!token || createdJobs.length === 0) {
@@ -264,9 +340,13 @@ export default function AppHomePage() {
   }, [createdJobs, token]);
 
   const handleUpload = async (file: File) => {
+    const isAudio = isAudioFile(file);
+
     setIsUploading(true);
     setIsCreatingJobs(false);
     setUploadedVideo(null);
+    setUploadedAudio(null);
+    setUploadedMediaType(isAudio ? "audio" : "video");
     setCreatedJobs([]);
     setFallbackClips([]);
     setJobStatusMap({});
@@ -275,17 +355,35 @@ export default function AppHomePage() {
     setJobError(null);
     window.localStorage.removeItem(HOME_DRAFT_KEY);
 
-    let uploaded: VideoUploadResponse;
+    let uploadedVideoResponse: VideoUploadResponse | null = null;
+    let uploadedAudioResponse: AudioUploadResponse | null = null;
 
     try {
-      uploaded = await videoApi.upload(file, token);
+      if (isAudio) {
+        uploadedAudioResponse = await videoApi.uploadAudio(file, token);
+      } else {
+        uploadedVideoResponse = await videoApi.upload(file, token);
+      }
     } catch (error) {
-      setUploadError(normalizeVideoError(error, "No pudimos subir el video."));
+      setUploadError(normalizeVideoError(error, "No pudimos subir el archivo."));
       setIsUploading(false);
       return;
     }
 
-    setUploadedVideo(uploaded);
+    if (uploadedAudioResponse) {
+      setUploadedAudio(uploadedAudioResponse);
+      setUploadedVideo(null);
+      setIsUploading(false);
+      return;
+    }
+
+    if (!uploadedVideoResponse) {
+      setUploadError("No pudimos determinar el tipo de archivo subido.");
+      setIsUploading(false);
+      return;
+    }
+
+    setUploadedVideo(uploadedVideoResponse);
     setIsUploading(false);
 
     if (!token) {
@@ -296,9 +394,11 @@ export default function AppHomePage() {
     setIsCreatingJobs(true);
 
     try {
-      const autoJobs = await videoApi.createAutoReframeJobs(uploaded.video_id, token, {
+      const autoJobs = await videoApi.createAutoReframeJobs(uploadedVideoResponse.video_id, token, {
         outputStyle,
-        contentProfile
+        contentProfile,
+        subtitles: withSubtitles,
+        watermark
       });
       setCreatedJobs(autoJobs.jobs);
       setAutoJobCount(autoJobs.total_jobs);
@@ -382,7 +482,29 @@ export default function AppHomePage() {
       <div className="grid gap-5 xl:grid-cols-[1.55fr_0.95fr]">
         <Panel variant="accent" className="p-4 sm:p-5">
           <div className="mb-4 rounded-xl border border-white/12 bg-white/5 p-3">
-            <p className="text-xs uppercase tracking-[0.18em] text-white/60">Estilo de clip</p>
+            <p className="text-xs uppercase tracking-[0.18em] text-white/60">Opciones de procesamiento</p>
+            <div className="mt-2 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
+              <label className="flex items-center justify-between rounded-lg border border-white/15 bg-night-900/70 px-3 py-2 text-sm text-white/85">
+                <span>Subtitulos automaticos</span>
+                <input
+                  type="checkbox"
+                  checked={withSubtitles}
+                  onChange={(event) => setWithSubtitles(event.target.checked)}
+                  className="h-4 w-4 rounded border-white/20 bg-night-900 text-neon-cyan focus:ring-neon-cyan"
+                />
+              </label>
+              <label className="rounded-lg border border-white/15 bg-night-900/70 px-3 py-2 text-sm text-white/85">
+                <span className="mr-2 text-xs uppercase tracking-[0.12em] text-white/55">Watermark</span>
+                <input
+                  value={watermark}
+                  onChange={(event) => setWatermark(event.target.value.slice(0, 12))}
+                  maxLength={12}
+                  className="mt-1 w-full rounded-md border border-white/20 bg-night-900/80 px-2 py-1.5 text-sm text-white outline-none focus:border-neon-cyan/50"
+                />
+              </label>
+            </div>
+
+            <p className="mt-4 text-xs uppercase tracking-[0.18em] text-white/60">Estilo de clip</p>
             <div className="mt-2 grid gap-2 sm:grid-cols-2">
               <button
                 type="button"
@@ -470,18 +592,31 @@ export default function AppHomePage() {
           <UploadDropzone
             onUpload={handleUpload}
             isUploading={isUploading}
-            fileName={uploadedVideo?.filename}
+            fileName={uploadedVideo?.filename ?? uploadedAudio?.filename}
+            fileKind={uploadedMediaType ?? (uploadedAudio ? "audio" : "video")}
           />
+          {hasAudio ? (
+            <div className="mt-4 rounded-xl border border-neon-mint/35 bg-neon-mint/10 p-3 text-xs text-neon-mint">
+              Audio cargado correctamente. Ya podes verlo en Biblioteca - Audios y usarlo en los proximos flujos de mezcla.
+            </div>
+          ) : null}
         </Panel>
 
         <Panel>
           <ProjectStatusPanel
             hasVideo={hasVideo}
+            hasAudio={hasAudio}
+            activeMediaType={uploadedMediaType}
             isUploading={isUploading}
             uploadError={uploadError}
             videoId={uploadedVideo?.video_id ?? null}
+            audioId={uploadedAudio?.audio_id ?? null}
             isCreatingJobs={isCreatingJobs}
             jobsCreated={autoJobCount}
+            clipsDone={clipProgress.done}
+            clipsFailed={clipProgress.failed}
+            clipsPending={clipProgress.pending}
+            clipProgressPercent={clipProgress.percent}
             jobError={jobError}
           />
         </Panel>
@@ -489,8 +624,16 @@ export default function AppHomePage() {
       <Panel className="mt-5">
         <GeneratedClipsSection
           clips={visibleClips}
-          showLoading={isUploading || (isCreatingJobs && createdJobs.length === 0) || (isHydratingClips && visibleClips.length === 0)}
+          showLoading={
+            uploadedMediaType !== "audio" &&
+            (isUploading || (isCreatingJobs && createdJobs.length === 0) || (isHydratingClips && visibleClips.length === 0))
+          }
           isRefreshingStatuses={isPollingStatuses}
+          emptyMessage={
+            uploadedMediaType === "audio"
+              ? "Subiste un audio. Los clips se generan cuando subis un video en este panel."
+              : "Todavia no hay clips generados. Subi un video para empezar."
+          }
         />
       </Panel>
     </section>

--- a/frontend/src/app/app/share/[clipId]/page.tsx
+++ b/frontend/src/app/app/share/[clipId]/page.tsx
@@ -2,7 +2,8 @@
 
 import { Button } from "@/src/components/ui/Button";
 import { Panel } from "@/src/components/ui/Panel";
-import { videoApi, type UserClipItem, VideoApiError } from "@/src/services/videoApi";
+import { authApi } from "@/src/services/authApi";
+import { videoApi, type UserClipItem, type YoutubeConnectionStatus, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { Facebook, Instagram, MessageCircle, Music2, Share2, Youtube } from "lucide-react";
 import Link from "next/link";
@@ -10,7 +11,7 @@ import { useParams } from "next/navigation";
 import { type ComponentType, useEffect, useState } from "react";
 
 type SocialTarget = {
-  id: string;
+  id: "instagram" | "tiktok" | "facebook" | "youtube" | "x" | "whatsapp";
   label: string;
   icon: ComponentType<{ size?: number; className?: string }>;
 };
@@ -43,7 +44,13 @@ export default function ShareClipPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
-  const [linkedTargets, setLinkedTargets] = useState<Record<string, boolean>>({});
+  const [youtubeStatus, setYoutubeStatus] = useState<YoutubeConnectionStatus | null>(null);
+  const [isLoadingYoutubeStatus, setIsLoadingYoutubeStatus] = useState(false);
+  const [isPublishingYoutube, setIsPublishingYoutube] = useState(false);
+  const [youtubeTitle, setYoutubeTitle] = useState("");
+  const [youtubeDescription, setYoutubeDescription] = useState("");
+  const [youtubePrivacy, setYoutubePrivacy] = useState<"public" | "private" | "unlisted">("private");
+  const canPublishClip = clip ? ["done", "completed"].includes(clip.status.toLowerCase()) : false;
 
   useEffect(() => {
     if (!token) {
@@ -85,12 +92,76 @@ export default function ShareClipPage() {
       }
     };
 
+    const loadYoutubeStatus = async () => {
+      setIsLoadingYoutubeStatus(true);
+      try {
+        const response = await videoApi.getYoutubeStatus(token);
+        if (!cancelled) {
+          setYoutubeStatus(response);
+        }
+      } catch {
+        if (!cancelled) {
+          setYoutubeStatus(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingYoutubeStatus(false);
+        }
+      }
+    };
+
     void loadClip();
+    void loadYoutubeStatus();
 
     return () => {
       cancelled = true;
     };
   }, [clipId, token]);
+
+  useEffect(() => {
+    if (!clip) {
+      return;
+    }
+
+    setYoutubeTitle(`Clip ${clip.job_id.slice(0, 8)} - Hacelo Corto`);
+    setYoutubeDescription(`Clip generado desde ${clip.source_filename}`);
+  }, [clip]);
+
+  const handleConnectYoutube = async () => {
+    setInfo(null);
+    try {
+      const oauth = await authApi.getGoogleAuthUrl();
+      window.sessionStorage.setItem("google_oauth_state", oauth.state);
+      window.location.href = oauth.authorization_url;
+    } catch {
+      setError("No pudimos iniciar la conexion con YouTube via Google OAuth.");
+    }
+  };
+
+  const handlePublishYoutube = async () => {
+    if (!token || !clip) {
+      setError("No hay sesion activa o clip seleccionado para publicar.");
+      return;
+    }
+
+    setIsPublishingYoutube(true);
+    setError(null);
+    setInfo(null);
+
+    try {
+      const response = await videoApi.publishToYoutube(clip.job_id, token, {
+        title: youtubeTitle.trim() || undefined,
+        description: youtubeDescription.trim() || undefined,
+        privacy: youtubePrivacy
+      });
+
+      setInfo(`Publicado en YouTube: ${response.youtube_url}`);
+    } catch (publishError) {
+      setError(normalizeVideoError(publishError, "No pudimos publicar el clip en YouTube."));
+    } finally {
+      setIsPublishingYoutube(false);
+    }
+  };
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
@@ -138,7 +209,8 @@ export default function ShareClipPage() {
             <div className="space-y-3">
               {socialTargets.map((target, index) => {
                 const Icon = target.icon;
-                const isLinked = Boolean(linkedTargets[target.id]);
+                const isYoutube = target.id === "youtube";
+                const isYoutubeConnected = Boolean(youtubeStatus?.connected);
                 return (
                   <div
                     key={target.id}
@@ -151,38 +223,74 @@ export default function ShareClipPage() {
                           <Icon size={16} className="text-neon-mint" />
                           {target.label}
                         </p>
-                        <p className="mt-1 text-xs text-white/65">{isLinked ? "Cuenta vinculada" : "Cuenta pendiente de vincular"}</p>
+                        <p className="mt-1 text-xs text-white/65">
+                          {isYoutube
+                            ? isLoadingYoutubeStatus
+                              ? "Validando conexion con YouTube..."
+                              : isYoutubeConnected
+                                ? `Cuenta vinculada${youtubeStatus?.provider_username ? ` (${youtubeStatus.provider_username})` : ""}`
+                                : "Cuenta pendiente de vincular"
+                            : "Integracion en roadmap. Disponible proximamente."}
+                        </p>
                       </div>
                       <div className="grid grid-cols-2 gap-2 sm:min-w-[260px]">
                         <Button
                           className="h-9 px-3 py-2 text-xs"
-                          variant={isLinked ? "neutral" : "violet"}
-                          onClick={() => {
-                            if (isLinked) {
-                              setInfo(`Tu cuenta de ${target.label} ya esta vinculada en este entorno de demo.`);
-                              return;
-                            }
-
-                            setLinkedTargets((previous) => ({
-                              ...previous,
-                              [target.id]: true
-                            }));
-                            setInfo(
-                              `Marcamos ${target.label} como vinculada. Cuando backend exponga endpoints, este boton abrira OAuth real para conectar la cuenta.`
-                            );
-                          }}
+                          variant={isYoutubeConnected ? "neutral" : "violet"}
+                          disabled={!isYoutube || isLoadingYoutubeStatus}
+                          onClick={isYoutube ? () => void handleConnectYoutube() : undefined}
                         >
-                          {isLinked ? "Vinculada" : "Vincular cuenta"}
+                          {isYoutubeConnected ? "Reconectar" : "Conectar"}
                         </Button>
                         <Button
                           className="h-9 px-3 py-2 text-xs"
-                          disabled={!isLinked}
-                          onClick={() => setInfo(`Publicacion en ${target.label} preparada. En cuanto tengamos endpoint, esta accion publicara el clip.`)}
+                          disabled={!isYoutube || !isYoutubeConnected || isPublishingYoutube || !canPublishClip}
+                          onClick={isYoutube ? () => void handlePublishYoutube() : undefined}
                         >
-                          Publicar clip
+                          {isPublishingYoutube ? "Publicando..." : "Publicar clip"}
                         </Button>
                       </div>
                     </div>
+
+                    {isYoutube && !canPublishClip ? (
+                      <p className="mt-2 text-xs text-amber-200">Este clip debe estar en estado DONE para poder publicarse en YouTube.</p>
+                    ) : null}
+
+                    {isYoutube ? (
+                      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                        <label className="text-xs text-white/75 sm:col-span-2">
+                          Titulo
+                          <input
+                            value={youtubeTitle}
+                            onChange={(event) => setYoutubeTitle(event.target.value.slice(0, 100))}
+                            maxLength={100}
+                            className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-cyan/50"
+                          />
+                        </label>
+                        <label className="text-xs text-white/75 sm:col-span-2">
+                          Descripcion
+                          <textarea
+                            value={youtubeDescription}
+                            onChange={(event) => setYoutubeDescription(event.target.value.slice(0, 5000))}
+                            maxLength={5000}
+                            rows={3}
+                            className="mt-1 w-full resize-y rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-cyan/50"
+                          />
+                        </label>
+                        <label className="text-xs text-white/75 sm:col-span-2">
+                          Privacidad
+                          <select
+                            value={youtubePrivacy}
+                            onChange={(event) => setYoutubePrivacy(event.target.value as "public" | "private" | "unlisted")}
+                            className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-cyan/50"
+                          >
+                            <option value="private">private</option>
+                            <option value="unlisted">unlisted</option>
+                            <option value="public">public</option>
+                          </select>
+                        </label>
+                      </div>
+                    ) : null}
                   </div>
                 );
               })}

--- a/frontend/src/app/app/share/[clipId]/page.tsx
+++ b/frontend/src/app/app/share/[clipId]/page.tsx
@@ -30,6 +30,10 @@ function normalizeVideoError(error: unknown, fallbackMessage: string) {
     return error.message;
   }
   if (error instanceof Error) {
+    const normalized = error.message.toLowerCase();
+    if (normalized.includes("failed to fetch") || normalized.includes("networkerror")) {
+      return "No pudimos conectar con la API. Verifica que backend este levantado e intenta nuevamente.";
+    }
     return error.message;
   }
   return fallbackMessage;
@@ -65,13 +69,8 @@ export default function ShareClipPage() {
       setIsLoading(true);
       setError(null);
       try {
-        const response = await videoApi.getMyClips(token, {
-          limit: 10,
-          offset: 0,
-          query: clipId
-        });
-
-        const selectedClip = response.clips.find((item) => item.job_id === clipId) ?? null;
+        const response = await videoApi.getMyClipById(clipId, token);
+        const selectedClip = response.clip ?? null;
 
         if (!cancelled) {
           if (!selectedClip) {
@@ -179,8 +178,17 @@ export default function ShareClipPage() {
 
         {isLoading ? <p className="mt-4 text-sm text-white/70">Cargando clip...</p> : null}
 
-        {error ? (
-          <p className="mt-4 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{error}</p>
+      {error ? (
+          <div className="mt-4 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">
+            <p>{error}</p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-2 rounded-lg border border-rose-300/35 bg-rose-300/10 px-2.5 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] text-rose-100 transition hover:bg-rose-300/20"
+            >
+              Reintentar
+            </button>
+          </div>
         ) : null}
 
         {!isLoading && !error && clip ? (

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -200,6 +200,7 @@ export default function TimelinePage() {
         end_sec: normalizedEnd,
         crop_to_vertical: settings.cropToVertical,
         subtitles: settings.subtitles,
+        watermark: settings.watermark,
         face_tracking: settings.faceTracking,
         color_filter: settings.colorFilter
       });

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -3,10 +3,11 @@
 import { VideoSettings } from "@/src/components/home/VideoSettings";
 import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
 import { Panel } from "@/src/components/ui/Panel";
-import { videoApi, type UserAudioItem, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
+import { videoApi, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useVideoSettingsStore } from "@/src/store/useVideoSettingsStore";
-import { Music2, Search } from "lucide-react";
+import { Search } from "lucide-react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
@@ -25,16 +26,6 @@ function normalizeVideoError(error: unknown, fallbackMessage: string) {
   return fallbackMessage;
 }
 
-function isTerminalStatus(status: string) {
-  const normalized = status.toLowerCase();
-  return normalized === "done" || normalized === "completed" || normalized === "failed" || normalized === "error";
-}
-
-function isDoneStatus(status: string) {
-  const normalized = status.toLowerCase();
-  return normalized === "done" || normalized === "completed";
-}
-  
 export default function TimelinePage() {
   const searchParams = useSearchParams();
   const preferredVideoId = searchParams.get("videoId")?.trim() ?? "";
@@ -57,21 +48,6 @@ export default function TimelinePage() {
   const [submitErrorSettings, setSubmitErrorSettings] = useState<string | null>(null);
   const [submitInfoSettings, setSubmitInfoSettings] = useState<string | null>(null);
   const [draftFilename, setDraftFilename] = useState("");
-  const [audios, setAudios] = useState<UserAudioItem[]>([]);
-  const [isLoadingAudios, setIsLoadingAudios] = useState(false);
-  const [audioError, setAudioError] = useState<string | null>(null);
-  const [selectedAudioId, setSelectedAudioId] = useState<string | null>(null);
-  const [selectedAudioUrl, setSelectedAudioUrl] = useState<string | null>(null);
-  const [audioOffsetSec, setAudioOffsetSec] = useState(0);
-  const [audioStartSec, setAudioStartSec] = useState(0);
-  const [audioEndSec, setAudioEndSec] = useState(15);
-  const [audioVolume, setAudioVolume] = useState(1);
-  const [isSubmittingAudio, setIsSubmittingAudio] = useState(false);
-  const [audioSubmitInfo, setAudioSubmitInfo] = useState<string | null>(null);
-  const [audioSubmitError, setAudioSubmitError] = useState<string | null>(null);
-  const [audioJobId, setAudioJobId] = useState<string | null>(null);
-  const [isPollingAudioJob, setIsPollingAudioJob] = useState(false);
-  const [mixedVideoUrl, setMixedVideoUrl] = useState<string | null>(null);
 
 
   const saveRaname =  async()=>{
@@ -187,130 +163,6 @@ export default function TimelinePage() {
     };
   }, [token, page, preferredClipId, preferredVideoId, query]);
 
-  useEffect(() => {
-    if (!token) {
-      setAudios([]);
-      setSelectedAudioId(null);
-      setSelectedAudioUrl(null);
-      return;
-    }
-
-    let cancelled = false;
-
-    const loadAudios = async () => {
-      setIsLoadingAudios(true);
-      setAudioError(null);
-      try {
-        const response = await videoApi.getMyAudios(token, { limit: 50, offset: 0 });
-        if (cancelled) {
-          return;
-        }
-
-        setAudios(response.audios);
-        setSelectedAudioId((prev) => {
-          if (prev && response.audios.some((audio) => audio.audio_id === prev)) {
-            return prev;
-          }
-          return response.audios[0]?.audio_id ?? null;
-        });
-      } catch (loadError) {
-        if (!cancelled) {
-          setAudioError(normalizeVideoError(loadError, "No pudimos cargar tus audios."));
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoadingAudios(false);
-        }
-      }
-    };
-
-    void loadAudios();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [token]);
-
-  useEffect(() => {
-    if (!token || !selectedAudioId) {
-      setSelectedAudioUrl(null);
-      return;
-    }
-
-    let cancelled = false;
-
-    const resolveAudioUrl = async () => {
-      try {
-        const response = await videoApi.getAudioUrl(selectedAudioId, token);
-        if (!cancelled) {
-          setSelectedAudioUrl(response.url);
-        }
-      } catch {
-        if (!cancelled) {
-          setSelectedAudioUrl(null);
-        }
-      }
-    };
-
-    void resolveAudioUrl();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedAudioId, token]);
-
-  useEffect(() => {
-    if (!token || !audioJobId) {
-      setIsPollingAudioJob(false);
-      return;
-    }
-
-    let cancelled = false;
-
-    const syncAudioJob = async () => {
-      try {
-        const status = await videoApi.getJobStatus(audioJobId, token);
-        if (cancelled) {
-          return;
-        }
-
-        if (status.output_path) {
-          setMixedVideoUrl(status.output_path);
-        }
-
-        if (isDoneStatus(status.status)) {
-          setAudioSubmitInfo(`Mezcla de audio lista. Job ${audioJobId.slice(0, 8)} finalizado.`);
-        }
-
-        if (isTerminalStatus(status.status) && (status.output_path || !isDoneStatus(status.status))) {
-          window.clearInterval(intervalId);
-          setIsPollingAudioJob(false);
-
-          if (!isDoneStatus(status.status)) {
-            setAudioSubmitError(`La mezcla de audio termino con estado ${status.status}.`);
-          }
-        }
-      } catch {
-        if (!cancelled) {
-          setAudioSubmitError("No pudimos actualizar el estado del job de mezcla de audio.");
-        }
-      }
-    };
-
-    setIsPollingAudioJob(true);
-    const intervalId = window.setInterval(() => {
-      void syncAudioJob();
-    }, 4000);
-
-    void syncAudioJob();
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-      setIsPollingAudioJob(false);
-    };
-  }, [audioJobId, token]);
-
   const totalPages = Math.max(1, Math.ceil(totalVideos / PAGE_SIZE));
 
   const selectedVideo = useMemo(
@@ -325,9 +177,8 @@ export default function TimelinePage() {
     setDraftFilename(selectedVideo.filename);
   }, [selectedVideo]);
 
-  const selectedPreviewUrl = mixedVideoUrl
-    ? mixedVideoUrl
-    : focusedClip && focusedClip.video_id === selectedVideoId
+  const selectedPreviewUrl =
+    focusedClip && focusedClip.video_id === selectedVideoId
       ? (focusedClip.output_path ?? selectedVideo?.preview_url ?? null)
       : (selectedVideo?.preview_url ?? null);
 
@@ -360,40 +211,6 @@ export default function TimelinePage() {
       setSubmitError(normalizeVideoError(createError, "No pudimos crear el clip desde timeline."));
     } finally {
       setIsSubmitting(false);
-    }
-  };
-
-  const handleAddAudioToVideo = async () => {
-    if (!token || !selectedVideoId || !selectedAudioId) {
-      setAudioSubmitError("Selecciona video y audio para iniciar la mezcla.");
-      return;
-    }
-
-    if (audioEndSec <= audioStartSec) {
-      setAudioSubmitError("El fin del segmento de audio debe ser mayor al inicio.");
-      return;
-    }
-
-    setIsSubmittingAudio(true);
-    setAudioSubmitError(null);
-    setAudioSubmitInfo(null);
-    setMixedVideoUrl(null);
-
-    try {
-      const response = await videoApi.addAudioToVideo(selectedVideoId, token, {
-        audio_id: selectedAudioId,
-        audio_offset_sec: Math.max(0, Math.floor(audioOffsetSec)),
-        audio_start_sec: Math.max(0, Math.floor(audioStartSec)),
-        audio_end_sec: Math.max(1, Math.ceil(audioEndSec)),
-        audio_volume: Math.min(2, Math.max(0.1, Number(audioVolume.toFixed(2))))
-      });
-
-      setAudioJobId(response.job_id);
-      setAudioSubmitInfo(`Mezcla enviada a cola. Job ${response.job_id.slice(0, 8)} en estado ${response.status}.`);
-    } catch (mixError) {
-      setAudioSubmitError(normalizeVideoError(mixError, "No pudimos enviar el job para mezclar audio."));
-    } finally {
-      setIsSubmittingAudio(false);
     }
   };
 
@@ -484,7 +301,6 @@ export default function TimelinePage() {
                       key={video.video_id}
                       onClick={() => {
                         setSelectedVideoId(video.video_id);
-                        setMixedVideoUrl(null);
                         if (focusedClip && focusedClip.video_id !== video.video_id) {
                           setFocusedClip(null);
                         }
@@ -536,94 +352,17 @@ export default function TimelinePage() {
           <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Ajustes de recorte</h3>
           <VideoSettings submitInfoSettings={submitInfoSettings} submitErrorSettings={submitErrorSettings} videoEditarBool={videoEditarBool} draftFilename={draftFilename} setDraftFilename={setDraftFilename} saveRaname={saveRaname} trimStart={trimStart} trimEnd={trimEnd} minClipDurationSec={MIN_CLIP_SECONDS} isSubmitting={isSubmitting} submitInfo={submitInfo} selectedVideoId={selectedVideoId} submitError={submitError}  handleCreateJob={handleCreateJob} />
 
-          <div className="mt-4 rounded-xl border border-neon-mint/30 bg-neon-mint/5 p-3">
-            <p className="text-xs uppercase tracking-[0.18em] text-neon-mint/80">Mezclar audio en video</p>
-
-            {isLoadingAudios ? <p className="mt-2 text-xs text-white/70">Cargando audios...</p> : null}
-            {audioError ? <p className="mt-2 text-xs text-rose-200">{audioError}</p> : null}
-
-            {!isLoadingAudios && audios.length > 0 ? (
-              <>
-                <label className="mt-3 block text-xs text-white/75">
-                  Audio de biblioteca
-                  <select
-                    value={selectedAudioId ?? ""}
-                    onChange={(event) => setSelectedAudioId(event.target.value || null)}
-                    className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
-                  >
-                    {audios.map((audio) => (
-                      <option key={audio.audio_id} value={audio.audio_id}>
-                        {audio.filename}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-
-                {selectedAudioUrl ? <audio controls preload="metadata" className="mt-3 w-full" src={selectedAudioUrl} /> : null}
-
-                <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                  <label className="text-xs text-white/75">
-                    Offset en video (seg)
-                    <input
-                      type="number"
-                      min={0}
-                      value={audioOffsetSec}
-                      onChange={(event) => setAudioOffsetSec(Number(event.target.value || 0))}
-                      className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
-                    />
-                  </label>
-                  <label className="text-xs text-white/75">
-                    Volumen (0.1 - 2.0)
-                    <input
-                      type="number"
-                      min={0.1}
-                      max={2}
-                      step={0.1}
-                      value={audioVolume}
-                      onChange={(event) => setAudioVolume(Number(event.target.value || 1))}
-                      className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
-                    />
-                  </label>
-                  <label className="text-xs text-white/75">
-                    Inicio audio (seg)
-                    <input
-                      type="number"
-                      min={0}
-                      value={audioStartSec}
-                      onChange={(event) => setAudioStartSec(Number(event.target.value || 0))}
-                      className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
-                    />
-                  </label>
-                  <label className="text-xs text-white/75">
-                    Fin audio (seg)
-                    <input
-                      type="number"
-                      min={1}
-                      value={audioEndSec}
-                      onChange={(event) => setAudioEndSec(Number(event.target.value || 1))}
-                      className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
-                    />
-                  </label>
-                </div>
-
-                <button
-                  type="button"
-                  onClick={() => void handleAddAudioToVideo()}
-                  disabled={!selectedVideoId || !selectedAudioId || isSubmittingAudio}
-                  className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-mint/45 bg-neon-mint/15 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neon-mint transition hover:bg-neon-mint/20 disabled:opacity-40"
-                >
-                  <Music2 size={14} /> {isSubmittingAudio ? "Encolando..." : "Aplicar audio al video"}
-                </button>
-
-                {audioSubmitInfo ? <p className="mt-2 text-xs text-neon-mint">{audioSubmitInfo}</p> : null}
-                {audioSubmitError ? <p className="mt-2 text-xs text-rose-200">{audioSubmitError}</p> : null}
-                {isPollingAudioJob ? <p className="mt-2 text-xs text-white/65">Procesando mezcla de audio...</p> : null}
-              </>
-            ) : null}
-
-            {!isLoadingAudios && audios.length === 0 ? (
-              <p className="mt-2 text-xs text-white/70">No hay audios cargados. Subi uno desde Home para mezclarlo aca.</p>
-            ) : null}
+          <div className="mt-4 rounded-xl border border-neon-violet/30 bg-neon-violet/5 p-3">
+            <p className="text-xs uppercase tracking-[0.18em] text-neon-violet/85">Audio Editor</p>
+            <p className="mt-2 text-xs text-white/75">
+              La mezcla de audio ahora vive en una pantalla dedicada para trabajar por pistas.
+            </p>
+            <Link
+              href={selectedVideoId ? `/app/audio_editor?videoId=${selectedVideoId}` : "/app/audio_editor"}
+              className="mt-3 inline-flex w-full items-center justify-center rounded-lg border border-neon-violet/45 bg-neon-violet/15 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neon-violet transition hover:bg-neon-violet/20"
+            >
+              Abrir Audio Editor
+            </Link>
           </div>
         </Panel>
       </div>

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -3,10 +3,10 @@
 import { VideoSettings } from "@/src/components/home/VideoSettings";
 import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
 import { Panel } from "@/src/components/ui/Panel";
-import { videoApi, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
+import { videoApi, type UserAudioItem, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useVideoSettingsStore } from "@/src/store/useVideoSettingsStore";
-import { Search } from "lucide-react";
+import { Music2, Search } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
@@ -23,6 +23,16 @@ function normalizeVideoError(error: unknown, fallbackMessage: string) {
   }
 
   return fallbackMessage;
+}
+
+function isTerminalStatus(status: string) {
+  const normalized = status.toLowerCase();
+  return normalized === "done" || normalized === "completed" || normalized === "failed" || normalized === "error";
+}
+
+function isDoneStatus(status: string) {
+  const normalized = status.toLowerCase();
+  return normalized === "done" || normalized === "completed";
 }
   
 export default function TimelinePage() {
@@ -47,6 +57,21 @@ export default function TimelinePage() {
   const [submitErrorSettings, setSubmitErrorSettings] = useState<string | null>(null);
   const [submitInfoSettings, setSubmitInfoSettings] = useState<string | null>(null);
   const [draftFilename, setDraftFilename] = useState("");
+  const [audios, setAudios] = useState<UserAudioItem[]>([]);
+  const [isLoadingAudios, setIsLoadingAudios] = useState(false);
+  const [audioError, setAudioError] = useState<string | null>(null);
+  const [selectedAudioId, setSelectedAudioId] = useState<string | null>(null);
+  const [selectedAudioUrl, setSelectedAudioUrl] = useState<string | null>(null);
+  const [audioOffsetSec, setAudioOffsetSec] = useState(0);
+  const [audioStartSec, setAudioStartSec] = useState(0);
+  const [audioEndSec, setAudioEndSec] = useState(15);
+  const [audioVolume, setAudioVolume] = useState(1);
+  const [isSubmittingAudio, setIsSubmittingAudio] = useState(false);
+  const [audioSubmitInfo, setAudioSubmitInfo] = useState<string | null>(null);
+  const [audioSubmitError, setAudioSubmitError] = useState<string | null>(null);
+  const [audioJobId, setAudioJobId] = useState<string | null>(null);
+  const [isPollingAudioJob, setIsPollingAudioJob] = useState(false);
+  const [mixedVideoUrl, setMixedVideoUrl] = useState<string | null>(null);
 
 
   const saveRaname =  async()=>{
@@ -162,6 +187,130 @@ export default function TimelinePage() {
     };
   }, [token, page, preferredClipId, preferredVideoId, query]);
 
+  useEffect(() => {
+    if (!token) {
+      setAudios([]);
+      setSelectedAudioId(null);
+      setSelectedAudioUrl(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadAudios = async () => {
+      setIsLoadingAudios(true);
+      setAudioError(null);
+      try {
+        const response = await videoApi.getMyAudios(token, { limit: 50, offset: 0 });
+        if (cancelled) {
+          return;
+        }
+
+        setAudios(response.audios);
+        setSelectedAudioId((prev) => {
+          if (prev && response.audios.some((audio) => audio.audio_id === prev)) {
+            return prev;
+          }
+          return response.audios[0]?.audio_id ?? null;
+        });
+      } catch (loadError) {
+        if (!cancelled) {
+          setAudioError(normalizeVideoError(loadError, "No pudimos cargar tus audios."));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingAudios(false);
+        }
+      }
+    };
+
+    void loadAudios();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    if (!token || !selectedAudioId) {
+      setSelectedAudioUrl(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const resolveAudioUrl = async () => {
+      try {
+        const response = await videoApi.getAudioUrl(selectedAudioId, token);
+        if (!cancelled) {
+          setSelectedAudioUrl(response.url);
+        }
+      } catch {
+        if (!cancelled) {
+          setSelectedAudioUrl(null);
+        }
+      }
+    };
+
+    void resolveAudioUrl();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAudioId, token]);
+
+  useEffect(() => {
+    if (!token || !audioJobId) {
+      setIsPollingAudioJob(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const syncAudioJob = async () => {
+      try {
+        const status = await videoApi.getJobStatus(audioJobId, token);
+        if (cancelled) {
+          return;
+        }
+
+        if (status.output_path) {
+          setMixedVideoUrl(status.output_path);
+        }
+
+        if (isDoneStatus(status.status)) {
+          setAudioSubmitInfo(`Mezcla de audio lista. Job ${audioJobId.slice(0, 8)} finalizado.`);
+        }
+
+        if (isTerminalStatus(status.status) && (status.output_path || !isDoneStatus(status.status))) {
+          window.clearInterval(intervalId);
+          setIsPollingAudioJob(false);
+
+          if (!isDoneStatus(status.status)) {
+            setAudioSubmitError(`La mezcla de audio termino con estado ${status.status}.`);
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setAudioSubmitError("No pudimos actualizar el estado del job de mezcla de audio.");
+        }
+      }
+    };
+
+    setIsPollingAudioJob(true);
+    const intervalId = window.setInterval(() => {
+      void syncAudioJob();
+    }, 4000);
+
+    void syncAudioJob();
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      setIsPollingAudioJob(false);
+    };
+  }, [audioJobId, token]);
+
   const totalPages = Math.max(1, Math.ceil(totalVideos / PAGE_SIZE));
 
   const selectedVideo = useMemo(
@@ -176,8 +325,9 @@ export default function TimelinePage() {
     setDraftFilename(selectedVideo.filename);
   }, [selectedVideo]);
 
-  const selectedPreviewUrl =
-    focusedClip && focusedClip.video_id === selectedVideoId
+  const selectedPreviewUrl = mixedVideoUrl
+    ? mixedVideoUrl
+    : focusedClip && focusedClip.video_id === selectedVideoId
       ? (focusedClip.output_path ?? selectedVideo?.preview_url ?? null)
       : (selectedVideo?.preview_url ?? null);
 
@@ -212,7 +362,42 @@ export default function TimelinePage() {
       setIsSubmitting(false);
     }
   };
-    const videoEditarBool = !Boolean(preferredVideoId && preferredVideoId.trim().length > 0);
+
+  const handleAddAudioToVideo = async () => {
+    if (!token || !selectedVideoId || !selectedAudioId) {
+      setAudioSubmitError("Selecciona video y audio para iniciar la mezcla.");
+      return;
+    }
+
+    if (audioEndSec <= audioStartSec) {
+      setAudioSubmitError("El fin del segmento de audio debe ser mayor al inicio.");
+      return;
+    }
+
+    setIsSubmittingAudio(true);
+    setAudioSubmitError(null);
+    setAudioSubmitInfo(null);
+    setMixedVideoUrl(null);
+
+    try {
+      const response = await videoApi.addAudioToVideo(selectedVideoId, token, {
+        audio_id: selectedAudioId,
+        audio_offset_sec: Math.max(0, Math.floor(audioOffsetSec)),
+        audio_start_sec: Math.max(0, Math.floor(audioStartSec)),
+        audio_end_sec: Math.max(1, Math.ceil(audioEndSec)),
+        audio_volume: Math.min(2, Math.max(0.1, Number(audioVolume.toFixed(2))))
+      });
+
+      setAudioJobId(response.job_id);
+      setAudioSubmitInfo(`Mezcla enviada a cola. Job ${response.job_id.slice(0, 8)} en estado ${response.status}.`);
+    } catch (mixError) {
+      setAudioSubmitError(normalizeVideoError(mixError, "No pudimos enviar el job para mezclar audio."));
+    } finally {
+      setIsSubmittingAudio(false);
+    }
+  };
+
+  const videoEditarBool = !Boolean(preferredVideoId && preferredVideoId.trim().length > 0);
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
@@ -299,6 +484,7 @@ export default function TimelinePage() {
                       key={video.video_id}
                       onClick={() => {
                         setSelectedVideoId(video.video_id);
+                        setMixedVideoUrl(null);
                         if (focusedClip && focusedClip.video_id !== video.video_id) {
                           setFocusedClip(null);
                         }
@@ -349,6 +535,96 @@ export default function TimelinePage() {
           <p className="text-xs uppercase tracking-[0.22em] text-white/65">configuracion</p>
           <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Ajustes de recorte</h3>
           <VideoSettings submitInfoSettings={submitInfoSettings} submitErrorSettings={submitErrorSettings} videoEditarBool={videoEditarBool} draftFilename={draftFilename} setDraftFilename={setDraftFilename} saveRaname={saveRaname} trimStart={trimStart} trimEnd={trimEnd} minClipDurationSec={MIN_CLIP_SECONDS} isSubmitting={isSubmitting} submitInfo={submitInfo} selectedVideoId={selectedVideoId} submitError={submitError}  handleCreateJob={handleCreateJob} />
+
+          <div className="mt-4 rounded-xl border border-neon-mint/30 bg-neon-mint/5 p-3">
+            <p className="text-xs uppercase tracking-[0.18em] text-neon-mint/80">Mezclar audio en video</p>
+
+            {isLoadingAudios ? <p className="mt-2 text-xs text-white/70">Cargando audios...</p> : null}
+            {audioError ? <p className="mt-2 text-xs text-rose-200">{audioError}</p> : null}
+
+            {!isLoadingAudios && audios.length > 0 ? (
+              <>
+                <label className="mt-3 block text-xs text-white/75">
+                  Audio de biblioteca
+                  <select
+                    value={selectedAudioId ?? ""}
+                    onChange={(event) => setSelectedAudioId(event.target.value || null)}
+                    className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
+                  >
+                    {audios.map((audio) => (
+                      <option key={audio.audio_id} value={audio.audio_id}>
+                        {audio.filename}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                {selectedAudioUrl ? <audio controls preload="metadata" className="mt-3 w-full" src={selectedAudioUrl} /> : null}
+
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <label className="text-xs text-white/75">
+                    Offset en video (seg)
+                    <input
+                      type="number"
+                      min={0}
+                      value={audioOffsetSec}
+                      onChange={(event) => setAudioOffsetSec(Number(event.target.value || 0))}
+                      className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
+                    />
+                  </label>
+                  <label className="text-xs text-white/75">
+                    Volumen (0.1 - 2.0)
+                    <input
+                      type="number"
+                      min={0.1}
+                      max={2}
+                      step={0.1}
+                      value={audioVolume}
+                      onChange={(event) => setAudioVolume(Number(event.target.value || 1))}
+                      className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
+                    />
+                  </label>
+                  <label className="text-xs text-white/75">
+                    Inicio audio (seg)
+                    <input
+                      type="number"
+                      min={0}
+                      value={audioStartSec}
+                      onChange={(event) => setAudioStartSec(Number(event.target.value || 0))}
+                      className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
+                    />
+                  </label>
+                  <label className="text-xs text-white/75">
+                    Fin audio (seg)
+                    <input
+                      type="number"
+                      min={1}
+                      value={audioEndSec}
+                      onChange={(event) => setAudioEndSec(Number(event.target.value || 1))}
+                      className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-mint/50"
+                    />
+                  </label>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => void handleAddAudioToVideo()}
+                  disabled={!selectedVideoId || !selectedAudioId || isSubmittingAudio}
+                  className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-mint/45 bg-neon-mint/15 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neon-mint transition hover:bg-neon-mint/20 disabled:opacity-40"
+                >
+                  <Music2 size={14} /> {isSubmittingAudio ? "Encolando..." : "Aplicar audio al video"}
+                </button>
+
+                {audioSubmitInfo ? <p className="mt-2 text-xs text-neon-mint">{audioSubmitInfo}</p> : null}
+                {audioSubmitError ? <p className="mt-2 text-xs text-rose-200">{audioSubmitError}</p> : null}
+                {isPollingAudioJob ? <p className="mt-2 text-xs text-white/65">Procesando mezcla de audio...</p> : null}
+              </>
+            ) : null}
+
+            {!isLoadingAudios && audios.length === 0 ? (
+              <p className="mt-2 text-xs text-white/70">No hay audios cargados. Subi uno desde Home para mezclarlo aca.</p>
+            ) : null}
+          </div>
         </Panel>
       </div>
     </section>

--- a/frontend/src/components/home/GeneratedClipsSection.tsx
+++ b/frontend/src/components/home/GeneratedClipsSection.tsx
@@ -14,6 +14,7 @@ type GeneratedClipsSectionProps = {
   clips: Clip[];
   showLoading: boolean;
   isRefreshingStatuses?: boolean;
+  emptyMessage?: string;
 };
 
 const statusStyles: Record<Clip["status"], string> = {
@@ -22,7 +23,12 @@ const statusStyles: Record<Clip["status"], string> = {
   render: "border-neon-cyan/45 bg-neon-cyan/15 text-neon-cyan"
 };
 
-export function GeneratedClipsSection({ clips, showLoading, isRefreshingStatuses = false }: GeneratedClipsSectionProps) {
+export function GeneratedClipsSection({
+  clips,
+  showLoading,
+  isRefreshingStatuses = false,
+  emptyMessage = "Todavia no hay clips generados. Subi un video para empezar."
+}: GeneratedClipsSectionProps) {
   return (
     <section>
       <p className="text-xs uppercase tracking-[0.22em] text-white/65">clips generados</p>
@@ -40,7 +46,7 @@ export function GeneratedClipsSection({ clips, showLoading, isRefreshingStatuses
         </div>
       ) : clips.length === 0 ? (
         <div className="mt-5 rounded-2xl border border-white/10 bg-night-900/45 p-6 text-sm text-white/70">
-          Todavia no hay clips generados. Subi un video para empezar.
+          {emptyMessage}
         </div>
       ) : (
         <div className="mt-5 grid justify-center gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/frontend/src/components/home/ProjectStatusPanel.tsx
+++ b/frontend/src/components/home/ProjectStatusPanel.tsx
@@ -3,38 +3,67 @@ import { Loader } from "@/src/components/ui/Loader";
 
 type ProjectStatusPanelProps = {
   hasVideo: boolean;
+  hasAudio: boolean;
+  activeMediaType: "video" | "audio" | null;
   isUploading: boolean;
   uploadError: string | null;
   videoId: string | null;
+  audioId: string | null;
   isCreatingJobs: boolean;
   jobsCreated: number;
+  clipsDone: number;
+  clipsFailed: number;
+  clipsPending: number;
+  clipProgressPercent: number;
   jobError: string | null;
 };
 
 export function ProjectStatusPanel({
   hasVideo,
+  hasAudio,
+  activeMediaType,
   isUploading,
   uploadError,
   videoId,
+  audioId,
   isCreatingJobs,
   jobsCreated,
+  clipsDone,
+  clipsFailed,
+  clipsPending,
+  clipProgressPercent,
   jobError
 }: ProjectStatusPanelProps) {
-  const status = uploadError
-    ? "Error de carga"
-    : jobError
-      ? "Error al crear clips"
-      : isUploading
-        ? "Subiendo video"
-        : isCreatingJobs
-          ? "Creando clips"
-          : jobsCreated > 0
-            ? "Clips en proceso"
-            : hasVideo
-              ? "Video cargado"
-              : "Sin video";
+  let status = "Sin video";
+  if (uploadError) {
+    status = "Error de carga";
+  } else if (jobError) {
+    status = "Error al crear clips";
+  } else if (isUploading) {
+    status = "Subiendo archivo";
+  } else if (isCreatingJobs) {
+    status = "Creando clips";
+  } else if (jobsCreated > 0 && clipsPending > 0) {
+    status = "Clips en proceso";
+  } else if (jobsCreated > 0) {
+    status = "Clips listos";
+  } else if (hasAudio) {
+    status = "Audio cargado";
+  } else if (hasVideo) {
+    status = "Video cargado";
+  }
 
-  const progress = isUploading ? 35 : isCreatingJobs ? 70 : jobsCreated > 0 ? 100 : hasVideo ? 55 : 0;
+  const progress = isUploading
+    ? 30
+    : isCreatingJobs
+      ? 55
+      : jobsCreated > 0
+        ? Math.max(55, clipProgressPercent)
+        : hasAudio
+          ? 100
+          : hasVideo
+            ? 45
+            : 0;
 
   return (
     <section>
@@ -62,12 +91,19 @@ export function ProjectStatusPanel({
       </div>
 
       <ul className="mt-4 space-y-2 text-sm text-white/80">
-        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Upload recibido</li>
+        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
+          Upload recibido{activeMediaType ? ` (${activeMediaType})` : ""}
+        </li>
         <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Generacion automatica de segmentos</li>
         <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Encolado de jobs de reframe</li>
       </ul>
-      {jobsCreated > 0 ? <p className="mt-3 text-xs text-neon-cyan">Jobs creados: {jobsCreated}</p> : null}
+      {jobsCreated > 0 ? (
+        <p className="mt-3 text-xs text-neon-cyan">
+          Jobs creados: {jobsCreated} | listos: {clipsDone} | en proceso: {clipsPending} | con error: {clipsFailed}
+        </p>
+      ) : null}
       {videoId ? <p className="mt-3 text-xs text-white/60">ID de video: {videoId}</p> : null}
+      {audioId ? <p className="mt-3 text-xs text-white/60">ID de audio: {audioId}</p> : null}
       {uploadError ? (
         <p className="mt-3 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{uploadError}</p>
       ) : null}
@@ -76,7 +112,7 @@ export function ProjectStatusPanel({
       ) : null}
 
       {isUploading || isCreatingJobs ? (
-        <Loader className="mt-4" label={isUploading ? "Subiendo video..." : "Creando clips automaticos..."} />
+        <Loader className="mt-4" label={isUploading ? "Subiendo archivo..." : "Creando clips automaticos..."} />
       ) : null}
     </section>
   );

--- a/frontend/src/components/home/ProjectStatusPanel.tsx
+++ b/frontend/src/components/home/ProjectStatusPanel.tsx
@@ -65,6 +65,11 @@ export function ProjectStatusPanel({
             ? 45
             : 0;
 
+  const trackedTotal = Math.max(jobsCreated, clipsDone + clipsFailed + clipsPending);
+  const donePct = trackedTotal > 0 ? Math.round((clipsDone / trackedTotal) * 100) : 0;
+  const failedPct = trackedTotal > 0 ? Math.round((clipsFailed / trackedTotal) * 100) : 0;
+  const pendingPct = Math.max(0, 100 - donePct - failedPct);
+
   return (
     <section>
       <div className="flex items-center justify-between gap-3">
@@ -82,12 +87,27 @@ export function ProjectStatusPanel({
           <span className="text-white/80">Progreso</span>
           <span className="text-white">{progress}%</span>
         </div>
-        <div className="mt-2 h-2 rounded-full bg-night-950/90">
+        <div className="mt-2 h-2 overflow-hidden rounded-full bg-night-950/90">
           <div
             className="h-full rounded-full bg-gradient-to-r from-neon-cyan to-neon-violet transition-all duration-500"
             style={{ width: `${progress}%` }}
           />
         </div>
+
+        {trackedTotal > 0 ? (
+          <>
+            <div className="mt-3 h-2 overflow-hidden rounded-full border border-white/10 bg-night-950/90">
+              <div className="flex h-full w-full">
+                <div className="h-full bg-emerald-400/85" style={{ width: `${donePct}%` }} />
+                <div className="h-full bg-rose-400/85" style={{ width: `${failedPct}%` }} />
+                <div className="h-full bg-sky-400/70" style={{ width: `${pendingPct}%` }} />
+              </div>
+            </div>
+            <p className="mt-2 text-[11px] text-white/65">
+              Verde: listos · Rojo: con error · Celeste: pendientes
+            </p>
+          </>
+        ) : null}
       </div>
 
       <ul className="mt-4 space-y-2 text-sm text-white/80">

--- a/frontend/src/components/home/UploadDropzone.tsx
+++ b/frontend/src/components/home/UploadDropzone.tsx
@@ -2,16 +2,17 @@
 
 import { Button } from "@/src/components/ui/Button";
 import { Loader } from "@/src/components/ui/Loader";
-import { CloudUpload, Film } from "lucide-react";
+import { AudioLines, CloudUpload, Film } from "lucide-react";
 import { useRef, useState } from "react";
 
 type UploadDropzoneProps = {
   onUpload: (file: File) => Promise<void>;
   isUploading: boolean;
   fileName?: string;
+  fileKind?: "video" | "audio";
 };
 
-export function UploadDropzone({ onUpload, isUploading, fileName }: UploadDropzoneProps) {
+export function UploadDropzone({ onUpload, isUploading, fileName, fileKind = "video" }: UploadDropzoneProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -42,11 +43,11 @@ export function UploadDropzone({ onUpload, isUploading, fileName }: UploadDropzo
         borderClass
       ].join(" ")}
     >
-      <input
-        ref={inputRef}
-        type="file"
-        accept="video/*"
-        className="hidden"
+        <input
+          ref={inputRef}
+          type="file"
+          accept="video/*,audio/*"
+          className="hidden"
         onChange={(event) => {
           const file = event.target.files?.[0] ?? null;
           void processFile(file);
@@ -55,12 +56,12 @@ export function UploadDropzone({ onUpload, isUploading, fileName }: UploadDropzo
       />
 
       <div className="mb-4 grid h-14 w-14 place-items-center rounded-2xl border border-neon-cyan/50 bg-neon-cyan/10 text-neon-cyan">
-        <Film size={18} />
+        {fileKind === "audio" ? <AudioLines size={18} /> : <Film size={18} />}
       </div>
 
-      <p className="text-xs uppercase tracking-[0.22em] text-neon-cyan/80">carga de video</p>
-      <h2 className="mt-2 font-display text-2xl text-white sm:text-3xl">Arrastra tu video o subilo con un click</h2>
-      <p className="mt-2 max-w-xl text-sm text-white/70">Soporta archivos de video. Recomendado: mp4 horizontal 16:9 para mejores resultados.</p>
+      <p className="text-xs uppercase tracking-[0.22em] text-neon-cyan/80">carga de media</p>
+      <h2 className="mt-2 font-display text-2xl text-white sm:text-3xl">Arrastra tu video o audio, o subilo con un click</h2>
+      <p className="mt-2 max-w-xl text-sm text-white/70">Soporta videos y audios. Recomendado para clips: mp4 horizontal 16:9.</p>
 
       <Button
         className="mt-6 w-auto min-w-52"
@@ -72,7 +73,11 @@ export function UploadDropzone({ onUpload, isUploading, fileName }: UploadDropzo
       </Button>
 
       {isUploading ? <Loader className="mt-4" label="Procesando archivo..." /> : null}
-      {!isUploading && fileName ? <p className="mt-4 text-sm text-neon-mint">Archivo cargado: {fileName}</p> : null}
+      {!isUploading && fileName ? (
+        <p className="mt-4 text-sm text-neon-mint">
+          Archivo cargado ({fileKind === "audio" ? "audio" : "video"}): {fileName}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/home/VideoSettings.tsx
+++ b/frontend/src/components/home/VideoSettings.tsx
@@ -30,7 +30,7 @@ const settingItems: Array<{ key: keyof VideoSettings; label: string }> = [
 export function VideoSettings( {submitInfoSettings,submitErrorSettings, trimStart,videoEditarBool,draftFilename,setDraftFilename, saveRaname,  trimEnd, minClipDurationSec, isSubmitting,  submitInfo, submitError,selectedVideoId,handleCreateJob}:ButtonGeneraRecorte){
       const settings = useVideoSettingsStore((state) => state.settings);
       const saveSettings = useVideoSettingsStore((state) => state.saveSettings);
-      const [draft, setDraft] = useState<VideoSettings>(settings);
+      const [draft, setDraft] = useState<VideoSettings>({ ...settings, watermark: settings.watermark ?? "Hacelo Corto" });
       const selectedDuration = Math.max(0, Math.ceil(trimEnd) - Math.floor(trimStart));
       const canCreateClip = Boolean(selectedVideoId) && selectedDuration >= minClipDurationSec;
       
@@ -61,6 +61,20 @@ export function VideoSettings( {submitInfoSettings,submitErrorSettings, trimStar
                         />
                       </label>
                     ))}
+
+                    <label className="block rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90">
+                      <span className="text-xs uppercase tracking-[0.12em] text-white/65">Watermark</span>
+                      <input
+                        type="text"
+                        value={draft.watermark}
+                        onChange={(event) => {
+                          const value = event.target.value.slice(0, 12);
+                          setDraft((prev) => ({ ...prev, watermark: value }));
+                        }}
+                        maxLength={12}
+                        className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/70 px-3 py-2 text-xs text-white outline-none transition focus:border-neon-cyan/50"
+                      />
+                    </label>
                   </div>
     {
           !videoEditarBool&&(

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,10 +1,11 @@
-import { Film, Home, Upload, Waypoints, X } from "lucide-react";
+import { AudioLines, Film, Home, Upload, Waypoints, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const items = [
   { icon: Home, label: "Panel", href: "/app" },
   { icon: Waypoints, label: "Timeline editor", href: "/app/timeline" },
+  { icon: AudioLines, label: "Audio editor", href: "/app/audio_editor" },
   { icon: Film, label: "Biblioteca clips", href: "/app/library" },
   { icon: Upload, label: "Exportacion", href: "/app/export" }
 ];

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -29,6 +29,32 @@ export type VideoFromJobResponse = {
   uploaded_at: string;
 };
 
+export type YoutubePublishRequest = {
+  title?: string;
+  description?: string;
+  privacy?: "public" | "private" | "unlisted";
+};
+
+export type YoutubePublishResponse = {
+  success: boolean;
+  message: string;
+  job_id: string;
+  youtube_video_id: string;
+  youtube_url: string;
+  title: string;
+  privacy: string;
+  thumbnail_url: string | null;
+};
+
+export type YoutubeConnectionStatus = {
+  connected: boolean;
+  message: string | null;
+  provider_username: string | null;
+  provider_user_id: string | null;
+  token_expires_at: string | null;
+  is_expired: boolean | null;
+};
+
 export type AudioUploadResponse = {
   audio_id: string;
   bucket: string;
@@ -370,6 +396,30 @@ export const videoApi = {
     });
 
     return parseResponse<VideoFromJobResponse>(response);
+  },
+
+  async getYoutubeStatus(token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/youtube/status`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<YoutubeConnectionStatus>(response);
+  },
+
+  async publishToYoutube(jobId: string, token: string, payload: YoutubePublishRequest) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/youtube/publish/${jobId}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    return parseResponse<YoutubePublishResponse>(response);
   },
 
   async createAutoReframeJobs(

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -19,6 +19,16 @@ export type VideoUrlResponse = {
   filename: string;
 };
 
+export type VideoFromJobResponse = {
+  video_id: string;
+  bucket: string;
+  object_key: string;
+  filename: string;
+  user_id: string | null;
+  storage_path: string;
+  uploaded_at: string;
+};
+
 export type AudioUploadResponse = {
   audio_id: string;
   bucket: string;
@@ -87,10 +97,36 @@ export type ReframeJobResponse = {
   created_at: string;
 };
 
+export type AddAudioJobRequest = {
+  audio_id: string;
+  audio_offset_sec: number;
+  audio_start_sec: number;
+  audio_end_sec: number;
+  audio_volume: number;
+};
+
+export type AddAudioJobResponse = {
+  job_id: string;
+  job_type: string;
+  status: string;
+  filename: string;
+  audio_filename: string;
+  audio_volume: number;
+  created_at: string;
+};
+
 export type JobStatusResponse = {
   job_id: string;
   status: string;
   output_path: string | null;
+};
+
+type RawOutputPath = string | Record<string, unknown> | null;
+
+type RawJobStatusResponse = {
+  job_id: string;
+  status: string;
+  output_path: RawOutputPath;
 };
 
 export type UserClipItem = {
@@ -100,6 +136,26 @@ export type UserClipItem = {
   output_path: string | null;
   source_filename: string;
   created_at: string;
+};
+
+type RawUserClipItem = {
+  job_id: string;
+  video_id: string;
+  status: string;
+  output_path: RawOutputPath;
+  source_filename: string;
+  created_at: string;
+};
+
+type RawUserClipsResponse = {
+  total: number;
+  limit: number;
+  offset: number;
+  clips: RawUserClipItem[];
+};
+
+type RawUserClipDetailResponse = {
+  clip: RawUserClipItem;
 };
 
 export type UserClipsResponse = {
@@ -194,6 +250,46 @@ function getErrorMessage(payload: unknown) {
   return null;
 }
 
+function extractPlayableUrl(outputPath: RawOutputPath) {
+  if (!outputPath) {
+    return null;
+  }
+
+  if (typeof outputPath === "string") {
+    const cleaned = outputPath.trim();
+    return cleaned.length > 0 ? cleaned : null;
+  }
+
+  if (typeof outputPath !== "object") {
+    return null;
+  }
+
+  const map = outputPath as Record<string, unknown>;
+  const preferredKeys = ["video", "url", "preview_url", "previewUrl"];
+
+  for (const key of preferredKeys) {
+    const candidate = map[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+
+  for (const candidate of Object.values(map)) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function normalizeUserClip(raw: RawUserClipItem): UserClipItem {
+  return {
+    ...raw,
+    output_path: extractPlayableUrl(raw.output_path)
+  };
+}
+
 async function parseResponse<T>(response: Response) {
   if (response.status === 204) {
     return null as T;
@@ -265,6 +361,17 @@ export const videoApi = {
     return parseResponse<VideoUrlResponse>(response);
   },
 
+  async createVideoFromJob(jobId: string, token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/videos/from-job/${jobId}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<VideoFromJobResponse>(response);
+  },
+
   async createAutoReframeJobs(
     videoId: string,
     token: string,
@@ -329,6 +436,19 @@ export const videoApi = {
     return parseResponse<ReframeJobResponse>(response);
   },
 
+  async addAudioToVideo(videoId: string, token: string, payload: AddAudioJobRequest) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/jobs/add-audio/${videoId}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    return parseResponse<AddAudioJobResponse>(response);
+  },
+
   async getJobStatus(jobId: string, token: string) {
     const response = await fetch(`${apiBaseUrl}/api/v1/jobs/status/${jobId}`, {
       method: "GET",
@@ -337,7 +457,11 @@ export const videoApi = {
       }
     });
 
-    return parseResponse<JobStatusResponse>(response);
+    const payload = await parseResponse<RawJobStatusResponse>(response);
+    return {
+      ...payload,
+      output_path: extractPlayableUrl(payload.output_path)
+    } satisfies JobStatusResponse;
   },
 
   async getMyClips(token: string, options?: { limit?: number; offset?: number; query?: string }) {
@@ -358,7 +482,11 @@ export const videoApi = {
       }
     });
 
-    return parseResponse<UserClipsResponse>(response);
+    const payload = await parseResponse<RawUserClipsResponse>(response);
+    return {
+      ...payload,
+      clips: payload.clips.map(normalizeUserClip)
+    } satisfies UserClipsResponse;
   },
 
   async deleteMyClip(jobId: string, token: string) {
@@ -380,7 +508,10 @@ export const videoApi = {
       }
     });
 
-    return parseResponse<UserClipDetailResponse>(response);
+    const payload = await parseResponse<RawUserClipDetailResponse>(response);
+    return {
+      clip: normalizeUserClip(payload.clip)
+    } satisfies UserClipDetailResponse;
   },
 
   async getMyVideos(token: string, options?: { limit?: number; offset?: number; query?: string }) {

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -19,6 +19,25 @@ export type VideoUrlResponse = {
   filename: string;
 };
 
+export type AudioUploadResponse = {
+  audio_id: string;
+  bucket: string;
+  object_key: string;
+  filename: string;
+  content_type: string | null;
+  size_bytes: number;
+  user_id: string | null;
+  storage_path: string;
+  uploaded_at: string;
+};
+
+export type AudioUrlResponse = {
+  audio_id: string;
+  url: string;
+  expires_in_seconds: number;
+  filename: string;
+};
+
 export type AutoReframeJobItem = {
   job_id: string;
   job_type: string;
@@ -39,7 +58,11 @@ export type AutoReframeResponse = {
 
 type AutoReframeResponseV2 = {
   job_id: string;
+  job_type: string;
+  status: string;
+  filename: string;
   total_jobs: number;
+  created_at: string;
 };
 
 export type ReframeJobRequest = {
@@ -47,6 +70,7 @@ export type ReframeJobRequest = {
   end_sec: number;
   crop_to_vertical?: boolean;
   subtitles?: boolean;
+  watermark?: string;
   face_tracking?: boolean;
   color_filter?: boolean;
   output_style?: "vertical" | "speaker_split";
@@ -112,6 +136,20 @@ export type UserVideosResponse = {
   limit: number;
   offset: number;
   videos: UserVideoItem[];
+};
+
+export type UserAudioItem = {
+  audio_id: string;
+  filename: string;
+  status: string | null;
+  uploaded_at: string;
+};
+
+export type UserAudiosResponse = {
+  total: number;
+  limit: number;
+  offset: number;
+  audios: UserAudioItem[];
 };
 
 const apiBaseUrl = env.apiBaseUrl.replace(/\/$/, "");
@@ -195,6 +233,26 @@ export const videoApi = {
     return parseResponse<VideoUploadResponse>(response);
   },
 
+  async uploadAudio(file: File, token?: string | null) {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const hasToken = Boolean(token && token.trim().length > 0);
+    if (!hasToken) {
+      throw new VideoApiError("Necesitas iniciar sesion para subir audios.", 401);
+    }
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/audios/audio`, {
+      method: "POST",
+      body: formData,
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<AudioUploadResponse>(response);
+  },
+
   async getVideoUrl(videoId: string, expiresInSeconds = 3600) {
     const params = new URLSearchParams({
       expires_in: String(expiresInSeconds)
@@ -215,13 +273,18 @@ export const videoApi = {
       clipDurationSec?: number;
       outputStyle?: "vertical" | "speaker_split";
       contentProfile?: "auto" | "interview" | "sports" | "music";
+      subtitles?: boolean;
+      watermark?: string;
     }
   ) {
+    const watermark = options?.watermark?.trim();
     const body: Record<string, unknown> = {
       clips_count: options?.clipsCount ?? 3,
       clip_duration_sec: options?.clipDurationSec ?? 15,
       output_style: options?.outputStyle ?? "vertical",
-      content_profile: options?.contentProfile ?? "auto"
+      content_profile: options?.contentProfile ?? "auto",
+      subtitles: options?.subtitles ?? false,
+      watermark: watermark && watermark.length > 0 ? watermark : "Hacelo Corto"
     };
 
     const auto2Response = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto2`, {
@@ -250,20 +313,7 @@ export const videoApi = {
       };
     }
 
-    if (auto2Response.status !== 404) {
-      return parseResponse<AutoReframeResponse>(auto2Response);
-    }
-
-    const fallbackResponse = await fetch(`${apiBaseUrl}/api/v1/jobs/reframe/${videoId}/auto`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`
-      },
-      body: JSON.stringify(body)
-    });
-
-    return parseResponse<AutoReframeResponse>(fallbackResponse);
+    return parseResponse<AutoReframeResponse>(auto2Response);
   },
 
   async createReframeJob(videoId: string, token: string, payload: ReframeJobRequest) {
@@ -380,6 +430,53 @@ export const videoApi = {
 
   async deleteMyVideo(videoId: string, token: string) {
     const response = await fetch(`${apiBaseUrl}/api/v1/videos/${videoId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<null>(response);
+  },
+
+  async getMyAudios(token: string, options?: { limit?: number; offset?: number; query?: string }) {
+    const params = new URLSearchParams({
+      limit: String(options?.limit ?? 20),
+      offset: String(options?.offset ?? 0)
+    });
+
+    const query = options?.query?.trim();
+    if (query) {
+      params.set("q", query);
+    }
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/audios/my-audios?${params.toString()}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<UserAudiosResponse>(response);
+  },
+
+  async getAudioUrl(audioId: string, token: string, expiresInSeconds = 3600) {
+    const params = new URLSearchParams({
+      expires_in: String(expiresInSeconds)
+    });
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/audios/${audioId}/url?${params.toString()}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<AudioUrlResponse>(response);
+  },
+
+  async deleteMyAudio(audioId: string, token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/audios/${audioId}`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`

--- a/frontend/src/store/useVideoSettingsStore.ts
+++ b/frontend/src/store/useVideoSettingsStore.ts
@@ -6,6 +6,7 @@ export type VideoSettings = {
   subtitles: boolean;
   faceTracking: boolean;
   colorFilter: boolean;
+  watermark: string;
   videoStart: number;
   videoEnd: number;
 };
@@ -15,6 +16,7 @@ const defaultSettings: VideoSettings = {
   subtitles: true,
   faceTracking: false,
   colorFilter: false,
+  watermark: "Hacelo Corto",
   videoStart: 0,
   videoEnd: 60
 };


### PR DESCRIPTION
#Frontend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feat/frontend-auto2-audio-progress-clean`

### Objetivo

Alinear el frontend con los cambios recientes de backend: dejar de usar el endpoint legacy `/auto`, exponer opciones nuevas de subtitulos/watermark, mostrar progreso real de creacion de clips y agregar soporte inicial de audios en Home + Library.

### Cambios implementados en curso

- Se actualizo `frontend/src/services/videoApi.ts` para eliminar el fallback al endpoint removido `/api/v1/jobs/reframe/{video_id}/auto`; ahora Home usa solo `POST /auto2`.
- Se ampliaron los payloads de jobs (auto y manual) para soportar `subtitles` y `watermark`, con UI de configuracion en Home y Timeline.
- Se agrego seguimiento de avance real en Home (`ProjectStatusPanel`), mostrando porcentaje y conteo de jobs listos/en proceso/error durante la generacion de clips.
- Se extendio la carga inicial para aceptar archivos de audio (`video/*,audio/*`) y se incorporaron endpoints de audios en `videoApi` (`upload`, `list`, `url`, `delete`).
- Se agrego vista de `Audios` en `frontend/src/app/app/library/page.tsx` con busqueda, preview bajo demanda y eliminacion.
- Se ajustaron mensajes de estado para diferenciar uploads de video/audio sin romper la experiencia de clips.
- Hotfix: se restauro normalizacion de `output_path` (cuando backend responde JSON) en `frontend/src/services/videoApi.ts` para evitar previews rotos con `src="[object Object]"`.
- Se agrego en `frontend/src/app/app/timeline/page.tsx` el flujo de mezcla de audio sobre video: seleccion de audio, preview, parametros (`offset`, `start/end`, `volume`) y envio de job a `POST /api/v1/jobs/add-audio/{video_id}`.
- Se incorporo polling de estado para jobs de mezcla de audio en Timeline y preview del output final cuando el backend devuelve `output_path`.
- Se reforzo la visualizacion de avance en `frontend/src/components/home/ProjectStatusPanel.tsx` con barra segmentada por estados (listo/error/pendiente) y colores diferenciados.
- Se rediseño la card de audio en `frontend/src/app/app/library/page.tsx` para que tenga look catppuccin (gradientes violeta/rosa, onda visual y reproductor de preview mas integrado al estilo actual).
- Se integro `POST /api/v1/videos/from-job/{job_id}` en `frontend/src/app/app/library/page.tsx` para importar clips como videos reeditables desde la biblioteca.
- Se movio el flujo de mezcla a una nueva ruta dedicada `frontend/src/app/app/audio_editor/page.tsx` (selector de video + audio, parametros y visual de pistas), y Timeline ahora solo enlaza al nuevo editor.
- Se agrego acceso directo desde biblioteca de clips a `Audio editor` con query params (`videoId`, `clipId`) para abrir el video correcto.
- Fix UX: se acotaron pistas y campos del `Audio editor` a la duracion real del video/audio para evitar que el track se desborde visualmente o exceda el largo maximo permitido.
- Ajuste de biblioteca: se removio `Importar a Videos` en cards de clips y se priorizo navegacion directa a `Timeline` + `Audio editor`.
- Se integro flujo real de YouTube en `frontend/src/app/app/share/[clipId]/page.tsx`: estado de conexion, CTA de conexion OAuth Google y publicacion real por `POST /api/v1/youtube/publish/{job_id}`.
- Se agregaron en `frontend/src/services/videoApi.ts` los contratos para `GET /api/v1/youtube/status` y `POST /api/v1/youtube/publish/{job_id}`.
- Hotfix share: se cambio la carga del clip a `GET /api/v1/jobs/{job_id}` (en lugar de busqueda por listado) y se agrego mensaje/reintento explicito para errores de red (`Failed to fetch`).
- Se agrego asset de demo para landing en `frontend/public/landing-demos/video2_entrevista.mp4` para habilitar preview real en Home (`/landing-demos/video2_entrevista.mp4`).

### Commits de esta rama (frontend)

- `feat(frontend): sync auto2 flow, clip progress and audio library support`
- `docs(frontend): log auto2 and audio frontend refresh`
- `feat(frontend): add timeline audio-mix workflow and segmented clip progress`
- `feat(frontend): add import-from-job action in clips library`
- `feat(frontend): move audio workflow into dedicated audio editor route`
- `feat(frontend): connect share screen to real youtube publish endpoints`

### Validaciones locales

Ejecutado en `frontend/`:

- `npm run lint` -> OK
- `npm run build` -> OK
- `npm run test -- --run` -> OK
