### PR TITLE
Feat/frontend timeline library streamline

### DIFF
--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -27,6 +27,7 @@ Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 - Fix de compatibilidad temporal con backend en `frontend/src/app/app/audio_editor/page.tsx`: `audio_volume` ahora se envia como entero (`1` o `2`) para evitar `500` por validacion de `JobAddAudioResponse`.
 - Se agrego fallback visual en previews de clips en `frontend/src/app/app/library/page.tsx` para mostrar aviso cuando el `<video>` falla al reproducir (sin dejar card vacia/negra).
 - Se reemplazo el reproductor nativo de audio por un componente custom catppuccin (`frontend/src/components/audio/AudioPlayer.tsx` + `AudioPlayer.module.css`) reutilizado en `Audio editor` y `Biblioteca`.
+- Ajuste UX del player custom: se removio el bloque visual superior y se reorganizo el layout en dos filas limpias (arriba progreso/tiempos, abajo volumen), con foco en simplicidad visual.
 
 ## Commits realizados
 
@@ -36,6 +37,7 @@ Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 - `feat(frontend): streamline audio editor entry from library`
 - `fix(frontend): send integer audio volume and add clip preview fallback`
 - `feat(frontend): redesign custom audio player with catppuccin UI`
+- `refactor(frontend): simplify audio player layout for cleaner controls`
 - `docs(frontend): log timeline-library streamlining and settings cleanup`
 
 ## Archivos clave

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -20,11 +20,17 @@ Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 - Se removieron de ajustes de timeline valores sin uso real (`crop`, `face tracking`, `color filter`, `videoStart`, `videoEnd`) y se alinio el store en `frontend/src/store/useVideoSettingsStore.ts` a parametros vigentes del backend.
 - Se actualizo `frontend/src/components/home/VideoSettingsModal.tsx` para mantener consistencia de tipos/ajustes y evitar deuda tecnica por campos obsoletos.
 - Se persistio la sesion de Timeline en `localStorage` (`timeline:editor-session`) para conservar video activo + job en curso/resultado al recargar o navegar, evitando que se pierda el contexto de trabajo.
+- Se agrego el asset `frontend/public/landing-demos/video1_musica.mp4` para la seccion de demos de landing.
+- Se simplifico `frontend/src/app/app/audio_editor/page.tsx` removiendo listado/buscador/paginacion de videos para replicar el enfoque de Timeline: editor sobre un unico `videoId`/`clipId` proveniente de Biblioteca.
+- Se agrego CTA a Biblioteca en Audio Editor cuando no hay video seleccionado, evitando estado vacio confuso.
+- Se incorporo en Biblioteca (videos originales) el boton `Abrir en Audio Editor` en `frontend/src/app/app/library/page.tsx`, alineando la navegacion con clips.
 
 ## Commits realizados
 
 - `feat(frontend): streamline timeline flow and add job progress preview`
 - `fix(frontend): persist timeline editor session across reloads`
+- `chore(frontend): add landing demo video1 asset`
+- `feat(frontend): streamline audio editor entry from library`
 - `docs(frontend): log timeline-library streamlining and settings cleanup`
 
 ## Archivos clave

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -19,10 +19,12 @@ Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 - Se rediseño `frontend/src/components/home/VideoSettings.tsx` para incluir en Timeline `output_style` (`Vertical 9:16` y `Speaker split`) + `content_profile` (`auto`, `entrevista`, `deporte`, `musica`) con UI mas limpia.
 - Se removieron de ajustes de timeline valores sin uso real (`crop`, `face tracking`, `color filter`, `videoStart`, `videoEnd`) y se alinio el store en `frontend/src/store/useVideoSettingsStore.ts` a parametros vigentes del backend.
 - Se actualizo `frontend/src/components/home/VideoSettingsModal.tsx` para mantener consistencia de tipos/ajustes y evitar deuda tecnica por campos obsoletos.
+- Se persistio la sesion de Timeline en `localStorage` (`timeline:editor-session`) para conservar video activo + job en curso/resultado al recargar o navegar, evitando que se pierda el contexto de trabajo.
 
 ## Commits realizados
 
 - `feat(frontend): streamline timeline flow and add job progress preview`
