### PR TITLE
fix(frontend): sync home polling progress and simplify status panel

### DIFF
--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -2,7 +2,49 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feat/frontend-auto2-audio-progress-clean`
+Rama de trabajo actual: `feat/frontend-home-status-polling-subtitles`
+
+## Objetivo de la rama
+
+Pulir Home para que el estado de generacion avance en tiempo real sin recarga manual, simplificar la UI del panel de estado y exponer acceso a subtitulos por clip.
+
+Rama de trabajo: `feat/frontend-home-status-polling-subtitles`.
+
+## Cambios realizados
+
+- Se simplifico `frontend/src/components/home/ProjectStatusPanel.tsx` para mostrar solo dos barras: `Subida de archivo` y `Generacion de clips`, removiendo IDs tecnicos y bloques de estado sobrecargados.
+- Se ajusto el polling de Home en `frontend/src/app/app/page.tsx` para soportar orquestador `auto2` (`orchestrator_job_id`) y resolver `child_jobs` desde `GET /api/v1/jobs/status/{job_id}`.
+- Se corrigio la hidratacion de resultados en Home para que continue mientras existan jobs no terminales, evitando que la lista quede congelada hasta navegar o recargar.
+- Se robustecio el calculo de progreso priorizando estados terminales obtenidos desde biblioteca cuando el estado local aun no se actualizo.
+- Se extendio `frontend/src/services/videoApi.ts` para extraer `child_jobs` y `subtitles_path` del `output_path`, y se forzo `cache: "no-store"` en `getJobStatus`/`getMyClips`.
+- Se actualizo `frontend/src/components/home/GeneratedClipsSection.tsx` con CTA `Ver subtitulos (.srt)` cuando el backend devuelve URL de subtitulos.
+
+## Commits realizados
+
+- `fix(frontend): sync home polling progress and simplify project status panel`
+
+## Archivos clave
+
+- `frontend/src/app/app/page.tsx`
+- `frontend/src/components/home/ProjectStatusPanel.tsx`
+- `frontend/src/components/home/GeneratedClipsSection.tsx`
+- `frontend/src/services/videoApi.ts`
+- `docs/frontend-pr-log.md`
+
+## Validaciones locales
+
+Ejecutado en `frontend/`:
+
+- `npm run lint` -> OK
+- `npm run build` -> OK
+
+## Checklist antes de PR a develop
+
+- [x] Rama nueva creada para cambios posteriores al merge previo
+- [x] Cambios limitados al alcance frontend/documentacion de esta iteracion
+- [x] `npm run lint` OK
+- [x] `npm run build` OK
+- [x] Documentacion actualizada
 
 ### Objetivo
 

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -19,6 +19,11 @@ const HOME_DRAFT_KEY = "home:uploaded-video-draft";
 type ClipOutputStyle = "vertical" | "speaker_split";
 type ClipContentProfile = "auto" | "interview" | "sports" | "music";
 type UploadedMediaType = "video" | "audio";
+type JobStatusInfo = {
+  status: string;
+  outputPath: string | null;
+  subtitlesPath: string | null;
+};
 
 function toTimeLabel(seconds: number) {
   const min = Math.floor(seconds / 60)
@@ -45,7 +50,7 @@ function mapJobStatusToClipStatus(status: string): Clip["status"] {
 
 function mapJobsToClips(
   jobs: AutoReframeJobItem[],
-  jobStatusMap: Record<string, { status: string; outputPath: string | null }>,
+  jobStatusMap: Record<string, JobStatusInfo>,
   fallbackClips: UserClipItem[]
 ): Clip[] {
   const fallbackByJobId = new Map(fallbackClips.map((clip) => [clip.job_id, clip]));
@@ -61,7 +66,8 @@ function mapJobsToClips(
       duration: toTimeLabel(Math.max(job.end_sec - job.start_sec, 0)),
       preset: "Auto Reframe",
       status: mapJobStatusToClipStatus(status),
-      previewUrl: statusInfo?.outputPath ?? fallbackClip?.output_path ?? null
+      previewUrl: statusInfo?.outputPath ?? fallbackClip?.output_path ?? null,
+      subtitlesUrl: statusInfo?.subtitlesPath ?? null
     };
   });
 
@@ -150,7 +156,8 @@ export default function AppHomePage() {
   const [uploadedMediaType, setUploadedMediaType] = useState<UploadedMediaType | null>(null);
   const [autoJobCount, setAutoJobCount] = useState(0);
   const [createdJobs, setCreatedJobs] = useState<AutoReframeJobItem[]>([]);
-  const [jobStatusMap, setJobStatusMap] = useState<Record<string, { status: string; outputPath: string | null }>>({});
+  const [jobStatusMap, setJobStatusMap] = useState<Record<string, JobStatusInfo>>({});
+  const [orchestratorJobId, setOrchestratorJobId] = useState<string | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [jobError, setJobError] = useState<string | null>(null);
   const [isHydratingClips, setIsHydratingClips] = useState(false);
@@ -178,7 +185,8 @@ export default function AppHomePage() {
     });
 
     fallbackClips.forEach((clip) => {
-      if (!statusByJob.has(clip.job_id)) {
+      const current = statusByJob.get(clip.job_id);
+      if (!current || (!isTerminalStatus(current) && isTerminalStatus(clip.status))) {
         statusByJob.set(clip.job_id, clip.status);
       }
     });
@@ -212,6 +220,7 @@ export default function AppHomePage() {
         uploadedMediaType?: UploadedMediaType | null;
         createdJobs: AutoReframeJobItem[];
         autoJobCount: number;
+        orchestratorJobId?: string | null;
         outputStyle?: ClipOutputStyle;
         contentProfile?: ClipContentProfile;
         withSubtitles?: boolean;
@@ -232,6 +241,9 @@ export default function AppHomePage() {
       }
       if (typeof parsed.autoJobCount === "number") {
         setAutoJobCount(parsed.autoJobCount);
+      }
+      if (typeof parsed.orchestratorJobId === "string") {
+        setOrchestratorJobId(parsed.orchestratorJobId);
       }
       if (parsed.outputStyle === "vertical" || parsed.outputStyle === "speaker_split") {
         setOutputStyle(parsed.outputStyle);
@@ -267,6 +279,7 @@ export default function AppHomePage() {
       uploadedMediaType,
       createdJobs,
       autoJobCount,
+      orchestratorJobId,
       outputStyle,
       contentProfile,
       withSubtitles,
@@ -274,10 +287,10 @@ export default function AppHomePage() {
     };
 
     window.localStorage.setItem(HOME_DRAFT_KEY, JSON.stringify(payload));
-  }, [uploadedVideo, uploadedAudio, uploadedMediaType, createdJobs, autoJobCount, outputStyle, contentProfile, withSubtitles, watermark]);
+  }, [uploadedVideo, uploadedAudio, uploadedMediaType, createdJobs, autoJobCount, orchestratorJobId, outputStyle, contentProfile, withSubtitles, watermark]);
 
   useEffect(() => {
-    if (!token || createdJobs.length === 0) {
+    if (!token || (createdJobs.length === 0 && !orchestratorJobId)) {
       setIsPollingStatuses(false);
       return;
     }
@@ -286,7 +299,42 @@ export default function AppHomePage() {
 
     const syncStatuses = async () => {
       try {
-        const statuses = await Promise.all(createdJobs.map((job) => videoApi.getJobStatus(job.job_id, token)));
+        let jobIds = createdJobs.map((job) => job.job_id);
+
+        if (jobIds.length === 0 && orchestratorJobId) {
+          const orchestratorStatus = await videoApi.getJobStatus(orchestratorJobId, token);
+          if (cancelled) {
+            return;
+          }
+
+          if (orchestratorStatus.child_jobs.length > 0) {
+            jobIds = orchestratorStatus.child_jobs;
+            setAutoJobCount((prev) => (prev > 0 ? prev : orchestratorStatus.child_jobs.length));
+            setCreatedJobs((prev) => {
+              if (prev.length > 0) {
+                return prev;
+              }
+
+              return orchestratorStatus.child_jobs.map((jobId, index) => ({
+                job_id: jobId,
+                job_type: "AUTO_REFRAME",
+                status: "PENDING",
+                start_sec: index * 15,
+                end_sec: (index + 1) * 15,
+                created_at: new Date().toISOString()
+              }));
+            });
+          } else {
+            const isOrchestratorOpen = !isTerminalStatus(orchestratorStatus.status);
+            setIsPollingStatuses(isOrchestratorOpen);
+            if (!isOrchestratorOpen) {
+              window.clearInterval(intervalId);
+            }
+            return;
+          }
+        }
+
+        const statuses = await Promise.all(jobIds.map((jobId) => videoApi.getJobStatus(jobId, token)));
         if (cancelled) {
           return;
         }
@@ -294,14 +342,16 @@ export default function AppHomePage() {
         let shouldContinuePolling = false;
 
         setJobStatusMap((prev) => {
-          const nextMap: Record<string, { status: string; outputPath: string | null }> = {};
+          const nextMap: Record<string, JobStatusInfo> = {};
 
           statuses.forEach((item) => {
             const previous = prev[item.job_id];
             const stableOutputPath = previous?.outputPath ?? item.output_path ?? null;
+            const stableSubtitlesPath = previous?.subtitlesPath ?? item.subtitles_path ?? null;
             nextMap[item.job_id] = {
               status: item.status,
-              outputPath: stableOutputPath
+              outputPath: stableOutputPath,
+              subtitlesPath: stableSubtitlesPath
             };
 
             const waitingForOutput = !stableOutputPath && (item.status.toLowerCase() === "done" || item.status.toLowerCase() === "completed");
@@ -337,7 +387,7 @@ export default function AppHomePage() {
       window.clearInterval(intervalId);
       setIsPollingStatuses(false);
     };
-  }, [createdJobs, token]);
+  }, [createdJobs, orchestratorJobId, token]);
 
   const handleUpload = async (file: File) => {
     const isAudio = isAudioFile(file);
@@ -351,6 +401,7 @@ export default function AppHomePage() {
     setFallbackClips([]);
     setJobStatusMap({});
     setAutoJobCount(0);
+    setOrchestratorJobId(null);
     setUploadError(null);
     setJobError(null);
     window.localStorage.removeItem(HOME_DRAFT_KEY);
@@ -402,10 +453,11 @@ export default function AppHomePage() {
       });
       setCreatedJobs(autoJobs.jobs);
       setAutoJobCount(autoJobs.total_jobs);
+      setOrchestratorJobId(autoJobs.orchestrator_job_id ?? null);
 
-      const initialMap: Record<string, { status: string; outputPath: string | null }> = {};
+      const initialMap: Record<string, JobStatusInfo> = {};
       autoJobs.jobs.forEach((job) => {
-        initialMap[job.job_id] = { status: job.status, outputPath: null };
+        initialMap[job.job_id] = { status: job.status, outputPath: null, subtitlesPath: null };
       });
       setJobStatusMap(initialMap);
     } catch (error) {
@@ -421,10 +473,17 @@ export default function AppHomePage() {
       return;
     }
 
+    const hasPendingTrackedJobs =
+      createdJobs.length > 0 &&
+      createdJobs.some((job) => {
+        const status = jobStatusMap[job.job_id]?.status ?? job.status;
+        return !isTerminalStatus(status);
+      });
+
     const shouldHydrateFromLibrary =
       !isUploading &&
       !isCreatingJobs &&
-      (createdJobs.length === 0 || (autoJobCount > 0 && createdJobs.length < autoJobCount));
+      (createdJobs.length === 0 || hasPendingTrackedJobs || (autoJobCount > 0 && createdJobs.length < autoJobCount));
 
     if (!shouldHydrateFromLibrary) {
       setIsHydratingClips(false);
@@ -475,7 +534,7 @@ export default function AppHomePage() {
       window.clearInterval(intervalId);
       setIsHydratingClips(false);
     };
-  }, [token, uploadedVideo, createdJobs.length, isUploading, isCreatingJobs, autoJobCount]);
+  }, [token, uploadedVideo, createdJobs, jobStatusMap, isUploading, isCreatingJobs, autoJobCount]);
 
   return (
     <section className="w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
@@ -606,15 +665,10 @@ export default function AppHomePage() {
           <ProjectStatusPanel
             hasVideo={hasVideo}
             hasAudio={hasAudio}
-            activeMediaType={uploadedMediaType}
             isUploading={isUploading}
             uploadError={uploadError}
-            videoId={uploadedVideo?.video_id ?? null}
-            audioId={uploadedAudio?.audio_id ?? null}
             isCreatingJobs={isCreatingJobs}
             jobsCreated={autoJobCount}
-            clipsDone={clipProgress.done}
-            clipsFailed={clipProgress.failed}
             clipsPending={clipProgress.pending}
             clipProgressPercent={clipProgress.percent}
             jobError={jobError}

--- a/frontend/src/components/home/GeneratedClipsSection.tsx
+++ b/frontend/src/components/home/GeneratedClipsSection.tsx
@@ -8,6 +8,7 @@ type Clip = {
   preset: string;
   status: "listo" | "revision" | "render";
   previewUrl?: string | null;
+  subtitlesUrl?: string | null;
 };
 
 type GeneratedClipsSectionProps = {
@@ -85,13 +86,23 @@ export function GeneratedClipsSection({
               <p className="mt-1 text-sm text-white/75">{clip.duration}</p>
               <p className="mt-2 rounded-lg border border-white/15 px-2 py-1 text-xs text-white/80">Preset: {clip.preset}</p>
               {isRefreshingStatuses ? <p className="mt-2 text-xs text-white/60">Actualizando estado de jobs...</p> : null}
-              <div className="mt-3">
+              <div className="mt-3 flex flex-wrap gap-2">
                 <Link
                   href="/app/timeline"
                   className="inline-flex rounded-lg border border-neon-cyan/35 bg-neon-cyan/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-neon-cyan transition hover:bg-neon-cyan/20"
                 >
                   Editar en timeline
                 </Link>
+                {clip.subtitlesUrl ? (
+                  <a
+                    href={clip.subtitlesUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex rounded-lg border border-neon-mint/35 bg-neon-mint/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.12em] text-neon-mint transition hover:bg-neon-mint/20"
+                  >
+                    Ver subtitulos (.srt)
+                  </a>
+                ) : null}
               </div>
             </article>
           ))}

--- a/frontend/src/components/home/ProjectStatusPanel.tsx
+++ b/frontend/src/components/home/ProjectStatusPanel.tsx
@@ -4,15 +4,10 @@ import { Loader } from "@/src/components/ui/Loader";
 type ProjectStatusPanelProps = {
   hasVideo: boolean;
   hasAudio: boolean;
-  activeMediaType: "video" | "audio" | null;
   isUploading: boolean;
   uploadError: string | null;
-  videoId: string | null;
-  audioId: string | null;
   isCreatingJobs: boolean;
   jobsCreated: number;
-  clipsDone: number;
-  clipsFailed: number;
   clipsPending: number;
   clipProgressPercent: number;
   jobError: string | null;
@@ -21,15 +16,10 @@ type ProjectStatusPanelProps = {
 export function ProjectStatusPanel({
   hasVideo,
   hasAudio,
-  activeMediaType,
   isUploading,
   uploadError,
-  videoId,
-  audioId,
   isCreatingJobs,
   jobsCreated,
-  clipsDone,
-  clipsFailed,
   clipsPending,
   clipProgressPercent,
   jobError
@@ -53,22 +43,14 @@ export function ProjectStatusPanel({
     status = "Video cargado";
   }
 
-  const progress = isUploading
-    ? 30
-    : isCreatingJobs
-      ? 55
-      : jobsCreated > 0
-        ? Math.max(55, clipProgressPercent)
-        : hasAudio
-          ? 100
-          : hasVideo
-            ? 45
-            : 0;
-
-  const trackedTotal = Math.max(jobsCreated, clipsDone + clipsFailed + clipsPending);
-  const donePct = trackedTotal > 0 ? Math.round((clipsDone / trackedTotal) * 100) : 0;
-  const failedPct = trackedTotal > 0 ? Math.round((clipsFailed / trackedTotal) * 100) : 0;
-  const pendingPct = Math.max(0, 100 - donePct - failedPct);
+  const uploadProgress = isUploading ? 60 : hasVideo || hasAudio ? 100 : 0;
+  const generationProgress = isCreatingJobs
+    ? 25
+    : jobsCreated > 0
+      ? clipProgressPercent
+      : hasVideo
+        ? 10
+        : 0;
 
   return (
     <section>
@@ -84,46 +66,28 @@ export function ProjectStatusPanel({
 
       <div className="mt-4 rounded-xl border border-white/15 bg-white/5 p-3">
         <div className="flex items-center justify-between text-sm">
-          <span className="text-white/80">Progreso</span>
-          <span className="text-white">{progress}%</span>
+          <span className="text-white/80">Subida de archivo</span>
+          <span className="text-white">{uploadProgress}%</span>
+        </div>
+        <div className="mt-2 h-2 overflow-hidden rounded-full bg-night-950/90">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-neon-cyan to-neon-mint transition-all duration-500"
+            style={{ width: `${uploadProgress}%` }}
+          />
+        </div>
+
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <span className="text-white/80">Generacion de clips</span>
+          <span className="text-white">{generationProgress}%</span>
         </div>
         <div className="mt-2 h-2 overflow-hidden rounded-full bg-night-950/90">
           <div
             className="h-full rounded-full bg-gradient-to-r from-neon-cyan to-neon-violet transition-all duration-500"
-            style={{ width: `${progress}%` }}
+            style={{ width: `${generationProgress}%` }}
           />
         </div>
-
-        {trackedTotal > 0 ? (
-          <>
-            <div className="mt-3 h-2 overflow-hidden rounded-full border border-white/10 bg-night-950/90">
-              <div className="flex h-full w-full">
-                <div className="h-full bg-emerald-400/85" style={{ width: `${donePct}%` }} />
-                <div className="h-full bg-rose-400/85" style={{ width: `${failedPct}%` }} />
-                <div className="h-full bg-sky-400/70" style={{ width: `${pendingPct}%` }} />
-              </div>
-            </div>
-            <p className="mt-2 text-[11px] text-white/65">
-              Verde: listos · Rojo: con error · Celeste: pendientes
-            </p>
-          </>
-        ) : null}
       </div>
 
-      <ul className="mt-4 space-y-2 text-sm text-white/80">
-        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
-          Upload recibido{activeMediaType ? ` (${activeMediaType})` : ""}
-        </li>
-        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Generacion automatica de segmentos</li>
-        <li className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">Encolado de jobs de reframe</li>
-      </ul>
-      {jobsCreated > 0 ? (
-        <p className="mt-3 text-xs text-neon-cyan">
-          Jobs creados: {jobsCreated} | listos: {clipsDone} | en proceso: {clipsPending} | con error: {clipsFailed}
-        </p>
-      ) : null}
-      {videoId ? <p className="mt-3 text-xs text-white/60">ID de video: {videoId}</p> : null}
-      {audioId ? <p className="mt-3 text-xs text-white/60">ID de audio: {audioId}</p> : null}
       {uploadError ? (
         <p className="mt-3 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{uploadError}</p>
       ) : null}

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -145,6 +145,8 @@ export type JobStatusResponse = {
   job_id: string;
   status: string;
   output_path: string | null;
+  subtitles_path: string | null;
+  child_jobs: string[];
 };
 
 type RawOutputPath = string | Record<string, unknown> | null;
@@ -307,6 +309,41 @@ function extractPlayableUrl(outputPath: RawOutputPath) {
   }
 
   return null;
+}
+
+function extractStringFromKeys(map: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const candidate = map[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function extractChildJobIds(outputPath: RawOutputPath) {
+  if (!outputPath || typeof outputPath !== "object") {
+    return [] as string[];
+  }
+
+  const map = outputPath as Record<string, unknown>;
+  const jobs = map.jobs;
+
+  if (!Array.isArray(jobs)) {
+    return [] as string[];
+  }
+
+  return jobs.filter((job): job is string => typeof job === "string" && job.trim().length > 0);
+}
+
+function extractSubtitlesUrl(outputPath: RawOutputPath) {
+  if (!outputPath || typeof outputPath !== "object") {
+    return null;
+  }
+
+  const map = outputPath as Record<string, unknown>;
+  return extractStringFromKeys(map, ["subtitles", "subtitle", "captions", "srt"]);
 }
 
 function normalizeUserClip(raw: RawUserClipItem): UserClipItem {
@@ -502,6 +539,7 @@ export const videoApi = {
   async getJobStatus(jobId: string, token: string) {
     const response = await fetch(`${apiBaseUrl}/api/v1/jobs/status/${jobId}`, {
       method: "GET",
+      cache: "no-store",
       headers: {
         Authorization: `Bearer ${token}`
       }
@@ -510,7 +548,9 @@ export const videoApi = {
     const payload = await parseResponse<RawJobStatusResponse>(response);
     return {
       ...payload,
-      output_path: extractPlayableUrl(payload.output_path)
+      output_path: extractPlayableUrl(payload.output_path),
+      subtitles_path: extractSubtitlesUrl(payload.output_path),
+      child_jobs: extractChildJobIds(payload.output_path)
     } satisfies JobStatusResponse;
   },
 
@@ -527,6 +567,7 @@ export const videoApi = {
 
     const response = await fetch(`${apiBaseUrl}/api/v1/jobs/my-clips?${params.toString()}`, {
       method: "GET",
+      cache: "no-store",
       headers: {
         Authorization: `Bearer ${token}`
       }


### PR DESCRIPTION
# Frontend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feat/frontend-home-status-polling-subtitles`

