### PR TITLE
Feat/frontend youtube ai metadata

### DIFF
--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -2,51 +2,32 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feat/frontend-timeline-library-streamline`
+Rama de trabajo actual: `feat/frontend-youtube-ai-metadata`
 
 ## Objetivo de la rama
 
-Simplificar el flujo entre Biblioteca y Timeline para evitar duplicidad de listados, sumar feedback de progreso/preview final en Timeline y dejar los ajustes del editor mas claros, limpios y alineados al look catppuccin.
+Mejorar la pantalla de Share para sugerir metadata de YouTube con IA (titulo, descripcion y hashtags), dejando control editable desde frontend y selector de tono para el copy.
 
-Rama de trabajo: `feat/frontend-timeline-library-streamline`.
+Rama de trabajo: `feat/frontend-youtube-ai-metadata`.
 
 ## Cambios realizados
 
-- Se agrego en `frontend/src/app/app/timeline/page.tsx` una barra de progreso para la creacion del clip con polling por `job_id` y estados visuales (`En cola`, `Procesando`, `Completado`, `Error`).
-- Se incorporo en Timeline una seccion de `Preview final` que reproduce el resultado renderizado cuando el backend expone `output_path`.
-- Se elimino del Timeline la lista duplicada de videos subidos; ahora la pantalla trabaja sobre un unico `videoId` (o resuelto por `clipId`) y muestra CTA a Biblioteca cuando falta seleccion.
-- Se agrego accion `Abrir Timeline` en `frontend/src/app/app/library/page.tsx` para cada video original, replicando el flujo de navegacion profunda que ya existia para clips.
-- Se rediseño `frontend/src/components/home/VideoSettings.tsx` para incluir en Timeline `output_style` (`Vertical 9:16` y `Speaker split`) + `content_profile` (`auto`, `entrevista`, `deporte`, `musica`) con UI mas limpia.
-- Se removieron de ajustes de timeline valores sin uso real (`crop`, `face tracking`, `color filter`, `videoStart`, `videoEnd`) y se alinio el store en `frontend/src/store/useVideoSettingsStore.ts` a parametros vigentes del backend.
-- Se actualizo `frontend/src/components/home/VideoSettingsModal.tsx` para mantener consistencia de tipos/ajustes y evitar deuda tecnica por campos obsoletos.
-- Se persistio la sesion de Timeline en `localStorage` (`timeline:editor-session`) para conservar video activo + job en curso/resultado al recargar o navegar, evitando que se pierda el contexto de trabajo.
-- Se agrego el asset `frontend/public/landing-demos/video1_musica.mp4` para la seccion de demos de landing.
-- Se simplifico `frontend/src/app/app/audio_editor/page.tsx` removiendo listado/buscador/paginacion de videos para replicar el enfoque de Timeline: editor sobre un unico `videoId`/`clipId` proveniente de Biblioteca.
-- Se agrego CTA a Biblioteca en Audio Editor cuando no hay video seleccionado, evitando estado vacio confuso.
-- Se incorporo en Biblioteca (videos originales) el boton `Abrir en Audio Editor` en `frontend/src/app/app/library/page.tsx`, alineando la navegacion con clips.
-- Fix de compatibilidad temporal con backend en `frontend/src/app/app/audio_editor/page.tsx`: `audio_volume` ahora se envia como entero (`1` o `2`) para evitar `500` por validacion de `JobAddAudioResponse`.
-- Se agrego fallback visual en previews de clips en `frontend/src/app/app/library/page.tsx` para mostrar aviso cuando el `<video>` falla al reproducir (sin dejar card vacia/negra).
-- Se reemplazo el reproductor nativo de audio por un componente custom catppuccin (`frontend/src/components/audio/AudioPlayer.tsx` + `AudioPlayer.module.css`) reutilizado en `Audio editor` y `Biblioteca`.
-- Ajuste UX del player custom: se removio el bloque visual superior y se reorganizo el layout en dos filas limpias (arriba progreso/tiempos, abajo volumen), con foco en simplicidad visual.
+- Se agrego en `frontend/src/services/videoApi.ts` el contrato `suggestYoutubeMetadata(jobId, token, tone)` para consumir `GET /api/v1/youtube/metadata/{job_id}` con tono opcional.
+- Se actualizo `frontend/src/app/app/share/[clipId]/page.tsx` con boton `Sugerir con IA`, estado de carga y autocompletado de titulo/descripcion/hashtags.
+- Se incorporo campo editable de hashtags y composicion automatica en descripcion final al publicar (sin perder edicion manual).
+- Se agrego selector de tono (`neutral`, `energetic`, `informative`) para personalizar estilo del copy sugerido.
+- Se agrego visualizacion de proveedor de metadata para trazabilidad en UI (`template` o `openrouter:<model>`).
 
 ## Commits realizados
 
-- `feat(frontend): streamline timeline flow and add job progress preview`
-- `fix(frontend): persist timeline editor session across reloads`
-- `chore(frontend): add landing demo video1 asset`
-- `feat(frontend): streamline audio editor entry from library`
-- `fix(frontend): send integer audio volume and add clip preview fallback`
-- `feat(frontend): redesign custom audio player with catppuccin UI`
-- `refactor(frontend): simplify audio player layout for cleaner controls`
-- `docs(frontend): log timeline-library streamlining and settings cleanup`
+- `feat(frontend): add ai metadata suggestions in share flow`
+- `feat(frontend): add tone selector for ai metadata suggestions`
+- `docs(frontend): log youtube ai metadata flow in share`
 
 ## Archivos clave
 
-- `frontend/src/app/app/timeline/page.tsx`
-- `frontend/src/app/app/library/page.tsx`
-- `frontend/src/components/home/VideoSettings.tsx`
-- `frontend/src/components/home/VideoSettingsModal.tsx`
-- `frontend/src/store/useVideoSettingsStore.ts`
+- `frontend/src/app/app/share/[clipId]/page.tsx`
+- `frontend/src/services/videoApi.ts`
 - `docs/frontend-pr-log.md`
 
 ## Validaciones locales

--- a/frontend/src/app/app/share/[clipId]/page.tsx
+++ b/frontend/src/app/app/share/[clipId]/page.tsx
@@ -55,6 +55,7 @@ export default function ShareClipPage() {
   const [youtubeDescription, setYoutubeDescription] = useState("");
   const [youtubePrivacy, setYoutubePrivacy] = useState<"public" | "private" | "unlisted">("private");
   const [youtubeHashtags, setYoutubeHashtags] = useState("#shorts #hacelocorto");
+  const [youtubeTone, setYoutubeTone] = useState<"neutral" | "energetic" | "informative">("neutral");
   const [isGeneratingMetadata, setIsGeneratingMetadata] = useState(false);
   const [metadataProvider, setMetadataProvider] = useState<string | null>(null);
   const canPublishClip = clip ? ["done", "completed"].includes(clip.status.toLowerCase()) : false;
@@ -128,6 +129,7 @@ export default function ShareClipPage() {
     setYoutubeTitle(`Clip ${clip.job_id.slice(0, 8)} - Hacelo Corto`);
     setYoutubeDescription(`Clip generado desde ${clip.source_filename}`);
     setYoutubeHashtags("#shorts #hacelocorto");
+    setYoutubeTone("neutral");
     setMetadataProvider(null);
   }, [clip]);
 
@@ -197,7 +199,11 @@ export default function ShareClipPage() {
     setError(null);
 
     try {
-      const suggestion: YoutubeMetadataSuggestionResponse = await videoApi.suggestYoutubeMetadata(clip.job_id, token);
+      const suggestion: YoutubeMetadataSuggestionResponse = await videoApi.suggestYoutubeMetadata(
+        clip.job_id,
+        token,
+        youtubeTone
+      );
       setYoutubeTitle(suggestion.title.slice(0, 100));
       setYoutubeDescription(suggestion.description.slice(0, 5000));
       setYoutubeHashtags(suggestion.hashtags.join(" "));
@@ -323,14 +329,25 @@ export default function ShareClipPage() {
                             Mejora titulo y descripcion con sugerencias automaticas.
                             {metadataProvider ? ` Provider: ${metadataProvider}` : ""}
                           </p>
-                          <Button
-                            className="h-8 px-3 py-1.5 text-[11px]"
-                            variant="neutral"
-                            disabled={isGeneratingMetadata || !canPublishClip}
-                            onClick={() => void handleSuggestMetadata()}
-                          >
-                            {isGeneratingMetadata ? "Generando..." : "Sugerir con IA"}
-                          </Button>
+                          <div className="flex items-center gap-2">
+                            <select
+                              value={youtubeTone}
+                              onChange={(event) => setYoutubeTone(event.target.value as "neutral" | "energetic" | "informative")}
+                              className="h-8 rounded-lg border border-white/20 bg-night-900/80 px-2 text-[11px] text-white outline-none focus:border-neon-cyan/50"
+                            >
+                              <option value="neutral">Tono neutral</option>
+                              <option value="energetic">Tono energico</option>
+                              <option value="informative">Tono informativo</option>
+                            </select>
+                            <Button
+                              className="h-8 px-3 py-1.5 text-[11px]"
+                              variant="neutral"
+                              disabled={isGeneratingMetadata || !canPublishClip}
+                              onClick={() => void handleSuggestMetadata()}
+                            >
+                              {isGeneratingMetadata ? "Generando..." : "Sugerir con IA"}
+                            </Button>
+                          </div>
                         </div>
                         <label className="text-xs text-white/75 sm:col-span-2">
                           Titulo

--- a/frontend/src/app/app/share/[clipId]/page.tsx
+++ b/frontend/src/app/app/share/[clipId]/page.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/src/components/ui/Button";
 import { Panel } from "@/src/components/ui/Panel";
 import { authApi } from "@/src/services/authApi";
-import { videoApi, type UserClipItem, type YoutubeConnectionStatus, VideoApiError } from "@/src/services/videoApi";
+import { videoApi, type UserClipItem, type YoutubeConnectionStatus, type YoutubeMetadataSuggestionResponse, VideoApiError } from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
 import { Facebook, Instagram, MessageCircle, Music2, Share2, Youtube } from "lucide-react";
 import Link from "next/link";
@@ -54,6 +54,9 @@ export default function ShareClipPage() {
   const [youtubeTitle, setYoutubeTitle] = useState("");
   const [youtubeDescription, setYoutubeDescription] = useState("");
   const [youtubePrivacy, setYoutubePrivacy] = useState<"public" | "private" | "unlisted">("private");
+  const [youtubeHashtags, setYoutubeHashtags] = useState("#shorts #hacelocorto");
+  const [isGeneratingMetadata, setIsGeneratingMetadata] = useState(false);
+  const [metadataProvider, setMetadataProvider] = useState<string | null>(null);
   const canPublishClip = clip ? ["done", "completed"].includes(clip.status.toLowerCase()) : false;
 
   useEffect(() => {
@@ -124,7 +127,29 @@ export default function ShareClipPage() {
 
     setYoutubeTitle(`Clip ${clip.job_id.slice(0, 8)} - Hacelo Corto`);
     setYoutubeDescription(`Clip generado desde ${clip.source_filename}`);
+    setYoutubeHashtags("#shorts #hacelocorto");
+    setMetadataProvider(null);
   }, [clip]);
+
+  function buildPublishDescription(baseDescription: string, hashtagsText: string) {
+    const normalizedDescription = baseDescription.trim();
+    const hashtags = hashtagsText
+      .split(/\s+/)
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0)
+      .map((tag) => (tag.startsWith("#") ? tag : `#${tag}`));
+
+    if (hashtags.length === 0) {
+      return normalizedDescription || undefined;
+    }
+
+    const hashtagsLine = hashtags.join(" ");
+    if (!normalizedDescription) {
+      return hashtagsLine;
+    }
+
+    return `${normalizedDescription}\n\n${hashtagsLine}`;
+  }
 
   const handleConnectYoutube = async () => {
     setInfo(null);
@@ -150,7 +175,7 @@ export default function ShareClipPage() {
     try {
       const response = await videoApi.publishToYoutube(clip.job_id, token, {
         title: youtubeTitle.trim() || undefined,
-        description: youtubeDescription.trim() || undefined,
+        description: buildPublishDescription(youtubeDescription, youtubeHashtags),
         privacy: youtubePrivacy
       });
 
@@ -159,6 +184,33 @@ export default function ShareClipPage() {
       setError(normalizeVideoError(publishError, "No pudimos publicar el clip en YouTube."));
     } finally {
       setIsPublishingYoutube(false);
+    }
+  };
+
+  const handleSuggestMetadata = async () => {
+    if (!token || !clip) {
+      setError("No hay sesion activa o clip seleccionado para sugerir metadata.");
+      return;
+    }
+
+    setIsGeneratingMetadata(true);
+    setError(null);
+
+    try {
+      const suggestion: YoutubeMetadataSuggestionResponse = await videoApi.suggestYoutubeMetadata(clip.job_id, token);
+      setYoutubeTitle(suggestion.title.slice(0, 100));
+      setYoutubeDescription(suggestion.description.slice(0, 5000));
+      setYoutubeHashtags(suggestion.hashtags.join(" "));
+      setMetadataProvider(suggestion.provider);
+      setInfo(
+        suggestion.generated_with_ai
+          ? "Metadata sugerida con IA. Puedes editarla antes de publicar."
+          : "Aplicamos una sugerencia base de metadata. Puedes editarla antes de publicar."
+      );
+    } catch (suggestError) {
+      setError(normalizeVideoError(suggestError, "No pudimos generar metadata sugerida."));
+    } finally {
+      setIsGeneratingMetadata(false);
     }
   };
 
@@ -266,6 +318,20 @@ export default function ShareClipPage() {
 
                     {isYoutube ? (
                       <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                        <div className="sm:col-span-2 flex items-center justify-between gap-2">
+                          <p className="text-[11px] text-white/60">
+                            Mejora titulo y descripcion con sugerencias automaticas.
+                            {metadataProvider ? ` Provider: ${metadataProvider}` : ""}
+                          </p>
+                          <Button
+                            className="h-8 px-3 py-1.5 text-[11px]"
+                            variant="neutral"
+                            disabled={isGeneratingMetadata || !canPublishClip}
+                            onClick={() => void handleSuggestMetadata()}
+                          >
+                            {isGeneratingMetadata ? "Generando..." : "Sugerir con IA"}
+                          </Button>
+                        </div>
                         <label className="text-xs text-white/75 sm:col-span-2">
                           Titulo
                           <input
@@ -283,6 +349,16 @@ export default function ShareClipPage() {
                             maxLength={5000}
                             rows={3}
                             className="mt-1 w-full resize-y rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-cyan/50"
+                          />
+                        </label>
+                        <label className="text-xs text-white/75 sm:col-span-2">
+                          Hashtags
+                          <input
+                            value={youtubeHashtags}
+                            onChange={(event) => setYoutubeHashtags(event.target.value.slice(0, 300))}
+                            maxLength={300}
+                            placeholder="#shorts #hacelocorto"
+                            className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-cyan/50"
                           />
                         </label>
                         <label className="text-xs text-white/75 sm:col-span-2">

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -468,8 +468,13 @@ export const videoApi = {
     return parseResponse<YoutubePublishResponse>(response);
   },
 
-  async suggestYoutubeMetadata(jobId: string, token: string) {
-    const response = await fetch(`${apiBaseUrl}/api/v1/youtube/metadata/${jobId}`, {
+  async suggestYoutubeMetadata(
+    jobId: string,
+    token: string,
+    tone: "neutral" | "energetic" | "informative" = "neutral"
+  ) {
+    const params = new URLSearchParams({ tone });
+    const response = await fetch(`${apiBaseUrl}/api/v1/youtube/metadata/${jobId}?${params.toString()}`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -55,6 +55,15 @@ export type YoutubeConnectionStatus = {
   is_expired: boolean | null;
 };
 
+export type YoutubeMetadataSuggestionResponse = {
+  title: string;
+  description: string;
+  hashtags: string[];
+  tags: string[];
+  provider: string;
+  generated_with_ai: boolean;
+};
+
 export type AudioUploadResponse = {
   audio_id: string;
   bucket: string;
@@ -457,6 +466,17 @@ export const videoApi = {
     });
 
     return parseResponse<YoutubePublishResponse>(response);
+  },
+
+  async suggestYoutubeMetadata(jobId: string, token: string) {
+    const response = await fetch(`${apiBaseUrl}/api/v1/youtube/metadata/${jobId}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<YoutubeMetadataSuggestionResponse>(response);
   },
 
   async createAutoReframeJobs(


### PR DESCRIPTION
# Frontend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feat/frontend-youtube-ai-metadata`

## Objetivo de la rama

Mejorar la pantalla de Share para sugerir metadata de YouTube con IA (titulo, descripcion y hashtags), dejando control editable desde frontend y selector de tono para el copy.

Rama de trabajo: `feat/frontend-youtube-ai-metadata`.

## Cambios realizados

- Se agrego en `frontend/src/services/videoApi.ts` el contrato `suggestYoutubeMetadata(jobId, token, tone)` para consumir `GET /api/v1/youtube/metadata/{job_id}` con tono opcional.
- Se actualizo `frontend/src/app/app/share/[clipId]/page.tsx` con boton `Sugerir con IA`, estado de carga y autocompletado de titulo/descripcion/hashtags.
- Se incorporo campo editable de hashtags y composicion automatica en descripcion final al publicar (sin perder edicion manual).
- Se agrego selector de tono (`neutral`, `energetic`, `informative`) para personalizar estilo del copy sugerido.
- Se agrego visualizacion de proveedor de metadata para trazabilidad en UI (`template` o `openrouter:<model>`).

## Commits realizados

- `feat(frontend): add ai metadata suggestions in share flow`
- `feat(frontend): add tone selector for ai metadata suggestions`
- `docs(frontend): log youtube ai metadata flow in share`

## Archivos clave

- `frontend/src/app/app/share/[clipId]/page.tsx`
- `frontend/src/services/videoApi.ts`
- `docs/frontend-pr-log.md`

## Validaciones locales

Ejecutado en `frontend/`:

- `npm run lint` -> OK

## Checklist antes de PR a develop

- [x] Rama nueva creada desde `develop`
- [x] Cambios limitados al alcance frontend/documentacion de esta iteracion
- [x] `npm run lint` OK
- [x] Documentacion actualizada