+- `fix(frontend): persist timeline editor session across reloads`
 - `docs(frontend): log timeline-library streamlining and settings cleanup`
 
 ## Archivos clave

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -2,33 +2,36 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feat/frontend-home-status-polling-subtitles`
+Rama de trabajo actual: `feat/frontend-timeline-library-streamline`
 
 ## Objetivo de la rama
 
-Pulir Home para que el estado de generacion avance en tiempo real sin recarga manual, simplificar la UI del panel de estado y exponer acceso a subtitulos por clip.
+Simplificar el flujo entre Biblioteca y Timeline para evitar duplicidad de listados, sumar feedback de progreso/preview final en Timeline y dejar los ajustes del editor mas claros, limpios y alineados al look catppuccin.
 
-Rama de trabajo: `feat/frontend-home-status-polling-subtitles`.
+Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 
 ## Cambios realizados
 
-- Se simplifico `frontend/src/components/home/ProjectStatusPanel.tsx` para mostrar solo dos barras: `Subida de archivo` y `Generacion de clips`, removiendo IDs tecnicos y bloques de estado sobrecargados.
-- Se ajusto el polling de Home en `frontend/src/app/app/page.tsx` para soportar orquestador `auto2` (`orchestrator_job_id`) y resolver `child_jobs` desde `GET /api/v1/jobs/status/{job_id}`.
-- Se corrigio la hidratacion de resultados en Home para que continue mientras existan jobs no terminales, evitando que la lista quede congelada hasta navegar o recargar.
-- Se robustecio el calculo de progreso priorizando estados terminales obtenidos desde biblioteca cuando el estado local aun no se actualizo.
-- Se extendio `frontend/src/services/videoApi.ts` para extraer `child_jobs` y `subtitles_path` del `output_path`, y se forzo `cache: "no-store"` en `getJobStatus`/`getMyClips`.
-- Se actualizo `frontend/src/components/home/GeneratedClipsSection.tsx` con CTA `Ver subtitulos (.srt)` cuando el backend devuelve URL de subtitulos.
+- Se agrego en `frontend/src/app/app/timeline/page.tsx` una barra de progreso para la creacion del clip con polling por `job_id` y estados visuales (`En cola`, `Procesando`, `Completado`, `Error`).
+- Se incorporo en Timeline una seccion de `Preview final` que reproduce el resultado renderizado cuando el backend expone `output_path`.
+- Se elimino del Timeline la lista duplicada de videos subidos; ahora la pantalla trabaja sobre un unico `videoId` (o resuelto por `clipId`) y muestra CTA a Biblioteca cuando falta seleccion.
+- Se agrego accion `Abrir Timeline` en `frontend/src/app/app/library/page.tsx` para cada video original, replicando el flujo de navegacion profunda que ya existia para clips.
+- Se rediseño `frontend/src/components/home/VideoSettings.tsx` para incluir en Timeline `output_style` (`Vertical 9:16` y `Speaker split`) + `content_profile` (`auto`, `entrevista`, `deporte`, `musica`) con UI mas limpia.
+- Se removieron de ajustes de timeline valores sin uso real (`crop`, `face tracking`, `color filter`, `videoStart`, `videoEnd`) y se alinio el store en `frontend/src/store/useVideoSettingsStore.ts` a parametros vigentes del backend.
+- Se actualizo `frontend/src/components/home/VideoSettingsModal.tsx` para mantener consistencia de tipos/ajustes y evitar deuda tecnica por campos obsoletos.
 
 ## Commits realizados
 
-- `fix(frontend): sync home polling progress and simplify project status panel`
+- `feat(frontend): streamline timeline flow and add job progress preview`
+- `docs(frontend): log timeline-library streamlining and settings cleanup`
 
 ## Archivos clave
 
-- `frontend/src/app/app/page.tsx`
-- `frontend/src/components/home/ProjectStatusPanel.tsx`
-- `frontend/src/components/home/GeneratedClipsSection.tsx`
-- `frontend/src/services/videoApi.ts`
+- `frontend/src/app/app/timeline/page.tsx`
+- `frontend/src/app/app/library/page.tsx`
+- `frontend/src/components/home/VideoSettings.tsx`
+- `frontend/src/components/home/VideoSettingsModal.tsx`
+- `frontend/src/store/useVideoSettingsStore.ts`
 - `docs/frontend-pr-log.md`
 
 ## Validaciones locales
@@ -36,14 +39,12 @@ Rama de trabajo: `feat/frontend-home-status-polling-subtitles`.
 Ejecutado en `frontend/`:
 
 - `npm run lint` -> OK
-- `npm run build` -> OK
 
 ## Checklist antes de PR a develop
 
-- [x] Rama nueva creada para cambios posteriores al merge previo
+- [x] Rama nueva creada desde `develop`
 - [x] Cambios limitados al alcance frontend/documentacion de esta iteracion
 - [x] `npm run lint` OK
-- [x] `npm run build` OK
 - [x] Documentacion actualizada
 
 ### Objetivo

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -24,6 +24,8 @@ Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 - Se simplifico `frontend/src/app/app/audio_editor/page.tsx` removiendo listado/buscador/paginacion de videos para replicar el enfoque de Timeline: editor sobre un unico `videoId`/`clipId` proveniente de Biblioteca.
 - Se agrego CTA a Biblioteca en Audio Editor cuando no hay video seleccionado, evitando estado vacio confuso.
 - Se incorporo en Biblioteca (videos originales) el boton `Abrir en Audio Editor` en `frontend/src/app/app/library/page.tsx`, alineando la navegacion con clips.
+- Fix de compatibilidad temporal con backend en `frontend/src/app/app/audio_editor/page.tsx`: `audio_volume` ahora se envia como entero (`1` o `2`) para evitar `500` por validacion de `JobAddAudioResponse`.
+- Se agrego fallback visual en previews de clips en `frontend/src/app/app/library/page.tsx` para mostrar aviso cuando el `<video>` falla al reproducir (sin dejar card vacia/negra).
 
 ## Commits realizados
 
@@ -31,6 +33,7 @@ Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 - `fix(frontend): persist timeline editor session across reloads`
 - `chore(frontend): add landing demo video1 asset`
 - `feat(frontend): streamline audio editor entry from library`
+- `fix(frontend): send integer audio volume and add clip preview fallback`
 - `docs(frontend): log timeline-library streamlining and settings cleanup`
 
 ## Archivos clave

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -26,6 +26,7 @@ Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 - Se incorporo en Biblioteca (videos originales) el boton `Abrir en Audio Editor` en `frontend/src/app/app/library/page.tsx`, alineando la navegacion con clips.
 - Fix de compatibilidad temporal con backend en `frontend/src/app/app/audio_editor/page.tsx`: `audio_volume` ahora se envia como entero (`1` o `2`) para evitar `500` por validacion de `JobAddAudioResponse`.
 - Se agrego fallback visual en previews de clips en `frontend/src/app/app/library/page.tsx` para mostrar aviso cuando el `<video>` falla al reproducir (sin dejar card vacia/negra).
+- Se reemplazo el reproductor nativo de audio por un componente custom catppuccin (`frontend/src/components/audio/AudioPlayer.tsx` + `AudioPlayer.module.css`) reutilizado en `Audio editor` y `Biblioteca`.
 
 ## Commits realizados
 
@@ -34,6 +35,7 @@ Rama de trabajo: `feat/frontend-timeline-library-streamline`.
 - `chore(frontend): add landing demo video1 asset`
 - `feat(frontend): streamline audio editor entry from library`
 - `fix(frontend): send integer audio volume and add clip preview fallback`
+- `feat(frontend): redesign custom audio player with catppuccin UI`
 - `docs(frontend): log timeline-library streamlining and settings cleanup`
 
 ## Archivos clave

--- a/frontend/src/app/app/audio_editor/page.tsx
+++ b/frontend/src/app/app/audio_editor/page.tsx
@@ -4,11 +4,11 @@ import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPre
 import { Panel } from "@/src/components/ui/Panel";
 import { videoApi, type UserAudioItem, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
-import { Music2, Search } from "lucide-react";
+import { Music2 } from "lucide-react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
-const PAGE_SIZE = 10;
 const MIN_AUDIO_SEGMENT_SECONDS = 5;
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
@@ -57,9 +57,6 @@ export default function AudioEditorPage() {
   const token = useAuthStore((state) => state.token);
 
   const [videos, setVideos] = useState<UserVideoItem[]>([]);
-  const [totalVideos, setTotalVideos] = useState(0);
-  const [page, setPage] = useState(1);
-  const [query, setQuery] = useState("");
   const [isLoadingVideos, setIsLoadingVideos] = useState(true);
   const [videoError, setVideoError] = useState<string | null>(null);
   const [selectedVideoId, setSelectedVideoId] = useState<string | null>(null);
@@ -113,47 +110,32 @@ export default function AudioEditorPage() {
           }
         }
 
-        const response = await videoApi.getMyVideos(token, {
-          limit: PAGE_SIZE,
-          offset: (page - 1) * PAGE_SIZE,
-          query
-        });
+        const targetVideoId = preferredVideoFromQuery || selectedClip?.video_id || "";
+        if (!targetVideoId) {
+          setVideos([]);
+          setFocusedClip(null);
+          setSelectedVideoId(null);
+          setVideoError("Selecciona un video o clip desde Biblioteca para abrir el Audio editor.");
+          return;
+        }
+
+        const targetVideo = await videoApi.getMyVideoById(targetVideoId, token);
 
         if (cancelled) {
           return;
         }
 
-        let nextVideos = response.videos;
-        if (preferredVideoFromQuery && !response.videos.some((video) => video.video_id === preferredVideoFromQuery)) {
-          try {
-            const preferredVideo = await videoApi.getMyVideoById(preferredVideoFromQuery, token);
-            nextVideos = [
-              {
-                video_id: preferredVideo.video_id,
-                filename: preferredVideo.filename,
-                status: preferredVideo.status,
-                uploaded_at: preferredVideo.uploaded_at,
-                preview_url: preferredVideo.preview_url
-              },
-              ...response.videos.filter((video) => video.video_id !== preferredVideo.video_id)
-            ];
-          } catch {
-            nextVideos = response.videos;
+        setVideos([
+          {
+            video_id: targetVideo.video_id,
+            filename: targetVideo.filename,
+            status: targetVideo.status,
+            uploaded_at: targetVideo.uploaded_at,
+            preview_url: targetVideo.preview_url
           }
-        }
-
-        setVideos(nextVideos);
+        ]);
         setFocusedClip(selectedClip);
-        setTotalVideos(response.total);
-        setSelectedVideoId((prev) => {
-          if (preferredVideoFromQuery && nextVideos.some((video) => video.video_id === preferredVideoFromQuery)) {
-            return preferredVideoFromQuery;
-          }
-          if (prev && nextVideos.some((video) => video.video_id === prev)) {
-            return prev;
-          }
-          return nextVideos[0]?.video_id ?? null;
-        });
+        setSelectedVideoId(targetVideo.video_id);
       } catch (loadError) {
         if (!cancelled) {
           setVideoError(normalizeVideoError(loadError, "No pudimos cargar tus videos."));
@@ -170,7 +152,7 @@ export default function AudioEditorPage() {
     return () => {
       cancelled = true;
     };
-  }, [token, page, preferredClipId, preferredVideoId, query]);
+  }, [token, preferredClipId, preferredVideoId]);
 
   useEffect(() => {
     if (!token) {
@@ -297,7 +279,6 @@ export default function AudioEditorPage() {
     };
   }, [audioJobId, token]);
 
-  const totalPages = Math.max(1, Math.ceil(totalVideos / PAGE_SIZE));
   const selectedVideo = useMemo(() => videos.find((video) => video.video_id === selectedVideoId) ?? null, [videos, selectedVideoId]);
   const previewUrl = mixedVideoUrl ?? focusedClip?.output_path ?? selectedVideo?.preview_url ?? null;
 
@@ -426,18 +407,9 @@ export default function AudioEditorPage() {
           <p className="text-xs uppercase tracking-[0.22em] text-white/65">audio editor</p>
           <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Video + pista de audio</h3>
 
-          <label className="mt-3 flex items-center gap-2 rounded-xl border border-white/12 bg-white/5 px-3 py-2 text-sm text-white/80 transition hover:border-neon-violet/40">
-            <Search size={14} className="text-neon-violet/80" />
-            <input
-              value={query}
-              onChange={(event) => {
-                setQuery(event.target.value);
-                setPage(1);
-              }}
-              placeholder="Buscar video por id o archivo..."
-              className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/40"
-            />
-          </label>
+          <div className="mt-3 rounded-xl border border-neon-violet/30 bg-neon-violet/10 px-3 py-2 text-xs text-neon-violet/90">
+            Para cambiar de video, abrilo desde Biblioteca en la card de video o clip.
+          </div>
 
           {isLoadingVideos ? (
             <p className="mt-4 text-sm text-white/70">Cargando videos...</p>
@@ -476,49 +448,15 @@ export default function AudioEditorPage() {
             </div>
           </div>
 
-          <div className="mt-4 grid gap-2 sm:grid-cols-2">
-            {videos.map((video) => (
-              <button
-                type="button"
-                key={video.video_id}
-                onClick={() => {
-                  setSelectedVideoId(video.video_id);
-                  setMixedVideoUrl(null);
-                }}
-                className={[
-                  "rounded-xl border px-3 py-2 text-left text-sm transition",
-                  selectedVideoId === video.video_id
-                    ? "border-neon-violet/45 bg-neon-violet/10 text-white"
-                    : "border-white/10 bg-white/5 text-white/75 hover:border-white/20 hover:text-white"
-                ].join(" ")}
+          {!isLoadingVideos && !selectedVideoId ? (
+            <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
+              <p>No hay video seleccionado para este editor.</p>
+              <Link
+                href="/app/library"
+                className="mt-3 inline-flex items-center justify-center rounded-lg border border-neon-violet/40 bg-neon-violet/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neon-violet transition hover:bg-neon-violet/20"
               >
-                <p className="font-semibold">Video {video.video_id.slice(0, 8)}</p>
-                <p className="mt-1 text-xs text-white/60">Archivo: {video.filename}</p>
-              </button>
-            ))}
-          </div>
-
-          {totalPages > 1 ? (
-            <div className="mt-4 flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/80">
-              <span>Pagina {page} de {totalPages}</span>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:opacity-40"
-                  disabled={page <= 1 || isLoadingVideos}
-                  onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-                >
-                  Anterior
-                </button>
-                <button
-                  type="button"
-                  className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:opacity-40"
-                  disabled={page >= totalPages || isLoadingVideos}
-                  onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
-                >
-                  Siguiente
-                </button>
-              </div>
+                Ir a Biblioteca
+              </Link>
             </div>
           ) : null}
         </Panel>

--- a/frontend/src/app/app/audio_editor/page.tsx
+++ b/frontend/src/app/app/audio_editor/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { VideoPreview } from "@/src/components/home/videoPrevewTimeLine/VideoPreview";
+import { AudioPlayer } from "@/src/components/audio/AudioPlayer";
 import { Panel } from "@/src/components/ui/Panel";
 import { videoApi, type UserAudioItem, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
@@ -486,13 +487,11 @@ export default function AudioEditorPage() {
               </label>
 
               {selectedAudioUrl ? (
-                <audio
-                  controls
-                  preload="metadata"
-                  className="mt-3 w-full rounded-lg [accent-color:#cba6f7]"
+                <AudioPlayer
+                  key={selectedAudioUrl}
                   src={selectedAudioUrl}
-                  onLoadedMetadata={(event) => {
-                    const duration = event.currentTarget.duration;
+                  className="mt-3"
+                  onDurationChange={(duration) => {
                     setAudioDurationSec(Number.isFinite(duration) ? duration : 0);
                   }}
                 />

--- a/frontend/src/app/app/audio_editor/page.tsx
+++ b/frontend/src/app/app/audio_editor/page.tsx
@@ -388,7 +388,7 @@ export default function AudioEditorPage() {
         audio_offset_sec: Math.max(0, Math.floor(audioOffsetSec)),
         audio_start_sec: Math.max(0, Math.floor(audioStartSec)),
         audio_end_sec: Math.max(MIN_AUDIO_SEGMENT_SECONDS, Math.ceil(audioEndSec)),
-        audio_volume: Math.min(2, Math.max(0.1, Number(audioVolume.toFixed(2))))
+        audio_volume: Math.round(clamp(audioVolume, 1, 2))
       });
 
       setAudioJobId(response.job_id);
@@ -507,7 +507,7 @@ export default function AudioEditorPage() {
                 <p className="mt-1">- `offset en video`: segundo del video donde empieza a sonar el audio.</p>
                 <p>- `inicio audio`: desde que segundo del archivo de audio recortas.</p>
                 <p>- `fin audio`: hasta que segundo del archivo de audio usas.</p>
-                <p>- `volumen`: ganancia del audio agregado (1.0 = normal).</p>
+                <p>- `volumen`: ganancia del audio agregado (1 = normal, 2 = fuerte).</p>
               </div>
 
               <div className="mt-3 grid gap-2 sm:grid-cols-2">
@@ -522,18 +522,18 @@ export default function AudioEditorPage() {
                     className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
                   />
                 </label>
-                <label className="text-xs text-white/75">
-                  Volumen (0.1 - 2.0)
-                  <input
-                    type="number"
-                    min={0.1}
-                    max={2}
-                    step={0.1}
-                    value={audioVolume}
-                    onChange={(event) => setAudioVolume(Number(event.target.value || 1))}
-                    className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
-                  />
-                </label>
+                 <label className="text-xs text-white/75">
+                   Volumen (1 - 2)
+                   <input
+                     type="number"
+                     min={1}
+                     max={2}
+                     step={1}
+                     value={audioVolume}
+                     onChange={(event) => setAudioVolume(clamp(Number(event.target.value || 1), 1, 2))}
+                     className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-violet/50"
+                   />
+                 </label>
                 <label className="text-xs text-white/75">
                   Inicio audio (seg)
                   <input

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -50,6 +50,7 @@ export default function LibraryPage() {
   const [deletingAudioId, setDeletingAudioId] = useState<string | null>(null);
   const [audioUrlMap, setAudioUrlMap] = useState<Record<string, string>>({});
   const [loadingAudioId, setLoadingAudioId] = useState<string | null>(null);
+  const [brokenClipPreviewIds, setBrokenClipPreviewIds] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     if (!token) {
@@ -394,8 +395,16 @@ export default function LibraryPage() {
             style={{ animationDelay: `${index * 90}ms` }}
           >
             <div className="relative mb-3 overflow-hidden rounded-xl border border-white/10 bg-night-900/80">
-              {clip.output_path ? (
-                <video controls preload="metadata" className="aspect-[9/13] w-full object-cover" src={clip.output_path} />
+              {clip.output_path && !brokenClipPreviewIds[clip.job_id] ? (
+                <video
+                  controls
+                  preload="metadata"
+                  className="aspect-[9/13] w-full object-cover"
+                  src={clip.output_path}
+                  onError={() => {
+                    setBrokenClipPreviewIds((prev) => ({ ...prev, [clip.job_id]: true }));
+                  }}
+                />
               ) : (
                 <div className="aspect-[9/13] bg-[radial-gradient(circle_at_20%_20%,rgba(53,208,255,0.32),transparent_45%),radial-gradient(circle_at_80%_78%,rgba(255,79,216,0.28),transparent_50%),#0d1630]" />
               )}
@@ -440,6 +449,10 @@ export default function LibraryPage() {
                 </span>
               )}
             </div>
+
+            {clip.output_path && brokenClipPreviewIds[clip.job_id] ? (
+              <p className="mt-2 text-xs text-amber-200">No pudimos reproducir el preview en el navegador. Abri el clip desde el boton para verificarlo.</p>
+            ) : null}
 
             <div className="mt-2 grid grid-cols-2 gap-2">
               <Link

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Panel } from "@/src/components/ui/Panel";
+import { AudioPlayer } from "@/src/components/audio/AudioPlayer";
 import { videoApi, type UserAudioItem, type UserClipItem, type UserVideoItem } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { AudioLines, Check, Clock3, Download, PencilLine, Search, Share2, Tag, Trash2, X } from "lucide-react";
@@ -636,12 +637,7 @@ export default function LibraryPage() {
                 {audioUrl ? (
                   <div className="mt-4 rounded-xl border border-white/12 bg-night-900/70 p-3">
                     <p className="text-[11px] uppercase tracking-[0.16em] text-white/60">Preview</p>
-                    <audio
-                      controls
-                      preload="metadata"
-                      className="mt-2 w-full rounded-lg [accent-color:#cba6f7]"
-                      src={audioUrl}
-                    />
+                    <AudioPlayer key={audio.audio_id} src={audioUrl} className="mt-2" />
                   </div>
                 ) : (
                   <button

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -549,6 +549,12 @@ export default function LibraryPage() {
 
               {editingVideoId !== video.video_id ? (
                 <div className="mt-2 grid grid-cols-2 gap-2">
+                  <Link
+                    href={`/app/timeline?videoId=${video.video_id}`}
+                    className="col-span-2 inline-flex items-center justify-center gap-1 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-neon-cyan transition hover:bg-neon-cyan/20"
+                  >
+                    <PencilLine size={12} /> Abrir Timeline
+                  </Link>
                   <button
                     type="button"
                     className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-cyan/40 hover:text-neon-cyan"

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -555,6 +555,12 @@ export default function LibraryPage() {
                   >
                     <PencilLine size={12} /> Abrir Timeline
                   </Link>
+                  <Link
+                    href={`/app/audio_editor?videoId=${video.video_id}`}
+                    className="col-span-2 inline-flex items-center justify-center gap-1 rounded-lg border border-neon-mint/40 bg-neon-mint/10 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-neon-mint transition hover:bg-neon-mint/20"
+                  >
+                    <AudioLines size={12} /> Abrir en Audio Editor
+                  </Link>
                   <button
                     type="button"
                     className="inline-flex items-center justify-center gap-1 rounded-lg border border-white/20 bg-white/5 px-2 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/75 transition hover:border-neon-cyan/40 hover:text-neon-cyan"

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -6,13 +6,52 @@ import { Panel } from "@/src/components/ui/Panel";
 import { videoApi, type UserClipItem, type UserVideoItem, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { useVideoSettingsStore } from "@/src/store/useVideoSettingsStore";
-import { Search } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
-const PAGE_SIZE = 10;
 const MIN_CLIP_SECONDS = 5;
+
+function normalizeJobStatus(status: string | null) {
+  return (status ?? "PENDING").toLowerCase();
+}
+
+function isTerminalJobStatus(status: string | null) {
+  const normalized = normalizeJobStatus(status);
+  return normalized === "done" || normalized === "completed" || normalized === "failed" || normalized === "error";
+}
+
+function getClipCreationProgress(status: string | null) {
+  const normalized = normalizeJobStatus(status);
+
+  if (normalized === "done" || normalized === "completed") {
+    return 100;
+  }
+
+  if (normalized === "failed" || normalized === "error") {
+    return 100;
+  }
+
+  if (normalized === "processing" || normalized === "running" || normalized === "in_progress") {
+    return 70;
+  }
+
+  return 20;
+}
+
+function formatJobStatusLabel(status: string | null) {
+  const normalized = normalizeJobStatus(status);
+  if (normalized === "done" || normalized === "completed") {
+    return "Completado";
+  }
+  if (normalized === "failed" || normalized === "error") {
+    return "Error";
+  }
+  if (normalized === "processing" || normalized === "running" || normalized === "in_progress") {
+    return "Procesando";
+  }
+  return "En cola";
+}
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
   if (error instanceof VideoApiError) {
@@ -33,9 +72,6 @@ export default function TimelinePage() {
   const token = useAuthStore((state) => state.token);
   const settings = useVideoSettingsStore((state) => state.settings);
   const [videos, setVideos] = useState<UserVideoItem[]>([]);
-  const [totalVideos, setTotalVideos] = useState(0);
-  const [page, setPage] = useState(1);
-  const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedVideoId, setSelectedVideoId] = useState<string | null>(null);
@@ -48,10 +84,15 @@ export default function TimelinePage() {
   const [submitErrorSettings, setSubmitErrorSettings] = useState<string | null>(null);
   const [submitInfoSettings, setSubmitInfoSettings] = useState<string | null>(null);
   const [draftFilename, setDraftFilename] = useState("");
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [activeJobStatus, setActiveJobStatus] = useState<string | null>(null);
+  const [activeJobOutputPath, setActiveJobOutputPath] = useState<string | null>(null);
+  const [activeJobPollingError, setActiveJobPollingError] = useState<string | null>(null);
+  const [isPollingActiveJob, setIsPollingActiveJob] = useState(false);
 
 
-  const saveRaname =  async()=>{
-      if (!token) {
+  const saveRaname = async () => {
+    if (!token) {
       return;
     }
 
@@ -66,14 +107,11 @@ export default function TimelinePage() {
       const updated = await videoApi.updateMyVideo(selectedVideoId, token, { filename: draftFilename.trim() });
       setVideos((prev) => prev.map((item) => (item.video_id === selectedVideoId ? updated : item)));
       setSubmitInfoSettings("Ajustes guardados.");
-
     } catch (saveError) {
       const message = saveError instanceof Error ? saveError.message : "No pudimos actualizar el nombre del video.";
       setSubmitErrorSettings(message);
-
     }
-
-  }
+  };
 
   useEffect(() => {
     if (!token) {
@@ -103,48 +141,34 @@ export default function TimelinePage() {
           }
         }
 
-        const response = await videoApi.getMyVideos(token, {
-          limit: PAGE_SIZE,
-          offset: (page - 1) * PAGE_SIZE,
-          query
-        });
+        const targetVideoId = preferredVideoFromQuery || selectedClip?.video_id || "";
+
+        if (!targetVideoId) {
+          setVideos([]);
+          setFocusedClip(null);
+          setSelectedVideoId(null);
+          setDraftFilename("");
+          setError("Selecciona un video desde Biblioteca para abrirlo en timeline.");
+          return;
+        }
+
+        const preferredVideo = await videoApi.getMyVideoById(targetVideoId, token);
         if (cancelled) {
           return;
         }
 
-        let nextVideos = response.videos;
-
-        if (preferredVideoFromQuery && !response.videos.some((video) => video.video_id === preferredVideoFromQuery)) {
-          try {
-            const preferredVideo = await videoApi.getMyVideoById(preferredVideoFromQuery, token);
-            nextVideos = [
-              {
-                video_id: preferredVideo.video_id,
-                filename: preferredVideo.filename,
-                status: preferredVideo.status,
-                uploaded_at: preferredVideo.uploaded_at,
-                preview_url: preferredVideo.preview_url
-              },
-              ...response.videos.filter((video) => video.video_id !== preferredVideo.video_id)
-            ];
-          } catch {
-            nextVideos = response.videos;
+        setVideos([
+          {
+            video_id: preferredVideo.video_id,
+            filename: preferredVideo.filename,
+            status: preferredVideo.status,
+            uploaded_at: preferredVideo.uploaded_at,
+            preview_url: preferredVideo.preview_url
           }
-        }
-
-        setVideos(nextVideos);
+        ]);
         setFocusedClip(selectedClip);
-        setDraftFilename(selectedClip?.source_filename || "")
-        setTotalVideos(response.total);
-        setSelectedVideoId((prev) => {
-          if (preferredVideoFromQuery && nextVideos.some((video) => video.video_id === preferredVideoFromQuery)) {
-            return preferredVideoFromQuery;
-          }
-          if (prev && nextVideos.some((video) => video.video_id === prev)) {
-            return prev;
-          }
-          return nextVideos[0]?.video_id ?? null;
-        });
+        setSelectedVideoId(preferredVideo.video_id);
+        setDraftFilename(preferredVideo.filename);
       } catch (loadError) {
         if (!cancelled) {
           setError(normalizeVideoError(loadError, "No pudimos cargar tus videos."));
@@ -161,9 +185,7 @@ export default function TimelinePage() {
     return () => {
       cancelled = true;
     };
-  }, [token, page, preferredClipId, preferredVideoId, query]);
-
-  const totalPages = Math.max(1, Math.ceil(totalVideos / PAGE_SIZE));
+  }, [token, preferredClipId, preferredVideoId]);
 
   const selectedVideo = useMemo(
     () => videos.find((video) => video.video_id === selectedVideoId) ?? null,
@@ -182,6 +204,53 @@ export default function TimelinePage() {
       ? (focusedClip.output_path ?? selectedVideo?.preview_url ?? null)
       : (selectedVideo?.preview_url ?? null);
 
+  const activeJobProgress = getClipCreationProgress(activeJobStatus);
+  const activeJobStatusLabel = formatJobStatusLabel(activeJobStatus);
+
+  useEffect(() => {
+    if (!token || !activeJobId) {
+      setIsPollingActiveJob(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const syncActiveJob = async () => {
+      try {
+        const status = await videoApi.getJobStatus(activeJobId, token);
+        if (cancelled) {
+          return;
+        }
+
+        setActiveJobStatus(status.status);
+        setActiveJobOutputPath((prev) => prev ?? status.output_path ?? null);
+        setActiveJobPollingError(null);
+        const shouldContinuePolling = !isTerminalJobStatus(status.status) || !status.output_path;
+        setIsPollingActiveJob(shouldContinuePolling);
+
+        if (!shouldContinuePolling) {
+          window.clearInterval(intervalId);
+        }
+      } catch (pollError) {
+        if (!cancelled) {
+          setActiveJobPollingError(normalizeVideoError(pollError, "No pudimos actualizar el estado del clip."));
+        }
+      }
+    };
+
+    setIsPollingActiveJob(true);
+    const intervalId = window.setInterval(() => {
+      void syncActiveJob();
+    }, 4000);
+    void syncActiveJob();
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      setIsPollingActiveJob(false);
+    };
+  }, [activeJobId, token]);
+
   const handleCreateJob = async () => {
     if (!token || !selectedVideoId) {
       setSubmitError("Selecciona un video y verifica tu sesion para crear el clip.");
@@ -199,14 +268,17 @@ export default function TimelinePage() {
       const response = await videoApi.createReframeJob(selectedVideoId, token, {
         start_sec: normalizedStart,
         end_sec: normalizedEnd,
-        crop_to_vertical: settings.cropToVertical,
         subtitles: settings.subtitles,
         watermark: settings.watermark,
-        face_tracking: settings.faceTracking,
-        color_filter: settings.colorFilter
+        output_style: settings.outputStyle,
+        content_profile: settings.contentProfile
       });
 
       setSubmitInfo(`Clip enviado a cola. Job ${response.job_id.slice(0, 8)} en estado ${response.status}.`);
+      setActiveJobId(response.job_id);
+      setActiveJobStatus(response.status);
+      setActiveJobOutputPath(null);
+      setActiveJobPollingError(null);
     } catch (createError) {
       setSubmitError(normalizeVideoError(createError, "No pudimos crear el clip desde timeline."));
     } finally {
@@ -222,19 +294,12 @@ export default function TimelinePage() {
         <Panel>
           <p className="text-xs uppercase tracking-[0.22em] text-white/65">timeline</p>
           <h3 className="mt-1 font-display text-2xl text-white sm:text-3xl">Preview y recorte</h3>
-          {videoEditarBool &&(<label className="mt-3 flex items-center gap-2 rounded-xl border border-white/12 bg-white/5 px-3 py-2 text-sm text-white/80 transition hover:border-neon-cyan/40">
-            <Search size={14} className="text-neon-cyan/80" />
-            <input
-              value={query}
-              onChange={(event) => {
-                setQuery(event.target.value);
-                setPage(1);
-              }}
-              placeholder="Buscar clip por job o archivo..."
-              className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/40"
-            />
-          </label>
-)}
+
+          {videoEditarBool ? (
+            <div className="mt-3 rounded-xl border border-neon-cyan/30 bg-neon-cyan/10 px-3 py-2 text-xs text-neon-cyan/90">
+              Para cambiar de video, abrilo desde Biblioteca - Videos originales.
+            </div>
+          ) : null}
           {focusedClip ? (
             <div className="mt-3 rounded-xl border border-neon-cyan/35 bg-neon-cyan/10 px-3 py-2 text-xs text-neon-cyan">
               Editando desde clip {focusedClip.job_id.slice(0, 8)} sobre video {focusedClip.video_id.slice(0, 8)}.
@@ -259,91 +324,50 @@ export default function TimelinePage() {
             </p>
           )}
 
-
-
-          {
-          // !videoEditarBool&&(
-          //   <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
-          //     <label className="">
-          //       Nombre
-          //     </label>
-          //     <input
-          //         value={draftFilename}
-          //         onChange={(event) => setDraftFilename(event.target.value)}
-          //         className="w-full rounded-lg border border-white/20 bg-night-900/70 px-3 mt-1 py-2 text-xs text-white outline-none transition focus:border-neon-cyan/50"
-          //         maxLength={255}
-          //         autoFocus
-          //         />
-          //         {/* <Button className="mt-3 w-auto px-4" disabled={isSubmitting || !selectedVideoId}>
-          //         Guardar Cambios
-          //       </Button> */}
-          // </div>)
-          
-          }
-
-          
-          {/* <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
-            <p>Recorte seleccionado: {Math.floor(trimStart)}s - {Math.ceil(trimEnd)}s</p>
-            <Button className="mt-3 w-auto px-4" onClick={handleCreateJob} disabled={isSubmitting || !selectedVideoId}>
-              {isSubmitting ? "Creando clip..." : "Generar clip con timeline"}
-            </Button>
-            {submitInfo ? <p className="mt-2 text-xs text-neon-mint">{submitInfo}</p> : null}
-            {submitError ? <p className="mt-2 text-xs text-rose-200">{submitError}</p> : null}
-          </div> */}
-
-          {videoEditarBool &&!isLoading && videos.length > 0 ? (
-            <>
-              <div className="mt-4 grid gap-2 sm:grid-cols-2">
-                {videos.map((video) => {
-                  return (
-                    <button
-                      type="button"
-                      key={video.video_id}
-                      onClick={() => {
-                        setSelectedVideoId(video.video_id);
-                        if (focusedClip && focusedClip.video_id !== video.video_id) {
-                          setFocusedClip(null);
-                        }
-                      }}
-                      className={[
-                        "rounded-xl border px-3 py-2 text-left text-sm transition",
-                        selectedVideoId === video.video_id
-                          ? "border-neon-cyan/45 bg-neon-cyan/10 text-white"
-                          : "border-white/10 bg-white/5 text-white/75 hover:border-white/20 hover:text-white"
-                      ].join(" ")}
-                    >
-                      <p className="font-semibold">Video {video.video_id.slice(0, 8)}</p>
-                      <p className="mt-1 text-xs text-white/60">Archivo: {video.filename}</p>
-                      <p className="mt-1 text-xs uppercase tracking-[0.16em] text-neon-cyan/80">Estado: {video.status ?? "uploaded"}</p>
-                    </button>
-                  );
-                })}
+          {activeJobId ? (
+            <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-white/80">Progreso de creacion del clip</span>
+                <span className="text-white">{activeJobProgress}%</span>
               </div>
+              <div className="mt-2 h-2 overflow-hidden rounded-full bg-night-950/90">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-neon-cyan to-neon-mint transition-all duration-700"
+                  style={{ width: `${activeJobProgress}%` }}
+                />
+              </div>
+              <p className="mt-2 text-xs text-white/65">
+                Job {activeJobId.slice(0, 8)} - {activeJobStatusLabel}{isPollingActiveJob ? " (actualizando...)" : ""}
+              </p>
+              {activeJobPollingError ? <p className="mt-2 text-xs text-rose-200">{activeJobPollingError}</p> : null}
 
-              {totalPages > 1 ? (
-                <div className="mt-4 flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/80">
-                  <span>Pagina {page} de {totalPages}</span>
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:cursor-not-allowed disabled:opacity-40"
-                      disabled={page <= 1 || isLoading}
-                      onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-                    >
-                      Anterior
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-lg border border-white/15 px-3 py-1.5 text-xs transition hover:border-white/35 disabled:cursor-not-allowed disabled:opacity-40"
-                      disabled={page >= totalPages || isLoading}
-                      onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
-                    >
-                      Siguiente
-                    </button>
+              <div className="mt-4">
+                <p className="text-xs uppercase tracking-[0.16em] text-white/60">Preview final</p>
+                {activeJobOutputPath ? (
+                  <div className="mt-2 overflow-hidden rounded-xl border border-neon-cyan/30 bg-black">
+                    <video controls preload="metadata" src={activeJobOutputPath} className="w-full max-h-[420px] bg-black" />
                   </div>
-                </div>
-              ) : null}
-            </>
+                ) : (
+                  <div className="mt-2 rounded-xl border border-white/10 bg-night-900/70 px-3 py-4 text-sm text-white/70">
+                    El preview final aparecera aca cuando termine el render.
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : null}
+
+
+
+          {videoEditarBool && !selectedVideoId && !isLoading ? (
+            <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
+              <p>No hay video seleccionado para este timeline.</p>
+              <Link
+                href="/app/library"
+                className="mt-3 inline-flex items-center justify-center rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neon-cyan transition hover:bg-neon-cyan/20"
+              >
+                Ir a Biblioteca
+              </Link>
+            </div>
           ) : null}
         </Panel>
 

--- a/frontend/src/app/app/timeline/page.tsx
+++ b/frontend/src/app/app/timeline/page.tsx
@@ -11,6 +11,24 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 const MIN_CLIP_SECONDS = 5;
+const TIMELINE_SESSION_KEY = "timeline:editor-session";
+
+type StoredTimelineJob = {
+  jobId: string;
+  status: string | null;
+  outputPath: string | null;
+  updatedAt: string;
+};
+
+type TimelineSession = {
+  lastVideoId: string | null;
+  jobsByVideo: Record<string, StoredTimelineJob>;
+};
+
+const emptyTimelineSession: TimelineSession = {
+  lastVideoId: null,
+  jobsByVideo: {}
+};
 
 function normalizeJobStatus(status: string | null) {
   return (status ?? "PENDING").toLowerCase();
@@ -89,6 +107,42 @@ export default function TimelinePage() {
   const [activeJobOutputPath, setActiveJobOutputPath] = useState<string | null>(null);
   const [activeJobPollingError, setActiveJobPollingError] = useState<string | null>(null);
   const [isPollingActiveJob, setIsPollingActiveJob] = useState(false);
+  const [storedSession, setStoredSession] = useState<TimelineSession>(emptyTimelineSession);
+  const [isSessionHydrated, setIsSessionHydrated] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(TIMELINE_SESSION_KEY);
+      if (!raw) {
+        setStoredSession(emptyTimelineSession);
+        setIsSessionHydrated(true);
+        return;
+      }
+
+      const parsed = JSON.parse(raw) as Partial<TimelineSession>;
+      const next: TimelineSession = {
+        lastVideoId: typeof parsed.lastVideoId === "string" ? parsed.lastVideoId : null,
+        jobsByVideo:
+          parsed.jobsByVideo && typeof parsed.jobsByVideo === "object"
+            ? (parsed.jobsByVideo as Record<string, StoredTimelineJob>)
+            : {}
+      };
+      setStoredSession(next);
+    } catch {
+      window.localStorage.removeItem(TIMELINE_SESSION_KEY);
+      setStoredSession(emptyTimelineSession);
+    } finally {
+      setIsSessionHydrated(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isSessionHydrated) {
+      return;
+    }
+
+    window.localStorage.setItem(TIMELINE_SESSION_KEY, JSON.stringify(storedSession));
+  }, [isSessionHydrated, storedSession]);
 
 
   const saveRaname = async () => {
@@ -114,6 +168,10 @@ export default function TimelinePage() {
   };
 
   useEffect(() => {
+    if (!isSessionHydrated) {
+      return;
+    }
+
     if (!token) {
       setIsLoading(false);
       setError("No encontramos una sesion activa para cargar el timeline.");
@@ -141,7 +199,7 @@ export default function TimelinePage() {
           }
         }
 
-        const targetVideoId = preferredVideoFromQuery || selectedClip?.video_id || "";
+        const targetVideoId = preferredVideoFromQuery || selectedClip?.video_id || storedSession.lastVideoId || "";
 
         if (!targetVideoId) {
           setVideos([]);
@@ -185,7 +243,77 @@ export default function TimelinePage() {
     return () => {
       cancelled = true;
     };
-  }, [token, preferredClipId, preferredVideoId]);
+  }, [token, preferredClipId, preferredVideoId, storedSession.lastVideoId, isSessionHydrated]);
+
+  useEffect(() => {
+    if (!selectedVideoId) {
+      return;
+    }
+
+    setStoredSession((prev) => {
+      if (prev.lastVideoId === selectedVideoId) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        lastVideoId: selectedVideoId
+      };
+    });
+  }, [selectedVideoId]);
+
+  useEffect(() => {
+    if (!selectedVideoId) {
+      return;
+    }
+
+    const storedJob = storedSession.jobsByVideo[selectedVideoId];
+    if (!storedJob) {
+      setActiveJobId(null);
+      setActiveJobStatus(null);
+      setActiveJobOutputPath(null);
+      setActiveJobPollingError(null);
+      return;
+    }
+
+    setActiveJobId(storedJob.jobId);
+    setActiveJobStatus(storedJob.status ?? null);
+    setActiveJobOutputPath(storedJob.outputPath ?? null);
+    setActiveJobPollingError(null);
+  }, [selectedVideoId, storedSession.jobsByVideo]);
+
+  useEffect(() => {
+    if (!selectedVideoId || !activeJobId) {
+      return;
+    }
+
+    setStoredSession((prev) => {
+      const previousStoredJob = prev.jobsByVideo[selectedVideoId];
+      const nextStoredJob: StoredTimelineJob = {
+        jobId: activeJobId,
+        status: activeJobStatus,
+        outputPath: activeJobOutputPath,
+        updatedAt: new Date().toISOString()
+      };
+
+      if (
+        previousStoredJob &&
+        previousStoredJob.jobId === nextStoredJob.jobId &&
+        previousStoredJob.status === nextStoredJob.status &&
+        previousStoredJob.outputPath === nextStoredJob.outputPath
+      ) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        jobsByVideo: {
+          ...prev.jobsByVideo,
+          [selectedVideoId]: nextStoredJob
+        }
+      };
+    });
+  }, [selectedVideoId, activeJobId, activeJobStatus, activeJobOutputPath]);
 
   const selectedVideo = useMemo(
     () => videos.find((video) => video.video_id === selectedVideoId) ?? null,

--- a/frontend/src/components/audio/AudioPlayer.module.css
+++ b/frontend/src/components/audio/AudioPlayer.module.css
@@ -47,6 +47,6 @@
   box-shadow: 0 0 0 2px rgba(17, 17, 27, 0.9);
 }
 
-.volume {
-  width: 5.2rem;
+.volumeFull {
+  width: 100%;
 }

--- a/frontend/src/components/audio/AudioPlayer.module.css
+++ b/frontend/src/components/audio/AudioPlayer.module.css
@@ -1,0 +1,52 @@
+.slider {
+  --progress: 0%;
+  appearance: none;
+  width: 100%;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: linear-gradient(to right, rgba(203, 166, 247, 0.95) var(--progress), rgba(255, 255, 255, 0.16) var(--progress));
+  cursor: pointer;
+  border: 0;
+}
+
+.slider::-webkit-slider-runnable-track {
+  height: 0.45rem;
+  border-radius: 999px;
+  background: transparent;
+}
+
+.slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: #f5e0dc;
+  border: 2px solid #cba6f7;
+  margin-top: -0.175rem;
+  box-shadow: 0 0 0 2px rgba(17, 17, 27, 0.9);
+}
+
+.slider::-moz-range-track {
+  height: 0.45rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.slider::-moz-range-progress {
+  height: 0.45rem;
+  border-radius: 999px;
+  background: rgba(203, 166, 247, 0.95);
+}
+
+.slider::-moz-range-thumb {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: #f5e0dc;
+  border: 2px solid #cba6f7;
+  box-shadow: 0 0 0 2px rgba(17, 17, 27, 0.9);
+}
+
+.volume {
+  width: 5.2rem;
+}

--- a/frontend/src/components/audio/AudioPlayer.tsx
+++ b/frontend/src/components/audio/AudioPlayer.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { Pause, Play, Volume2, VolumeX } from "lucide-react";
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react";
+import styles from "./AudioPlayer.module.css";
+
+type AudioPlayerProps = {
+  src: string;
+  className?: string;
+  onDurationChange?: (durationSec: number) => void;
+};
+
+function formatTime(seconds: number) {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "0:00";
+  }
+
+  const totalSeconds = Math.floor(seconds);
+  const min = Math.floor(totalSeconds / 60);
+  const sec = totalSeconds % 60;
+  return `${min}:${sec.toString().padStart(2, "0")}`;
+}
+
+export function AudioPlayer({ src, className, onDurationChange }: AudioPlayerProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+  const [isMuted, setIsMuted] = useState(false);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    const handleLoadedMetadata = () => {
+      const nextDuration = Number.isFinite(audio.duration) ? audio.duration : 0;
+      setDuration(nextDuration);
+      onDurationChange?.(nextDuration);
+    };
+
+    const handleTimeUpdate = () => {
+      setCurrentTime(audio.currentTime);
+    };
+
+    const handleEnded = () => {
+      setIsPlaying(false);
+    };
+
+    const handleError = () => {
+      setIsPlaying(false);
+      setCurrentTime(0);
+      setDuration(0);
+      onDurationChange?.(0);
+    };
+
+    audio.addEventListener("loadedmetadata", handleLoadedMetadata);
+    audio.addEventListener("timeupdate", handleTimeUpdate);
+    audio.addEventListener("ended", handleEnded);
+    audio.addEventListener("error", handleError);
+
+    return () => {
+      audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
+      audio.removeEventListener("timeupdate", handleTimeUpdate);
+      audio.removeEventListener("ended", handleEnded);
+      audio.removeEventListener("error", handleError);
+    };
+  }, [onDurationChange]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    audio.volume = volume;
+    audio.muted = isMuted;
+  }, [isMuted, volume]);
+
+  const progressPct = useMemo(() => {
+    if (duration <= 0) {
+      return 0;
+    }
+    return Math.min((currentTime / duration) * 100, 100);
+  }, [currentTime, duration]);
+
+  const waveformBars = useMemo(
+    () => Array.from({ length: 30 }, (_, index) => 20 + ((index * 11 + 7) % 70)),
+    []
+  );
+
+  const progressStyle = {
+    "--progress": `${progressPct}%`
+  } as CSSProperties;
+
+  const volumeStyle = {
+    "--progress": `${(isMuted ? 0 : volume) * 100}%`
+  } as CSSProperties;
+
+  const togglePlay = async () => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+      return;
+    }
+
+    try {
+      await audio.play();
+      setIsPlaying(true);
+    } catch {
+      setIsPlaying(false);
+    }
+  };
+
+  const handleSeek = (value: number) => {
+    const audio = audioRef.current;
+    if (!audio || duration <= 0) {
+      return;
+    }
+
+    const nextTime = (value / 100) * duration;
+    audio.currentTime = nextTime;
+    setCurrentTime(nextTime);
+  };
+
+  return (
+    <div className={["rounded-2xl border border-white/12 bg-gradient-to-b from-night-900/85 to-night-900/70 p-3.5", className ?? ""].join(" ")}>
+      <audio ref={audioRef} preload="metadata" src={src} />
+
+      <div className="grid grid-cols-[auto_1fr] gap-3">
+        <button
+          type="button"
+          onClick={() => void togglePlay()}
+          className="inline-flex h-10 w-10 items-center justify-center self-center rounded-full border border-neon-violet/45 bg-neon-violet/15 text-neon-violet transition hover:bg-neon-violet/25"
+          aria-label={isPlaying ? "Pausar audio" : "Reproducir audio"}
+        >
+          {isPlaying ? <Pause size={16} /> : <Play size={16} className="ml-0.5" />}
+        </button>
+
+        <div className="min-w-0">
+          <div className="mb-2 overflow-hidden rounded-xl border border-white/10 bg-night-950/80 px-2 py-1.5">
+            <div className="flex h-6 items-end gap-1">
+              {waveformBars.map((height, index) => {
+                const active = progressPct >= ((index + 1) / waveformBars.length) * 100;
+                return (
+                  <span
+                    key={`bar-${height}-${index}`}
+                    className={[
+                      "w-full rounded-full transition-colors duration-200",
+                      active ? "bg-gradient-to-t from-neon-violet/70 to-neon-magenta/90" : "bg-white/15"
+                    ].join(" ")}
+                    style={{ height: `${height}%` }}
+                  />
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="mb-1.5 flex items-center justify-between text-[11px] text-white/70">
+            <span>{formatTime(currentTime)}</span>
+            <span>{formatTime(duration)}</span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={0.1}
+              value={duration > 0 ? progressPct : 0}
+              onChange={(event) => handleSeek(Number(event.target.value))}
+              className={styles.slider}
+              style={progressStyle}
+              aria-label="Progreso de audio"
+            />
+
+            <button
+              type="button"
+              onClick={() => setIsMuted((prev) => !prev)}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/20 bg-white/5 text-white/75 transition hover:border-neon-violet/40 hover:text-neon-violet"
+              aria-label={isMuted ? "Activar audio" : "Silenciar audio"}
+            >
+              {isMuted ? <VolumeX size={14} /> : <Volume2 size={14} />}
+            </button>
+
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={volume}
+              onChange={(event) => setVolume(Number(event.target.value))}
+              className={[styles.slider, styles.volume].join(" ")}
+              style={volumeStyle}
+              aria-label="Volumen"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/audio/AudioPlayer.tsx
+++ b/frontend/src/components/audio/AudioPlayer.tsx
@@ -86,11 +86,6 @@ export function AudioPlayer({ src, className, onDurationChange }: AudioPlayerPro
     return Math.min((currentTime / duration) * 100, 100);
   }, [currentTime, duration]);
 
-  const waveformBars = useMemo(
-    () => Array.from({ length: 30 }, (_, index) => 20 + ((index * 11 + 7) % 70)),
-    []
-  );
-
   const progressStyle = {
     "--progress": `${progressPct}%`
   } as CSSProperties;
@@ -144,31 +139,9 @@ export function AudioPlayer({ src, className, onDurationChange }: AudioPlayerPro
           {isPlaying ? <Pause size={16} /> : <Play size={16} className="ml-0.5" />}
         </button>
 
-        <div className="min-w-0">
-          <div className="mb-2 overflow-hidden rounded-xl border border-white/10 bg-night-950/80 px-2 py-1.5">
-            <div className="flex h-6 items-end gap-1">
-              {waveformBars.map((height, index) => {
-                const active = progressPct >= ((index + 1) / waveformBars.length) * 100;
-                return (
-                  <span
-                    key={`bar-${height}-${index}`}
-                    className={[
-                      "w-full rounded-full transition-colors duration-200",
-                      active ? "bg-gradient-to-t from-neon-violet/70 to-neon-magenta/90" : "bg-white/15"
-                    ].join(" ")}
-                    style={{ height: `${height}%` }}
-                  />
-                );
-              })}
-            </div>
-          </div>
-
-          <div className="mb-1.5 flex items-center justify-between text-[11px] text-white/70">
-            <span>{formatTime(currentTime)}</span>
-            <span>{formatTime(duration)}</span>
-          </div>
-
+        <div className="min-w-0 space-y-2">
           <div className="flex items-center gap-2">
+            <span className="w-8 text-[11px] text-white/70">{formatTime(currentTime)}</span>
             <input
               type="range"
               min={0}
@@ -180,7 +153,10 @@ export function AudioPlayer({ src, className, onDurationChange }: AudioPlayerPro
               style={progressStyle}
               aria-label="Progreso de audio"
             />
+            <span className="w-8 text-right text-[11px] text-white/70">{formatTime(duration)}</span>
+          </div>
 
+          <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={() => setIsMuted((prev) => !prev)}
@@ -197,7 +173,7 @@ export function AudioPlayer({ src, className, onDurationChange }: AudioPlayerPro
               step={0.01}
               value={volume}
               onChange={(event) => setVolume(Number(event.target.value))}
-              className={[styles.slider, styles.volume].join(" ")}
+              className={[styles.slider, styles.volumeFull].join(" ")}
               style={volumeStyle}
               aria-label="Volumen"
             />

--- a/frontend/src/components/home/VideoSettings.tsx
+++ b/frontend/src/components/home/VideoSettings.tsx
@@ -1,129 +1,190 @@
-import { useVideoSettingsStore, type VideoSettings } from "@/src/store/useVideoSettingsStore";
-import { Button } from "../ui/Button";
+import { useVideoSettingsStore, type VideoSettings as TimelineVideoSettings } from "@/src/store/useVideoSettingsStore";
 import { FormEvent, useState } from "react";
+import { Button } from "../ui/Button";
 
+type VideoSettingsProps = {
+  trimStart: number;
+  selectedVideoId: string | null;
+  trimEnd: number;
+  minClipDurationSec: number;
+  isSubmitting: boolean;
+  submitInfo: string | null;
+  submitError: string | null;
+  submitErrorSettings: string | null;
+  submitInfoSettings: string | null;
+  handleCreateJob: () => void;
+  saveRaname: () => void;
+  videoEditarBool: boolean;
+  draftFilename: string;
+  setDraftFilename: (event: string) => void;
+};
 
-type ButtonGeneraRecorte={
-  trimStart :number,
-  selectedVideoId: string | null,
-  trimEnd:number,
-  minClipDurationSec:number,
-  isSubmitting:boolean,
-  submitInfo:string  | null, 
-  submitError:string| null,
-  submitErrorSettings:string | null,
-  submitInfoSettings:string | null,
-  handleCreateJob:() => void,
-  saveRaname:() => void,
-  videoEditarBool:boolean,
-  draftFilename:string,
-  setDraftFilename:(event:string) => void
-}
+type ClipOption = {
+  value: TimelineVideoSettings["outputStyle"];
+  label: string;
+  description: string;
+};
 
-const settingItems: Array<{ key: keyof VideoSettings; label: string }> = [
-  { key: "cropToVertical", label: "Recorte 9:16" },
-  { key: "subtitles", label: "Subtitulos" },
-  { key: "faceTracking", label: "Seguimiento facial" },
-  { key: "colorFilter", label: "Filtro de color" }
+type ProfileOption = {
+  value: TimelineVideoSettings["contentProfile"];
+  label: string;
+};
+
+const clipOptions: ClipOption[] = [
+  {
+    value: "vertical",
+    label: "Vertical 9:16",
+    description: "Formato clasico para Shorts, Reels y TikTok"
+  },
+  {
+    value: "speaker_split",
+    label: "Speaker split",
+    description: "Enfoque en hablante + plano general"
+  }
 ];
 
-export function VideoSettings( {submitInfoSettings,submitErrorSettings, trimStart,videoEditarBool,draftFilename,setDraftFilename, saveRaname,  trimEnd, minClipDurationSec, isSubmitting,  submitInfo, submitError,selectedVideoId,handleCreateJob}:ButtonGeneraRecorte){
-      const settings = useVideoSettingsStore((state) => state.settings);
-      const saveSettings = useVideoSettingsStore((state) => state.saveSettings);
-      const [draft, setDraft] = useState<VideoSettings>({ ...settings, watermark: settings.watermark ?? "Hacelo Corto" });
-      const selectedDuration = Math.max(0, Math.ceil(trimEnd) - Math.floor(trimStart));
-      const canCreateClip = Boolean(selectedVideoId) && selectedDuration >= minClipDurationSec;
-      
-     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        saveSettings(draft);
-        saveRaname()
-      };
-   
-    return (<>
-    
-                <form onSubmit={handleSubmit} className="mt-5 space-y-4 min-w-70">
-                  <div className="space-y-2">
-                    {settingItems.map((item) => (
-                      <label
-                        key={item.key}
-                        className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90"
-                      >
-                        <span>{item.label}</span>
-                        <input
-                          type="checkbox"
-                          checked={draft[item.key] as boolean}
-                          onChange={(event) => {
-                            const checked = event.target.checked;
-                            setDraft((prev) => ({ ...prev, [item.key]: checked }));
-                          }}
-                          className="h-4 w-4 rounded border-white/20 bg-night-900 text-neon-cyan focus:ring-neon-cyan"
-                        />
-                      </label>
-                    ))}
+const profileOptions: ProfileOption[] = [
+  { value: "auto", label: "Auto" },
+  { value: "interview", label: "Entrevista" },
+  { value: "sports", label: "Deporte" },
+  { value: "music", label: "Musica" }
+];
 
-                    <label className="block rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90">
-                      <span className="text-xs uppercase tracking-[0.12em] text-white/65">Watermark</span>
-                      <input
-                        type="text"
-                        value={draft.watermark}
-                        onChange={(event) => {
-                          const value = event.target.value.slice(0, 12);
-                          setDraft((prev) => ({ ...prev, watermark: value }));
-                        }}
-                        maxLength={12}
-                        className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/70 px-3 py-2 text-xs text-white outline-none transition focus:border-neon-cyan/50"
-                      />
-                    </label>
-                  </div>
-    {
-          !videoEditarBool&&(
-            <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
-              <label className="">
-                Nombre
-              </label>
-              <input
-                  value={draftFilename}
-                  onChange={(event) => setDraftFilename(event.target.value)}
-                  className="w-full rounded-lg border border-white/20 bg-night-900/70 px-3 mt-1 py-2 text-xs text-white outline-none transition focus:border-neon-cyan/50"
-                  maxLength={255}
-                  autoFocus
-                  />
-                                     {submitInfoSettings ? <p className="mt-2 text-xs text-neon-mint">{submitInfoSettings}</p> : null}
-                    {submitErrorSettings ? <p className="mt-2 text-xs text-rose-200">{submitErrorSettings}</p> : null}
-          </div>)}
+export function VideoSettings({
+  submitInfoSettings,
+  submitErrorSettings,
+  trimStart,
+  videoEditarBool,
+  draftFilename,
+  setDraftFilename,
+  saveRaname,
+  trimEnd,
+  minClipDurationSec,
+  isSubmitting,
+  submitInfo,
+  submitError,
+  selectedVideoId,
+  handleCreateJob
+}: VideoSettingsProps) {
+  const settings = useVideoSettingsStore((state) => state.settings);
+  const saveSettings = useVideoSettingsStore((state) => state.saveSettings);
+  const [draft, setDraft] = useState<TimelineVideoSettings>(settings);
+  const selectedDuration = Math.max(0, Math.ceil(trimEnd) - Math.floor(trimStart));
+  const canCreateClip = Boolean(selectedVideoId) && selectedDuration >= minClipDurationSec;
 
-                  <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
-                    {/* <Button
-                      type="button"
-                      variant="neutral"
-                      className="h-10 w-auto px-4"
-                      onClick={() => {
-                        resetSettings();
-                        setDraft(useVideoSettingsStore.getState().settings);
-                      }}
-                    >
-                      Restaurar
-                    </Button> */}
-                    <Button type="submit"  className="h-10 w-auto px-4">
-                      Guardar ajustes
-                    </Button>
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    saveSettings(draft);
+    saveRaname();
+  };
 
-                  </div>
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="mt-5 space-y-4 min-w-70">
+        <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+          <p className="text-xs uppercase tracking-[0.16em] text-white/60">Formato de salida</p>
+          <div className="mt-2 grid gap-2">
+            {clipOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setDraft((prev) => ({ ...prev, outputStyle: option.value }))}
+                className={[
+                  "rounded-lg border px-3 py-2 text-left transition",
+                  draft.outputStyle === option.value
+                    ? "border-neon-cyan/45 bg-neon-cyan/15 text-neon-cyan"
+                    : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                ].join(" ")}
+              >
+                <p className="text-sm font-semibold">{option.label}</p>
+                <p className="mt-0.5 text-xs text-white/65">{option.description}</p>
+              </button>
+            ))}
+          </div>
+        </div>
 
+        <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+          <p className="text-xs uppercase tracking-[0.16em] text-white/60">Perfil de contenido</p>
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            {profileOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setDraft((prev) => ({ ...prev, contentProfile: option.value }))}
+                className={[
+                  "rounded-lg border px-3 py-2 text-sm font-semibold transition",
+                  draft.contentProfile === option.value
+                    ? "border-neon-mint/45 bg-neon-mint/15 text-neon-mint"
+                    : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                ].join(" ")}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
 
+        <label className="block rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90">
+          <span className="text-xs uppercase tracking-[0.12em] text-white/65">Watermark</span>
+          <input
+            type="text"
+            value={draft.watermark}
+            onChange={(event) => {
+              const value = event.target.value.slice(0, 12);
+              setDraft((prev) => ({ ...prev, watermark: value }));
+            }}
+            maxLength={12}
+            className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/70 px-3 py-2 text-xs text-white outline-none transition focus:border-neon-cyan/50"
+          />
+        </label>
+
+        <label className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90">
+          <span>Subtitulos</span>
+          <input
+            type="checkbox"
+            checked={draft.subtitles}
+            onChange={(event) => {
+              const checked = event.target.checked;
+              setDraft((prev) => ({ ...prev, subtitles: checked }));
+            }}
+            className="h-4 w-4 rounded border-white/20 bg-night-900 text-neon-cyan focus:ring-neon-cyan"
+          />
+        </label>
+
+        {!videoEditarBool ? (
           <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
-            <p>Recorte seleccionado: {Math.floor(trimStart)}s - {Math.ceil(trimEnd)}s</p>
-            <p className="mt-1 text-xs text-white/60">Duracion estimada: {selectedDuration}s (minimo {minClipDurationSec}s)</p>
-            <Button className="mt-3 w-auto px-4" onClick={handleCreateJob} disabled={isSubmitting || !canCreateClip}>
-              {isSubmitting ? "Creando clip..." : "Generar clip con timeline"}
-            </Button>
-            {!canCreateClip ? (
-              <p className="mt-2 text-xs text-amber-200">Ajusta el recorte para que tenga al menos {minClipDurationSec}s.</p>
-            ) : null}
-            {submitInfo ? <p className="mt-2 text-xs text-neon-mint">{submitInfo}</p> : null}
-            {submitError ? <p className="mt-2 text-xs text-rose-200">{submitError}</p> : null}
-          </div> 
-                </form>
-    </>)
+            <label>Nombre</label>
+            <input
+              value={draftFilename}
+              onChange={(event) => setDraftFilename(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/70 px-3 py-2 text-xs text-white outline-none transition focus:border-neon-cyan/50"
+              maxLength={255}
+              autoFocus
+            />
+            {submitInfoSettings ? <p className="mt-2 text-xs text-neon-mint">{submitInfoSettings}</p> : null}
+            {submitErrorSettings ? <p className="mt-2 text-xs text-rose-200">{submitErrorSettings}</p> : null}
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <Button type="submit" className="h-10 w-auto px-4">
+            Guardar ajustes
+          </Button>
+        </div>
+
+        <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
+          <p>Recorte seleccionado: {Math.floor(trimStart)}s - {Math.ceil(trimEnd)}s</p>
+          <p className="mt-1 text-xs text-white/60">Duracion estimada: {selectedDuration}s (minimo {minClipDurationSec}s)</p>
+          <Button className="mt-3 w-auto px-4" onClick={handleCreateJob} disabled={isSubmitting || !canCreateClip}>
+            {isSubmitting ? "Creando clip..." : "Generar clip con timeline"}
+          </Button>
+          {!canCreateClip ? (
+            <p className="mt-2 text-xs text-amber-200">Ajusta el recorte para que tenga al menos {minClipDurationSec}s.</p>
+          ) : null}
+          {submitInfo ? <p className="mt-2 text-xs text-neon-mint">{submitInfo}</p> : null}
+          {submitError ? <p className="mt-2 text-xs text-rose-200">{submitError}</p> : null}
+        </div>
+      </form>
+    </>
+  );
 }

--- a/frontend/src/components/home/VideoSettingsModal.tsx
+++ b/frontend/src/components/home/VideoSettingsModal.tsx
@@ -5,11 +5,11 @@ import { useVideoSettingsStore, type VideoSettings } from "@/src/store/useVideoS
 import { Settings2, X } from "lucide-react";
 import { FormEvent, useState } from "react";
 
-const settingItems: Array<{ key: keyof VideoSettings; label: string }> = [
-  { key: "cropToVertical", label: "Recorte 9:16" },
-  { key: "subtitles", label: "Subtitulos" },
-  { key: "faceTracking", label: "Seguimiento facial" },
-  { key: "colorFilter", label: "Filtro de color" }
+const profileOptions: Array<{ value: VideoSettings["contentProfile"]; label: string }> = [
+  { value: "auto", label: "Auto" },
+  { value: "interview", label: "Entrevista" },
+  { value: "sports", label: "Deporte" },
+  { value: "music", label: "Musica" }
 ];
 
 export function VideoSettingsModal() {
@@ -68,52 +68,82 @@ export function VideoSettingsModal() {
             </div>
 
             <form onSubmit={handleSubmit} className="mt-5 space-y-4">
-              <div className="space-y-2">
-                {settingItems.map((item) => (
-                  <label
-                    key={item.key}
-                    className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90"
-                  >
-                    <span>{item.label}</span>
-                    <input
-                      type="checkbox"
-                      checked={draft[item.key] as boolean}
-                      onChange={(event) => {
-                        const checked = event.target.checked;
-                        setDraft((prev) => ({ ...prev, [item.key]: checked }));
-                      }}
-                      className="h-4 w-4 rounded border-white/20 bg-night-900 text-neon-cyan focus:ring-neon-cyan"
-                    />
-                  </label>
-                ))}
-              </div>
+              <div className="space-y-3">
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <p className="text-xs uppercase tracking-[0.16em] text-white/60">Formato</p>
+                  <div className="mt-2 grid gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setDraft((prev) => ({ ...prev, outputStyle: "vertical" }))}
+                      className={[
+                        "rounded-lg border px-3 py-2 text-left text-sm font-semibold transition",
+                        draft.outputStyle === "vertical"
+                          ? "border-neon-cyan/45 bg-neon-cyan/15 text-neon-cyan"
+                          : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                      ].join(" ")}
+                    >
+                      Vertical 9:16
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setDraft((prev) => ({ ...prev, outputStyle: "speaker_split" }))}
+                      className={[
+                        "rounded-lg border px-3 py-2 text-left text-sm font-semibold transition",
+                        draft.outputStyle === "speaker_split"
+                          ? "border-neon-cyan/45 bg-neon-cyan/15 text-neon-cyan"
+                          : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                      ].join(" ")}
+                    >
+                      Speaker split
+                    </button>
+                  </div>
+                </div>
 
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <label className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
-                  <span className="text-xs uppercase tracking-[0.18em] text-white/60">Inicio (seg)</span>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <p className="text-xs uppercase tracking-[0.16em] text-white/60">Perfil de contenido</p>
+                  <div className="mt-2 grid grid-cols-2 gap-2">
+                    {profileOptions.map((option) => (
+                      <button
+                        key={option.value}
+                        type="button"
+                        onClick={() => setDraft((prev) => ({ ...prev, contentProfile: option.value }))}
+                        className={[
+                          "rounded-lg border px-3 py-2 text-sm font-semibold transition",
+                          draft.contentProfile === option.value
+                            ? "border-neon-mint/45 bg-neon-mint/15 text-neon-mint"
+                            : "border-white/15 bg-night-900/70 text-white/80 hover:bg-white/10"
+                        ].join(" ")}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <label className="block rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90">
+                  <span className="text-xs uppercase tracking-[0.12em] text-white/65">Watermark</span>
                   <input
-                    type="number"
-                    min={0}
-                    value={draft.videoStart}
+                    type="text"
+                    value={draft.watermark}
                     onChange={(event) => {
-                      const value = Number(event.target.value);
-                      setDraft((prev) => ({ ...prev, videoStart: Number.isFinite(value) ? value : 0 }));
+                      const value = event.target.value.slice(0, 12);
+                      setDraft((prev) => ({ ...prev, watermark: value }));
                     }}
-                    className="mt-2 w-full rounded-lg border border-white/15 bg-night-900/90 px-2 py-1.5 text-sm text-white outline-none transition focus:border-neon-cyan"
+                    maxLength={12}
+                    className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/70 px-3 py-2 text-xs text-white outline-none transition focus:border-neon-cyan/50"
                   />
                 </label>
 
-                <label className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
-                  <span className="text-xs uppercase tracking-[0.18em] text-white/60">Fin (seg)</span>
+                <label className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/90">
+                  <span>Subtitulos</span>
                   <input
-                    type="number"
-                    min={0}
-                    value={draft.videoEnd}
+                    type="checkbox"
+                    checked={draft.subtitles}
                     onChange={(event) => {
-                      const value = Number(event.target.value);
-                      setDraft((prev) => ({ ...prev, videoEnd: Number.isFinite(value) ? value : 0 }));
+                      const checked = event.target.checked;
+                      setDraft((prev) => ({ ...prev, subtitles: checked }));
                     }}
-                    className="mt-2 w-full rounded-lg border border-white/15 bg-night-900/90 px-2 py-1.5 text-sm text-white outline-none transition focus:border-neon-cyan"
+                    className="h-4 w-4 rounded border-white/20 bg-night-900 text-neon-cyan focus:ring-neon-cyan"
                   />
                 </label>
               </div>

--- a/frontend/src/store/useVideoSettingsStore.ts
+++ b/frontend/src/store/useVideoSettingsStore.ts
@@ -2,23 +2,17 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 export type VideoSettings = {
-  cropToVertical: boolean;
   subtitles: boolean;
-  faceTracking: boolean;
-  colorFilter: boolean;
   watermark: string;
-  videoStart: number;
-  videoEnd: number;
+  outputStyle: "vertical" | "speaker_split";
+  contentProfile: "auto" | "interview" | "sports" | "music";
 };
 
 const defaultSettings: VideoSettings = {
-  cropToVertical: true,
   subtitles: true,
-  faceTracking: false,
-  colorFilter: false,
   watermark: "Hacelo Corto",
-  videoStart: 0,
-  videoEnd: 60
+  outputStyle: "vertical",
+  contentProfile: "auto"
 };
 
 type VideoSettingsState = {


### PR DESCRIPTION
# Frontend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feat/frontend-timeline-library-streamline`