## Objetivo de la rama

Pulir Home para que el estado de generacion avance en tiempo real sin recarga manual, simplificar la UI del panel de estado y exponer acceso a subtitulos por clip.

Rama de trabajo: `feat/frontend-home-status-polling-subtitles`.

## Cambios realizados

- Se simplifico `frontend/src/components/home/ProjectStatusPanel.tsx` para mostrar solo dos barras: `Subida de archivo` y `Generacion de clips`, removiendo IDs tecnicos y bloques de estado sobrecargados.
- Se ajusto el polling de Home en `frontend/src/app/app/page.tsx` para soportar orquestador `auto2` (`orchestrator_job_id`) y resolver `child_jobs` desde `GET /api/v1/jobs/status/{job_id}`.
- Se corrigio la hidratacion de resultados en Home para que continue mientras existan jobs no terminales, evitando que la lista quede congelada hasta navegar o recargar.
- Se robustecio el calculo de progreso priorizando estados terminales obtenidos desde biblioteca cuando el estado local aun no se actualizo.
- Se extendio `frontend/src/services/videoApi.ts` para extraer `child_jobs` y `subtitles_path` del `output_path`, y se forzo `cache: "no-store"` en `getJobStatus`/`getMyClips`.
- Se actualizo `frontend/src/components/home/GeneratedClipsSection.tsx` con CTA `Ver subtitulos (.srt)` cuando el backend devuelve URL de subtitulos.

## Commits realizados

- `fix(frontend): sync home polling progress and simplify project status panel`

## Archivos clave

- `frontend/src/app/app/page.tsx`
- `frontend/src/components/home/ProjectStatusPanel.tsx`
- `frontend/src/components/home/GeneratedClipsSection.tsx`
- `frontend/src/services/videoApi.ts`
- `docs/frontend-pr-log.md`

## Validaciones locales

Ejecutado en `frontend/`:

- `npm run lint` -> OK
- `npm run build` -> OK

## Checklist antes de PR a develop

- [x] Rama nueva creada para cambios posteriores al merge previo
- [x] Cambios limitados al alcance frontend/documentacion de esta iteracion
- [x] `npm run lint` OK
- [x] `npm run build` OK
- [x] Documentacion actualizada