### PR TITLE
Feat/backend youtube ai metadata

### DIFF
--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -37,6 +37,11 @@ GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback
 
+# === OPENROUTER (optional, for YouTube metadata suggestions) ===
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=arcee-ai/trinity-large-preview:free
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+
 # === CORS ===
 ALLOWED_ORIGINS=["http://localhost:3000","http://localhost:5173"]
 

--- a/backend/api/app/api/v1/endpoints/youtube.py
+++ b/backend/api/app/api/v1/endpoints/youtube.py
@@ -6,10 +6,10 @@ y devuelve respuestas HTTP. Toda la lógica de negocio vive
 en ``YouTubeUploadService``.
 """
 
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Path, status
+from fastapi import APIRouter, Depends, Path, Query, status
 
 from app.core.dependencies import get_current_active_user
 from app.models.user import User
@@ -89,8 +89,14 @@ async def suggest_metadata(
     job_id: Annotated[UUID, Path(description="ID del Job procesado")],
     current_user: Annotated[User, Depends(get_current_active_user)],
     service: Annotated[YouTubeUploadService, Depends(get_youtube_service)],
+    tone: Annotated[
+        Literal["neutral", "energetic", "informative"],
+        Query(description="Tono sugerido para la metadata"),
+    ] = "neutral",
 ) -> YouTubeMetadataSuggestionResponse:
     """Sugiere metadata para publicar un clip en YouTube."""
     return await service.suggest_metadata_for_job(
-        job_id=job_id, user_id=current_user.id
+        job_id=job_id,
+        user_id=current_user.id,
+        tone=tone,
     )

--- a/backend/api/app/api/v1/endpoints/youtube.py
+++ b/backend/api/app/api/v1/endpoints/youtube.py
@@ -15,6 +15,7 @@ from app.core.dependencies import get_current_active_user
 from app.models.user import User
 from app.schemas.youtube import (
     YouTubeConnectionStatus,
+    YouTubeMetadataSuggestionResponse,
     YouTubePublishRequest,
     YouTubePublishResponse,
 )
@@ -75,3 +76,21 @@ async def check_youtube_connection(
 ) -> YouTubeConnectionStatus:
     """Verifica si el usuario tiene cuenta de YouTube conectada."""
     return service.get_connection_status(current_user.id)
+
+
+@router.get(
+    "/metadata/{job_id}",
+    response_model=YouTubeMetadataSuggestionResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Sugerir metadata para YouTube",
+    description="Genera titulo, descripcion y hashtags sugeridos para un clip.",
+)
+async def suggest_metadata(
+    job_id: Annotated[UUID, Path(description="ID del Job procesado")],
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[YouTubeUploadService, Depends(get_youtube_service)],
+) -> YouTubeMetadataSuggestionResponse:
+    """Sugiere metadata para publicar un clip en YouTube."""
+    return await service.suggest_metadata_for_job(
+        job_id=job_id, user_id=current_user.id
+    )

--- a/backend/api/app/core/config.py
+++ b/backend/api/app/core/config.py
@@ -57,6 +57,11 @@ class Settings(BaseSettings):
     GOOGLE_CLIENT_SECRET: str = Field(default="")
     GOOGLE_REDIRECT_URI: str = Field(default="http://localhost:3000/auth/callback")
 
+    # === LLM metadata suggestions (optional) ===
+    OPENROUTER_API_KEY: str = Field(default="")
+    OPENROUTER_MODEL: str = Field(default="meta-llama/llama-3.1-8b-instruct:free")
+    OPENROUTER_BASE_URL: str = Field(default="https://openrouter.ai/api/v1")
+
     @field_validator("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET")
     @classmethod
     def validate_google_credentials(cls, v, info):

--- a/backend/api/app/schemas/youtube.py
+++ b/backend/api/app/schemas/youtube.py
@@ -49,3 +49,14 @@ class YouTubeConnectionStatus(BaseSchema):
     provider_user_id: str | None = None
     token_expires_at: str | None = None
     is_expired: bool | None = None
+
+
+class YouTubeMetadataSuggestionResponse(BaseSchema):
+    """Metadata sugerida para publicar en YouTube."""
+
+    title: str = Field(max_length=100)
+    description: str = Field(max_length=5000)
+    hashtags: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    provider: str = Field(description="Proveedor usado para sugerencia")
+    generated_with_ai: bool = Field(default=False)

--- a/backend/api/app/services/youtube_upload_service.py
+++ b/backend/api/app/services/youtube_upload_service.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import tempfile
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 APP_NAME = "Hacelo Corto"
 YOUTUBE_CATEGORY_PEOPLE_BLOGS = "22"
+DEFAULT_DESCRIPTION_TEMPLATE = "Clip generado con Hacelo Corto"
 
 
 class YouTubeUploadService:
@@ -105,7 +107,9 @@ class YouTubeUploadService:
 
         try:
             # 4. Preparar metadata
-            resolved_title = title or job.video.original_filename or f"Clip {str(job_id)[:8]}"
+            resolved_title = (
+                title or job.video.original_filename or f"Clip {str(job_id)[:8]}"
+            )
             resolved_description = description or f"Video generado con {APP_NAME}"
             tags = self._build_tags(job)
 
@@ -143,7 +147,10 @@ class YouTubeUploadService:
         oauth_token = self._find_youtube_token(user_id)
 
         if not oauth_token:
-            return {"connected": False, "message": "Usuario no tiene cuenta de YouTube conectada"}
+            return {
+                "connected": False,
+                "message": "Usuario no tiene cuenta de YouTube conectada",
+            }
 
         return {
             "connected": True,
@@ -155,9 +162,48 @@ class YouTubeUploadService:
             "is_expired": oauth_token.is_expired(),
         }
 
-   
-    #  Métodos privados — lógica interna
+    async def suggest_metadata_for_job(
+        self,
+        *,
+        job_id: UUID,
+        user_id: UUID,
+    ) -> Dict[str, Any]:
+        """Genera sugerencias de titulo/descripcion/hashtags para YouTube."""
+        job = self.db.query(Job).filter(Job.id == job_id).first()
+        if not job:
+            raise NotFoundException(f"Job {job_id} no encontrado")
 
+        if job.user_id != user_id:
+            raise BadRequestException(
+                "No tenes permiso para generar metadata de este clip"
+            )
+
+        source_name = "clip"
+        if job.video and job.video.original_filename:
+            source_name = job.video.original_filename
+
+        subtitle_excerpt = self._extract_subtitle_excerpt(job)
+        base_title = self._build_default_title(source_name, str(job.id))
+        base_description = self._build_default_description(
+            source_name, subtitle_excerpt
+        )
+
+        metadata = self._fallback_metadata(base_title, base_description)
+        metadata["provider"] = "template"
+        metadata["generated_with_ai"] = False
+
+        if not settings.OPENROUTER_API_KEY:
+            return metadata
+
+        ai_metadata = await self._generate_metadata_with_openrouter(
+            source_filename=source_name,
+            job_id=str(job.id),
+            subtitle_excerpt=subtitle_excerpt,
+            fallback=metadata,
+        )
+        return ai_metadata
+
+    #  Métodos privados — lógica interna
 
     def _get_validated_job(self, job_id: UUID, user_id: UUID) -> Job:
         """Busca el Job, valida pertenencia y estado DONE."""
@@ -236,9 +282,7 @@ class YouTubeUploadService:
             )
         except Exception as exc:
             self._cleanup_temp(temp_path)
-            raise BadRequestException(
-                f"Error descargando video de MinIO: {exc}"
-            )
+            raise BadRequestException(f"Error descargando video de MinIO: {exc}")
 
         logger.info("✅ Video descargado a: %s", temp_path)
         return temp_path
@@ -251,6 +295,236 @@ class YouTubeUploadService:
         if video and video.width and video.height and video.height > video.width:
             tags.append("vertical")
         return tags
+
+    def _extract_subtitle_excerpt(self, job: Job) -> str:
+        raw_output = job.output_path
+        if not isinstance(raw_output, dict):
+            return ""
+
+        subtitles_path = raw_output.get("subtitles")
+        if not isinstance(subtitles_path, str) or not subtitles_path.startswith(
+            "s3://"
+        ):
+            return ""
+
+        try:
+            bucket, key = self.storage._extract_bucket_and_key(subtitles_path)
+            response = self.storage.client.get_object(Bucket=bucket, Key=key)
+            body = response["Body"].read()
+            text = body.decode("utf-8", errors="ignore")
+        except Exception:
+            return ""
+
+        lines: list[str] = []
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line.isdigit():
+                continue
+            if "-->" in line:
+                continue
+            lines.append(line)
+            if len(lines) >= 4:
+                break
+
+        return " ".join(lines)[:500]
+
+    @staticmethod
+    def _sanitize_filename(filename: str) -> str:
+        cleaned = re.sub(r"\.[A-Za-z0-9]{2,5}$", "", filename)
+        cleaned = re.sub(r"[_\-]+", " ", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        return cleaned or "clip"
+
+    def _build_default_title(self, source_filename: str, job_id: str) -> str:
+        stem = self._sanitize_filename(source_filename)
+        title = f"{stem} | Clip corto"
+        if len(title) > 100:
+            title = title[:97].rstrip() + "..."
+        if not title.strip():
+            title = f"Clip {job_id[:8]} - {APP_NAME}"
+        return title
+
+    @staticmethod
+    def _build_default_description(source_filename: str, subtitle_excerpt: str) -> str:
+        source = f"Fuente: {source_filename}" if source_filename else ""
+        parts = [DEFAULT_DESCRIPTION_TEMPLATE]
+        if subtitle_excerpt:
+            parts.append(f"Momento destacado: {subtitle_excerpt}")
+        if source:
+            parts.append(source)
+        parts.append("#shorts #hacelocorto")
+        return "\n".join(parts)[:5000]
+
+    @staticmethod
+    def _normalize_hashtags(values: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for value in values:
+            token = value.strip()
+            if not token:
+                continue
+            token = token.replace(" ", "")
+            if not token.startswith("#"):
+                token = f"#{token}"
+            token = re.sub(r"[^#\w]", "", token)
+            if len(token) <= 1:
+                continue
+            lowered = token.lower()
+            if lowered in {item.lower() for item in normalized}:
+                continue
+            normalized.append(token)
+            if len(normalized) >= 10:
+                break
+        return normalized
+
+    @staticmethod
+    def _normalize_tags(values: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            token = value.strip().lstrip("#")
+            token = re.sub(r"\s+", " ", token)
+            if not token:
+                continue
+            key = token.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(token[:50])
+            if len(normalized) >= 15:
+                break
+        return normalized
+
+    def _fallback_metadata(self, title: str, description: str) -> Dict[str, Any]:
+        hashtags = self._normalize_hashtags(
+            ["#shorts", "#hacelocorto", "#clip", "#video"]
+        )
+        tags = self._normalize_tags([item.lstrip("#") for item in hashtags])
+        return {
+            "title": title[:100],
+            "description": description[:5000],
+            "hashtags": hashtags,
+            "tags": tags,
+        }
+
+    @staticmethod
+    def _extract_json_object(raw_text: str) -> Dict[str, Any] | None:
+        candidate = raw_text.strip()
+        if candidate.startswith("```"):
+            candidate = re.sub(r"^```(?:json)?", "", candidate).strip()
+            candidate = re.sub(r"```$", "", candidate).strip()
+
+        try:
+            parsed = json.loads(candidate)
+            return parsed if isinstance(parsed, dict) else None
+        except json.JSONDecodeError:
+            match = re.search(r"\{.*\}", candidate, flags=re.DOTALL)
+            if not match:
+                return None
+            try:
+                parsed = json.loads(match.group(0))
+                return parsed if isinstance(parsed, dict) else None
+            except json.JSONDecodeError:
+                return None
+
+    async def _generate_metadata_with_openrouter(
+        self,
+        *,
+        source_filename: str,
+        job_id: str,
+        subtitle_excerpt: str,
+        fallback: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        prompt = (
+            "Genera metadata para YouTube Shorts en español rioplatense. "
+            "Responde SOLO JSON valido con claves: title, description, hashtags, tags. "
+            "title max 100 chars. description max 5000 chars. "
+            "hashtags array de 5 a 10 items (con #). tags array de 5 a 12 items (sin #). "
+            "Evita promesas engañosas.\n"
+            f"job_id: {job_id}\n"
+            f"source_filename: {source_filename}\n"
+            f"subtitle_excerpt: {subtitle_excerpt or 'sin subtitulos'}"
+        )
+
+        body = {
+            "model": settings.OPENROUTER_MODEL,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Eres especialista en copy para YouTube Shorts. Devuelves JSON estricto.",
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+            "temperature": 0.5,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {settings.OPENROUTER_API_KEY}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=25) as client:
+                response = await client.post(
+                    f"{settings.OPENROUTER_BASE_URL.rstrip('/')}/chat/completions",
+                    headers=headers,
+                    json=body,
+                )
+                response.raise_for_status()
+                payload = response.json()
+
+            message = (
+                payload.get("choices", [{}])[0].get("message", {}).get("content", "")
+            )
+            parsed = self._extract_json_object(message)
+            if not parsed:
+                return {
+                    **fallback,
+                    "provider": f"openrouter:{settings.OPENROUTER_MODEL}",
+                    "generated_with_ai": False,
+                }
+
+            hashtags = (
+                parsed.get("hashtags")
+                if isinstance(parsed.get("hashtags"), list)
+                else []
+            )
+            tags = parsed.get("tags") if isinstance(parsed.get("tags"), list) else []
+
+            title = str(parsed.get("title") or fallback["title"]).strip()[:100]
+            description = str(
+                parsed.get("description") or fallback["description"]
+            ).strip()[:5000]
+
+            normalized_hashtags = self._normalize_hashtags(
+                [str(item) for item in hashtags]
+            )
+            if not normalized_hashtags:
+                normalized_hashtags = fallback["hashtags"]
+
+            normalized_tags = self._normalize_tags([str(item) for item in tags])
+            if not normalized_tags:
+                normalized_tags = fallback["tags"]
+
+            return {
+                "title": title,
+                "description": description,
+                "hashtags": normalized_hashtags,
+                "tags": normalized_tags,
+                "provider": f"openrouter:{settings.OPENROUTER_MODEL}",
+                "generated_with_ai": True,
+            }
+        except Exception as exc:
+            logger.warning("No se pudo generar metadata con OpenRouter: %s", exc)
+            return {
+                **fallback,
+                "provider": f"openrouter:{settings.OPENROUTER_MODEL}",
+                "generated_with_ai": False,
+            }
 
     @staticmethod
     def _cleanup_temp(path: str) -> None:
@@ -412,7 +686,9 @@ class YouTubeUploadService:
 
             # Persistir token renovado
             oauth_token.access_token = new_access_token
-            oauth_token.expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            oauth_token.expires_at = datetime.now(timezone.utc) + timedelta(
+                seconds=expires_in
+            )
             oauth_token.last_refreshed_at = datetime.now(timezone.utc)
             self.db.commit()
 

--- a/backend/api/app/services/youtube_upload_service.py
+++ b/backend/api/app/services/youtube_upload_service.py
@@ -167,6 +167,7 @@ class YouTubeUploadService:
         *,
         job_id: UUID,
         user_id: UUID,
+        tone: str = "neutral",
     ) -> Dict[str, Any]:
         """Genera sugerencias de titulo/descripcion/hashtags para YouTube."""
         job = self.db.query(Job).filter(Job.id == job_id).first()
@@ -185,7 +186,9 @@ class YouTubeUploadService:
         subtitle_excerpt = self._extract_subtitle_excerpt(job)
         base_title = self._build_default_title(source_name, str(job.id))
         base_description = self._build_default_description(
-            source_name, subtitle_excerpt
+            source_name,
+            subtitle_excerpt,
+            tone,
         )
 
         metadata = self._fallback_metadata(base_title, base_description)
@@ -199,6 +202,7 @@ class YouTubeUploadService:
             source_filename=source_name,
             job_id=str(job.id),
             subtitle_excerpt=subtitle_excerpt,
+            tone=tone,
             fallback=metadata,
         )
         return ai_metadata
@@ -347,9 +351,18 @@ class YouTubeUploadService:
         return title
 
     @staticmethod
-    def _build_default_description(source_filename: str, subtitle_excerpt: str) -> str:
+    def _build_default_description(
+        source_filename: str,
+        subtitle_excerpt: str,
+        tone: str,
+    ) -> str:
         source = f"Fuente: {source_filename}" if source_filename else ""
+        tone_line = {
+            "energetic": "Tono: dinamico y potente.",
+            "informative": "Tono: informativo y claro.",
+        }.get(tone, "Tono: neutral y directo.")
         parts = [DEFAULT_DESCRIPTION_TEMPLATE]
+        parts.append(tone_line)
         if subtitle_excerpt:
             parts.append(f"Momento destacado: {subtitle_excerpt}")
         if source:
@@ -434,8 +447,15 @@ class YouTubeUploadService:
         source_filename: str,
         job_id: str,
         subtitle_excerpt: str,
+        tone: str,
         fallback: Dict[str, Any],
     ) -> Dict[str, Any]:
+        tone_hint = {
+            "neutral": "Tono neutral y claro.",
+            "energetic": "Tono energico y dinamico, sin exageraciones.",
+            "informative": "Tono informativo y directo.",
+        }.get(tone, "Tono neutral y claro.")
+
         prompt = (
             "Genera metadata para YouTube Shorts en español rioplatense. "
             "Responde SOLO JSON valido con claves: title, description, hashtags, tags. "
@@ -444,7 +464,8 @@ class YouTubeUploadService:
             "Evita promesas engañosas.\n"
             f"job_id: {job_id}\n"
             f"source_filename: {source_filename}\n"
-            f"subtitle_excerpt: {subtitle_excerpt or 'sin subtitulos'}"
+            f"subtitle_excerpt: {subtitle_excerpt or 'sin subtitulos'}\n"
+            f"tono: {tone_hint}"
         )
 
         body = {
@@ -488,12 +509,10 @@ class YouTubeUploadService:
                     "generated_with_ai": False,
                 }
 
-            hashtags = (
-                parsed.get("hashtags")
-                if isinstance(parsed.get("hashtags"), list)
-                else []
-            )
-            tags = parsed.get("tags") if isinstance(parsed.get("tags"), list) else []
+            raw_hashtags = parsed.get("hashtags")
+            raw_tags = parsed.get("tags")
+            hashtags = raw_hashtags if isinstance(raw_hashtags, list) else []
+            tags = raw_tags if isinstance(raw_tags, list) else []
 
             title = str(parsed.get("title") or fallback["title"]).strip()[:100]
             description = str(

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -2,31 +2,43 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feat/frontend-auto2-audio-progress-clean`
+Rama de trabajo actual: `feat/backend-youtube-ai-metadata`
 
 ### Objetivo
 
-Dejar trazabilidad backend para el refresh de frontend sobre `auto2`, subtitulos/watermark y soporte de audios, incluyendo fix minimo en `delete clip` para contratos `output_path` JSON.
+Agregar sugerencias automaticas de metadata para YouTube (titulo, descripcion, hashtags y tags) desde backend, con fallback seguro y opcion IA via OpenRouter.
 
 ### Cambios implementados en curso
 
-- Se valido que el frontend ya no consuma el endpoint eliminado `POST /api/v1/jobs/reframe/{video_id}/auto` y quede alineado con `POST /api/v1/jobs/reframe/{video_id}/auto2`.
-- Se cableo en frontend el endpoint `POST /api/v1/jobs/add-audio/{video_id}` para iniciar jobs de mezcla de audio desde Timeline.
-- Se cableo en frontend el endpoint `POST /api/v1/videos/from-job/{job_id}` para importar resultados de jobs como videos editables.
-- Se movio en frontend el uso de `add-audio` hacia una pantalla dedicada `Audio editor` (sin cambios adicionales de backend requeridos).
-- Se aplico fix local en `backend/api/app/services/job_service.py` para eliminar clips cuando `output_path` llega como JSON (`video` + `subtitles`) y evitar fallos al borrar assets.
-- Ajuste de frontend: se validan limites de duracion antes de llamar `add-audio` para no enviar segmentos que excedan el largo del video destino.
-- Se consumen desde frontend los endpoints ya disponibles de YouTube (`GET /api/v1/youtube/status`, `POST /api/v1/youtube/publish/{job_id}`) para pasar de modo demo a flujo real de publicacion.
-- Ajuste de consumo frontend: la vista Share ahora usa `GET /api/v1/jobs/{job_id}` para resolver clip puntual y evitar dependencia de filtros en listados.
-- En esta iteracion no hubo cambios de codigo backend; solo se incorporo un asset de demo en frontend para landing.
+- Se agrego `GET /api/v1/youtube/metadata/{job_id}` en `backend/api/app/api/v1/endpoints/youtube.py` para devolver metadata sugerida por clip autenticado.
+- Se extendio `backend/api/app/schemas/youtube.py` con `YouTubeMetadataSuggestionResponse` (`title`, `description`, `hashtags`, `tags`, `provider`, `generated_with_ai`).
+- Se implemento en `backend/api/app/services/youtube_upload_service.py` la logica de sugerencia de copy usando como contexto:
+  - `source_filename` del video original,
+  - extracto de subtitulos si existe (`output_path.subtitles`),
+  - `job_id`,
+  - `tone` recibido desde frontend (`neutral`, `energetic`, `informative`).
+- Se enforcean limites y normalizacion post-modelo para asegurar salida publicable:
+  - `title <= 100`, `description <= 5000`,
+  - limpieza y dedupe de hashtags/tags,
+  - JSON estricto con fallback robusto si la respuesta IA viene en formato no ideal.
+- Se agrego fallback deterministico cuando no hay key o falla provider IA (`provider=template`, `generated_with_ai=false`) para no bloquear publicacion.
+- Se agregaron variables opcionales en `backend/api/app/core/config.py` y `backend/api/.env.example`:
+  - `OPENROUTER_API_KEY`,
+  - `OPENROUTER_MODEL` (ej: `arcee-ai/trinity-large-preview:free`),
+  - `OPENROUTER_BASE_URL=https://openrouter.ai/api/v1`.
 
 ### Commits de esta rama (backend)
 
-- `fix(backend): support deleting clips with json output_path`
+- `feat(backend): add youtube metadata suggestion endpoint`
+- `feat(backend): add tone control for youtube metadata suggestions`
+- `docs(backend): document youtube ai metadata flow and env setup`
 
 ### Validaciones locales
 
-- Verificacion manual del flujo `DELETE /api/v1/jobs/{job_id}` con `output_path` JSON (sin excepciones de tipo y borrado correcto de assets asociados).
+- `python3 -m compileall backend/api/app/api/v1/endpoints/youtube.py backend/api/app/services/youtube_upload_service.py` -> OK
+- Verificacion manual de `GET /api/v1/youtube/metadata/{job_id}`:
+  - sin key -> responde fallback `template`,
+  - con key -> responde `provider=openrouter:<model>` cuando IA responde correctamente.
 
 ## Objetivo
 


### PR DESCRIPTION
# Backend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feat/backend-youtube-ai-metadata`

### Objetivo

Agregar sugerencias automaticas de metadata para YouTube (titulo, descripcion, hashtags y tags) desde backend, con fallback seguro y opcion IA via OpenRouter.

### Cambios implementados en curso

- Se agrego `GET /api/v1/youtube/metadata/{job_id}` en `backend/api/app/api/v1/endpoints/youtube.py` para devolver metadata sugerida por clip autenticado.
- Se extendio `backend/api/app/schemas/youtube.py` con `YouTubeMetadataSuggestionResponse` (`title`, `description`, `hashtags`, `tags`, `provider`, `generated_with_ai`).
- Se implemento en `backend/api/app/services/youtube_upload_service.py` la logica de sugerencia de copy usando como contexto:
  - `source_filename` del video original,
  - extracto de subtitulos si existe (`output_path.subtitles`),
  - `job_id`,
  - `tone` recibido desde frontend (`neutral`, `energetic`, `informative`).
- Se enforcean limites y normalizacion post-modelo para asegurar salida publicable:
  - `title <= 100`, `description <= 5000`,
  - limpieza y dedupe de hashtags/tags,
  - JSON estricto con fallback robusto si la respuesta IA viene en formato no ideal.
- Se agrego fallback deterministico cuando no hay key o falla provider IA (`provider=template`, `generated_with_ai=false`) para no bloquear publicacion.
- Se agregaron variables opcionales en `backend/api/app/core/config.py` y `backend/api/.env.example`:
  - `OPENROUTER_API_KEY`,
  - `OPENROUTER_MODEL` (ej: `arcee-ai/trinity-large-preview:free`),
  - `OPENROUTER_BASE_URL=https://openrouter.ai/api/v1`.
  - https://openrouter.ai/ (creense un user y ahi sacan la api key, modelo gratis)

### Commits de esta rama (backend)

- `feat(backend): add youtube metadata suggestion endpoint`
- `feat(backend): add tone control for youtube metadata suggestions`
- `docs(backend): document youtube ai metadata flow and env setup`

### Validaciones locales

- `python3 -m compileall backend/api/app/api/v1/endpoints/youtube.py backend/api/app/services/youtube_upload_service.py` -> OK
- Verificacion manual de `GET /api/v1/youtube/metadata/{job_id}`:
  - sin key -> responde fallback `template`,
  - con key -> responde `provider=openrouter:<model>` cuando IA responde correctamente.