## Objetivo de la rama

Simplificar el flujo entre Biblioteca y Timeline para evitar duplicidad de listados, sumar feedback de progreso/preview final en Timeline y dejar los ajustes del editor mas claros, limpios y alineados al look catppuccin.

Rama de trabajo: `feat/frontend-timeline-library-streamline`.

## Cambios realizados

- Se agrego en `frontend/src/app/app/timeline/page.tsx` una barra de progreso para la creacion del clip con polling por `job_id` y estados visuales (`En cola`, `Procesando`, `Completado`, `Error`).
- Se incorporo en Timeline una seccion de `Preview final` que reproduce el resultado renderizado cuando el backend expone `output_path`.
- Se elimino del Timeline la lista duplicada de videos subidos; ahora la pantalla trabaja sobre un unico `videoId` (o resuelto por `clipId`) y muestra CTA a Biblioteca cuando falta seleccion.
- Se agrego accion `Abrir Timeline` en `frontend/src/app/app/library/page.tsx` para cada video original, replicando el flujo de navegacion profunda que ya existia para clips.
- Se rediseño `frontend/src/components/home/VideoSettings.tsx` para incluir en Timeline `output_style` (`Vertical 9:16` y `Speaker split`) + `content_profile` (`auto`, `entrevista`, `deporte`, `musica`) con UI mas limpia.
- Se removieron de ajustes de timeline valores sin uso real (`crop`, `face tracking`, `color filter`, `videoStart`, `videoEnd`) y se alinio el store en `frontend/src/store/useVideoSettingsStore.ts` a parametros vigentes del backend.
- Se actualizo `frontend/src/components/home/VideoSettingsModal.tsx` para mantener consistencia de tipos/ajustes y evitar deuda tecnica por campos obsoletos.
- Se persistio la sesion de Timeline en `localStorage` (`timeline:editor-session`) para conservar video activo + job en curso/resultado al recargar o navegar, evitando que se pierda el contexto de trabajo.
- Se agrego el asset `frontend/public/landing-demos/video1_musica.mp4` para la seccion de demos de landing.
- Se simplifico `frontend/src/app/app/audio_editor/page.tsx` removiendo listado/buscador/paginacion de videos para replicar el enfoque de Timeline: editor sobre un unico `videoId`/`clipId` proveniente de Biblioteca.
- Se agrego CTA a Biblioteca en Audio Editor cuando no hay video seleccionado, evitando estado vacio confuso.
- Se incorporo en Biblioteca (videos originales) el boton `Abrir en Audio Editor` en `frontend/src/app/app/library/page.tsx`, alineando la navegacion con clips.
- Fix de compatibilidad temporal con backend en `frontend/src/app/app/audio_editor/page.tsx`: `audio_volume` ahora se envia como entero (`1` o `2`) para evitar `500` por validacion de `JobAddAudioResponse`.
- Se agrego fallback visual en previews de clips en `frontend/src/app/app/library/page.tsx` para mostrar aviso cuando el `<video>` falla al reproducir (sin dejar card vacia/negra).
- Se reemplazo el reproductor nativo de audio por un componente custom catppuccin (`frontend/src/components/audio/AudioPlayer.tsx` + `AudioPlayer.module.css`) reutilizado en `Audio editor` y `Biblioteca`.
- Ajuste UX del player custom: se removio el bloque visual superior y se reorganizo el layout en dos filas limpias (arriba progreso/tiempos, abajo volumen), con foco en simplicidad visual.

## Commits realizados

- `feat(frontend): streamline timeline flow and add job progress preview`
- `fix(frontend): persist timeline editor session across reloads`
- `chore(frontend): add landing demo video1 asset`
- `feat(frontend): streamline audio editor entry from library`
- `fix(frontend): send integer audio volume and add clip preview fallback`
- `feat(frontend): redesign custom audio player with catppuccin UI`
- `refactor(frontend): simplify audio player layout for cleaner controls`
- `docs(frontend): log timeline-library streamlining and settings cleanup`

## Archivos clave

- `frontend/src/app/app/timeline/page.tsx`
- `frontend/src/app/app/library/page.tsx`
- `frontend/src/components/home/VideoSettings.tsx`
- `frontend/src/components/home/VideoSettingsModal.tsx`
- `frontend/src/store/useVideoSettingsStore.ts`
- `docs/frontend-pr-log.md`

## Validaciones locales

Ejecutado en `frontend/`:

- `npm run lint` -> OK

## Checklist antes de PR a develop

- [x] Rama nueva creada desde `develop`
- [x] Cambios limitados al alcance frontend/documentacion de esta iteracion
- [x] `npm run lint` OK
- [x] Documentacion actualizada