### PR TITLE
Feature/audio mix library youtube share ai

### DIFF
--- a/backend/api/app/schemas/job.py
+++ b/backend/api/app/schemas/job.py
@@ -14,14 +14,8 @@ class JobStatusResponse(BaseSchema):
 
 # ============ REFRAME ============
 class JobReframeRequest(BaseSchema):
-    start_sec: int = Field(
-        ge=0,
-        description="Inicio de recorte en Segundo"
-    )
-    end_sec: int = Field(
-        gt=0,
-        description="Final del recorte en Segundos"
-    )
+    start_sec: int = Field(ge=0, description="Inicio de recorte en Segundo")
+    end_sec: int = Field(gt=0, description="Final del recorte en Segundos")
     job_type: JobType = Field(
         default=JobType.REFRAME,
     )
@@ -93,9 +87,7 @@ class JobAutoReframeRequest(BaseSchema):
         max_length=12,
         description="Opcional: aplicar marca de agua (texto)",
     )
-    subtitles: bool | None = Field(
-        description="Opcional: crear archivo de Subtitulos"
-    )
+    subtitles: bool | None = Field(description="Opcional: crear archivo de Subtitulos")
 
 
 class JobAutoReframeItem(BaseSchema):
@@ -129,6 +121,7 @@ class JobAutoReframeResponse2(BaseSchema):
 class UserClipItem(BaseSchema):
     job_id: UUID
     video_id: UUID
+    job_type: JobType
     status: JobStatus
     output_path: dict[str, Any] | None = None
     source_filename: str
@@ -145,39 +138,36 @@ class UserClipsResponse(BaseSchema):
 class UserClipDetailResponse(BaseSchema):
     clip: UserClipItem
 
+
 class AutoClipSegment(BaseSchema):
     start_sec: int
     end_sec: int
 
 
-# ============ ADD AUDIO ============ 
+# ============ ADD AUDIO ============
 class JobAddAudioRequest(BaseSchema):
     audio_id: UUID
     audio_offset_sec: int = Field(
-        ge=0,
-        description="Segundos del video donde empieza el audio"
+        ge=0, description="Segundos del video donde empieza el audio"
     )
 
     audio_start_sec: int = Field(
-        ge=0,
-        description="Inicio del segmento de audio a usar"
+        ge=0, description="Inicio del segmento de audio a usar"
     )
 
-    audio_end_sec: int = Field(
-        gt=0,
-        description="Fin del segmento de audio a usar"
-    )
+    audio_end_sec: int = Field(gt=0, description="Fin del segmento de audio a usar")
 
     audio_volume: float = Field(
         default=1.0,
         ge=0.1,
         le=2.0,
-        description="Multiplicador de volumen (1.0 = volumen original)"
+        description="Multiplicador de volumen (1.0 = volumen original)",
     )
-    #mix_original_audio:
-    #fade_in_sec:
-    #fade_out_sec:
-    #allow_loop:
+    # mix_original_audio:
+    # fade_in_sec:
+    # fade_out_sec:
+    # allow_loop:
+
 
 class JobAddAudioResponse(BaseSchema):
     job_id: UUID

--- a/backend/api/app/services/job_service.py
+++ b/backend/api/app/services/job_service.py
@@ -436,7 +436,7 @@ class JobService:
             .join(Video, Video.id == Job.video_id)
             .filter(
                 Job.user_id == user_id,
-                Job.job_type == JobType.REFRAME,
+                Job.job_type.in_([JobType.REFRAME, JobType.ADD_AUDIO]),
                 Job.output_path.isnot(None),
             )
         )
@@ -458,6 +458,7 @@ class JobService:
             UserClipItem(
                 job_id=job.id,
                 video_id=job.video_id,
+                job_type=job.job_type,
                 status=job.status,
                 output_path=self._resolve_output_urls(job.output_path),
                 source_filename=video.original_filename,
@@ -475,7 +476,7 @@ class JobService:
             .filter(
                 Job.id == job_id,
                 Job.user_id == user_id,
-                Job.job_type == JobType.REFRAME,
+                Job.job_type.in_([JobType.REFRAME, JobType.ADD_AUDIO]),
             )
             .first()
         )
@@ -487,6 +488,7 @@ class JobService:
         clip = UserClipItem(
             job_id=job.id,
             video_id=job.video_id,
+            job_type=job.job_type,
             status=job.status,
             output_path=self._resolve_output_urls(job.output_path),
             source_filename=video.original_filename,
@@ -500,7 +502,7 @@ class JobService:
             .filter(
                 Job.id == job_id,
                 Job.user_id == user_id,
-                Job.job_type == JobType.REFRAME,
+                Job.job_type.in_([JobType.REFRAME, JobType.ADD_AUDIO]),
             )
             .first()
         )

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -2,6 +2,28 @@
 
 ## Seguimiento activo (rama actual)
 
+Rama de trabajo actual: `feature/mi-tarea`
+
+### Objetivo
+
+Hacer que los resultados de mezcla de audio (`ADD_AUDIO`) aparezcan en Biblioteca como clips del usuario, igual que los `REFRAME`.
+
+### Cambios implementados en curso
+
+- Se actualizo `backend/api/app/services/job_service.py` para que `GET /api/v1/jobs/my-clips` incluya jobs `REFRAME` y `ADD_AUDIO` cuando tienen `output_path`.
+- Se ajusto `GET /api/v1/jobs/{job_id}` y `DELETE /api/v1/jobs/{job_id}` para aceptar ambos tipos (`REFRAME` y `ADD_AUDIO`) manteniendo ownership checks.
+- Se agrego `job_type` en `UserClipItem` (`backend/api/app/schemas/job.py`) para que frontend pueda diferenciar visualmente el origen del clip.
+
+### Commits de esta rama (backend)
+
+- `feat(backend): include add-audio jobs in user clips endpoints`
+
+### Validaciones locales
+
+- `docker exec fastapi python -m compileall app` -> OK
+
+## Seguimiento activo (rama actual)
+
 Rama de trabajo actual: `feat/backend-youtube-ai-metadata`
 
 ### Objetivo

--- a/docs/backend-pr-log.md
+++ b/docs/backend-pr-log.md
@@ -8,11 +8,20 @@ Rama de trabajo actual: `feature/mi-tarea`
 
 Hacer que los resultados de mezcla de audio (`ADD_AUDIO`) aparezcan en Biblioteca como clips del usuario, igual que los `REFRAME`.
 
+### Contexto y por que se hizo
+
+- Antes de este ajuste, el endpoint `GET /api/v1/jobs/my-clips` filtraba solo `JobType.REFRAME`.
+- El flujo de Audio Editor genera jobs `JobType.ADD_AUDIO`, por lo que esos resultados quedaban fuera de la consulta de biblioteca aunque el archivo final existiera en MinIO y el `output_path` estuviera guardado.
+- Efecto visible en frontend: el usuario ve que la mezcla termina y existe en storage, pero no aparece en `Biblioteca > Clips`.
+- Tambien habia inconsistencia funcional: aunque un job `ADD_AUDIO` se mostrara por otras vias, `GET /api/v1/jobs/{job_id}` y `DELETE /api/v1/jobs/{job_id}` estaban restringidos a `REFRAME`, dejando acciones incompletas para ese tipo.
+- Agregar `job_type` al schema de salida permite a frontend etiquetar correctamente el origen del clip y evita tratar un mix de audio como si fuera un reframe comun.
+
 ### Cambios implementados en curso
 
 - Se actualizo `backend/api/app/services/job_service.py` para que `GET /api/v1/jobs/my-clips` incluya jobs `REFRAME` y `ADD_AUDIO` cuando tienen `output_path`.
 - Se ajusto `GET /api/v1/jobs/{job_id}` y `DELETE /api/v1/jobs/{job_id}` para aceptar ambos tipos (`REFRAME` y `ADD_AUDIO`) manteniendo ownership checks.
 - Se agrego `job_type` en `UserClipItem` (`backend/api/app/schemas/job.py`) para que frontend pueda diferenciar visualmente el origen del clip.
+- En la iteracion de `Share > YouTube + IA` no se requirieron cambios adicionales de API: frontend consume el endpoint ya disponible `GET /api/v1/youtube/metadata/{job_id}` y solo se reforzo documentacion para explicar el motivo de los ajustes previos.
 
 ### Commits de esta rama (backend)
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -2,6 +2,33 @@
 
 ## Seguimiento activo (rama actual)
 
+Rama de trabajo actual: `feature/mi-tarea`
+
+### Objetivo
+
+Mejorar visibilidad del progreso en Home y estabilizar Audio Editor/Biblioteca para que el flujo de mezcla no pierda contexto y muestre los resultados generados.
+
+### Cambios implementados en curso
+
+- Se mejoro `frontend/src/components/home/ProjectStatusPanel.tsx` para mostrar cantidad de clips en proceso junto al porcentaje (`pendientes/total`).
+- Se extendio `frontend/src/services/videoApi.ts` con `job_type` en `UserClipItem` para distinguir `REFRAME` vs `ADD_AUDIO`.
+- Se ajusto `frontend/src/app/app/library/page.tsx` para etiquetar los clips por tipo (`Auto Reframe` / `Audio Mix`).
+- Se reforzo `frontend/src/app/app/page.tsx` para que Home use solo clips `REFRAME` al calcular progreso/listado y no mezclar jobs de audio.
+- Se implemento persistencia de sesion en `frontend/src/app/app/audio_editor/page.tsx` usando `localStorage` por `videoId` (audio elegido, offsets, volumen, job, mensajes y preview).
+- Se agrego barra de progreso de mezcla en Audio Editor (estados `En cola`, `Procesando`, `Mezcla lista`, `Mezcla con error`) y label explicita cuando el preview corresponde al resultado mezclado.
+
+### Commits de esta rama (frontend)
+
+- `feat(frontend): persist audio editor session and expose mix progress`
+- `fix(frontend): surface audio-mix clips in library while keeping home scoped to reframe`
+
+### Validaciones locales
+
+- `npm run lint` -> OK
+- `npm run build` -> OK
+
+## Seguimiento activo (rama actual)
+
 Rama de trabajo actual: `feat/frontend-timeline-library-streamline`
 
 ## Objetivo de la rama

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -16,11 +16,16 @@ Mejorar visibilidad del progreso en Home y estabilizar Audio Editor/Biblioteca p
 - Se reforzo `frontend/src/app/app/page.tsx` para que Home use solo clips `REFRAME` al calcular progreso/listado y no mezclar jobs de audio.
 - Se implemento persistencia de sesion en `frontend/src/app/app/audio_editor/page.tsx` usando `localStorage` por `videoId` (audio elegido, offsets, volumen, job, mensajes y preview).
 - Se agrego barra de progreso de mezcla en Audio Editor (estados `En cola`, `Procesando`, `Mezcla lista`, `Mezcla con error`) y label explicita cuando el preview corresponde al resultado mezclado.
+- Se integro en `frontend/src/app/app/share/[clipId]/page.tsx` la generacion de metadata de YouTube con IA (`GET /api/v1/youtube/metadata/{job_id}`), incluyendo selector de tono (`neutral`, `energetic`, `informative`) y aplicacion directa de titulo/descripcion sugeridos.
+- Se extendio el formulario de publicacion con visualizacion de `hashtags`, `tags` y `provider` devueltos por backend para dejar trazabilidad del origen (IA/template).
+- Se mejoro la UX de publicacion en `frontend/src/app/app/share/[clipId]/page.tsx` con estado explicito de resultado (`Publicado` / `Fallo la publicacion`) y acceso directo al link de YouTube cuando la subida fue exitosa.
+- Se rediseño la presentacion de metadata sugerida para mostrar `hashtags` y `tags` como chips visuales, mejorando lectura y edicion previa a publicar.
 
 ### Commits de esta rama (frontend)
 
 - `feat(frontend): persist audio editor session and expose mix progress`
 - `fix(frontend): surface audio-mix clips in library while keeping home scoped to reframe`
+- `feat(frontend): add ai metadata suggestions to youtube share flow`
 
 ### Validaciones locales
 

--- a/frontend/src/app/app/audio_editor/page.tsx
+++ b/frontend/src/app/app/audio_editor/page.tsx
@@ -11,6 +11,7 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 const MIN_AUDIO_SEGMENT_SECONDS = 5;
+const AUDIO_EDITOR_DRAFT_KEY = "audio-editor:draft";
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
   if (error instanceof VideoApiError) {
@@ -51,6 +52,24 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
+function getAudioJobProgress(status: string | null) {
+  if (!status) {
+    return null;
+  }
+
+  const normalized = status.toLowerCase();
+  if (normalized === "done" || normalized === "completed") {
+    return { label: "Mezcla lista", percent: 100, isError: false };
+  }
+  if (normalized === "failed" || normalized === "error") {
+    return { label: "Mezcla con error", percent: 100, isError: true };
+  }
+  if (normalized === "running" || normalized === "processing" || normalized === "in_progress") {
+    return { label: "Procesando mezcla", percent: 68, isError: false };
+  }
+  return { label: "En cola", percent: 24, isError: false };
+}
+
 export default function AudioEditorPage() {
   const searchParams = useSearchParams();
   const preferredVideoId = searchParams.get("videoId")?.trim() ?? "";
@@ -80,8 +99,10 @@ export default function AudioEditorPage() {
   const [audioSubmitInfo, setAudioSubmitInfo] = useState<string | null>(null);
   const [audioSubmitError, setAudioSubmitError] = useState<string | null>(null);
   const [audioJobId, setAudioJobId] = useState<string | null>(null);
+  const [audioJobStatus, setAudioJobStatus] = useState<string | null>(null);
   const [isPollingAudioJob, setIsPollingAudioJob] = useState(false);
   const [mixedVideoUrl, setMixedVideoUrl] = useState<string | null>(null);
+  const [hasRestoredEditorDraft, setHasRestoredEditorDraft] = useState(false);
 
   useEffect(() => {
     if (!token) {
@@ -229,6 +250,103 @@ export default function AudioEditorPage() {
   }, [selectedAudioId, token]);
 
   useEffect(() => {
+    if (!selectedVideoId) {
+      setHasRestoredEditorDraft(false);
+      return;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(`${AUDIO_EDITOR_DRAFT_KEY}:${selectedVideoId}`);
+      if (!raw) {
+        setHasRestoredEditorDraft(true);
+        return;
+      }
+
+      const parsed = JSON.parse(raw) as {
+        selectedAudioId?: string | null;
+        audioOffsetSec?: number;
+        audioStartSec?: number;
+        audioEndSec?: number;
+        audioVolume?: number;
+        audioJobId?: string | null;
+        audioJobStatus?: string | null;
+        mixedVideoUrl?: string | null;
+        audioSubmitInfo?: string | null;
+        audioSubmitError?: string | null;
+      };
+
+      if (typeof parsed.selectedAudioId === "string") {
+        setSelectedAudioId(parsed.selectedAudioId);
+      }
+      if (typeof parsed.audioOffsetSec === "number") {
+        setAudioOffsetSec(parsed.audioOffsetSec);
+      }
+      if (typeof parsed.audioStartSec === "number") {
+        setAudioStartSec(parsed.audioStartSec);
+      }
+      if (typeof parsed.audioEndSec === "number") {
+        setAudioEndSec(parsed.audioEndSec);
+      }
+      if (typeof parsed.audioVolume === "number") {
+        setAudioVolume(parsed.audioVolume);
+      }
+      if (typeof parsed.audioJobId === "string") {
+        setAudioJobId(parsed.audioJobId);
+      }
+      if (typeof parsed.audioJobStatus === "string") {
+        setAudioJobStatus(parsed.audioJobStatus);
+      }
+      if (typeof parsed.mixedVideoUrl === "string") {
+        setMixedVideoUrl(parsed.mixedVideoUrl);
+      }
+      if (typeof parsed.audioSubmitInfo === "string") {
+        setAudioSubmitInfo(parsed.audioSubmitInfo);
+      }
+      if (typeof parsed.audioSubmitError === "string") {
+        setAudioSubmitError(parsed.audioSubmitError);
+      }
+    } catch {
+      window.localStorage.removeItem(`${AUDIO_EDITOR_DRAFT_KEY}:${selectedVideoId}`);
+    } finally {
+      setHasRestoredEditorDraft(true);
+    }
+  }, [selectedVideoId]);
+
+  useEffect(() => {
+    if (!selectedVideoId || !hasRestoredEditorDraft) {
+      return;
+    }
+
+    const payload = {
+      selectedAudioId,
+      audioOffsetSec,
+      audioStartSec,
+      audioEndSec,
+      audioVolume,
+      audioJobId,
+      audioJobStatus,
+      mixedVideoUrl,
+      audioSubmitInfo,
+      audioSubmitError
+    };
+
+    window.localStorage.setItem(`${AUDIO_EDITOR_DRAFT_KEY}:${selectedVideoId}`, JSON.stringify(payload));
+  }, [
+    selectedVideoId,
+    hasRestoredEditorDraft,
+    selectedAudioId,
+    audioOffsetSec,
+    audioStartSec,
+    audioEndSec,
+    audioVolume,
+    audioJobId,
+    audioJobStatus,
+    mixedVideoUrl,
+    audioSubmitInfo,
+    audioSubmitError
+  ]);
+
+  useEffect(() => {
     if (!token || !audioJobId) {
       setIsPollingAudioJob(false);
       return;
@@ -246,6 +364,8 @@ export default function AudioEditorPage() {
         if (status.output_path) {
           setMixedVideoUrl(status.output_path);
         }
+
+        setAudioJobStatus(status.status);
 
         if (isDoneStatus(status.status)) {
           setAudioSubmitInfo(`Mezcla de audio lista. Job ${audioJobId.slice(0, 8)} finalizado.`);
@@ -353,6 +473,7 @@ export default function AudioEditorPage() {
   }, [audioDurationSec, audioEndSec, audioOffsetSec, audioStartSec, maxAudioStartSec, maxOffsetSec, videoDurationSec]);
 
   const selectedSegmentDurationSec = Math.max(audioEndSec - audioStartSec, 0);
+  const audioJobProgress = getAudioJobProgress(audioJobStatus);
   const canSubmitAudioJob =
     Boolean(selectedVideoId) &&
     Boolean(selectedAudioId) &&
@@ -382,6 +503,7 @@ export default function AudioEditorPage() {
     setAudioSubmitError(null);
     setAudioSubmitInfo(null);
     setMixedVideoUrl(null);
+    setAudioJobStatus(null);
 
     try {
       const response = await videoApi.addAudioToVideo(selectedVideoId, token, {
@@ -393,6 +515,7 @@ export default function AudioEditorPage() {
       });
 
       setAudioJobId(response.job_id);
+      setAudioJobStatus(response.status);
       setAudioSubmitInfo(`Mezcla enviada a cola. Job ${response.job_id.slice(0, 8)} en estado ${response.status}.`);
     } catch (mixError) {
       setAudioSubmitError(normalizeVideoError(mixError, "No pudimos enviar el job para mezclar audio."));
@@ -417,7 +540,14 @@ export default function AudioEditorPage() {
           ) : videoError ? (
             <p className="mt-4 rounded-xl border border-rose-400/35 bg-rose-400/10 px-3 py-2 text-sm text-rose-200">{videoError}</p>
           ) : previewUrl ? (
-            <VideoPreview videoPreviewUrl={previewUrl} onTrimChange={() => {}} />
+            <>
+              {mixedVideoUrl ? (
+                <p className="mt-3 inline-flex rounded-full border border-neon-mint/35 bg-neon-mint/10 px-2 py-1 text-[11px] uppercase tracking-[0.14em] text-neon-mint">
+                  Preview del resultado mezclado
+                </p>
+              ) : null}
+              <VideoPreview videoPreviewUrl={previewUrl} onTrimChange={() => {}} />
+            </>
           ) : (
             <p className="mt-4 text-sm text-white/70">Selecciona un video con preview disponible.</p>
           )}
@@ -583,6 +713,21 @@ export default function AudioEditorPage() {
               {audioSubmitInfo ? <p className="mt-2 text-xs text-neon-mint">{audioSubmitInfo}</p> : null}
               {audioSubmitError ? <p className="mt-2 text-xs text-rose-200">{audioSubmitError}</p> : null}
               {isPollingAudioJob ? <p className="mt-2 text-xs text-white/65">Procesando mezcla de audio...</p> : null}
+
+              {audioJobProgress ? (
+                <div className="mt-3 rounded-xl border border-white/12 bg-white/5 p-3">
+                  <div className="flex items-center justify-between text-xs">
+                    <span className={audioJobProgress.isError ? "text-rose-200" : "text-white/80"}>{audioJobProgress.label}</span>
+                    <span className={audioJobProgress.isError ? "text-rose-200" : "text-white"}>{audioJobProgress.percent}%</span>
+                  </div>
+                  <div className="mt-2 h-2 overflow-hidden rounded-full bg-night-950/90">
+                    <div
+                      className={`h-full rounded-full transition-all duration-500 ${audioJobProgress.isError ? "bg-gradient-to-r from-rose-500 to-rose-300" : "bg-gradient-to-r from-neon-violet to-neon-mint"}`}
+                      style={{ width: `${audioJobProgress.percent}%` }}
+                    />
+                  </div>
+                </div>
+              ) : null}
             </>
           ) : null}
 

--- a/frontend/src/app/app/library/page.tsx
+++ b/frontend/src/app/app/library/page.tsx
@@ -30,6 +30,14 @@ function mapStatus(status: string): VisualStatus {
   return "render";
 }
 
+function toClipTypeLabel(jobType: string) {
+  const normalized = jobType.toLowerCase();
+  if (normalized === "add_audio") {
+    return "Audio Mix";
+  }
+  return "Auto Reframe";
+}
+
 export default function LibraryPage() {
   const token = useAuthStore((state) => state.token);
   const [view, setView] = useState<LibraryView>("clips");
@@ -428,7 +436,7 @@ export default function LibraryPage() {
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
               <span className="inline-flex items-center gap-1 rounded-full border border-neon-violet/35 bg-neon-violet/10 px-2 py-1 text-neon-violet">
                 <Tag size={11} />
-                Auto Reframe
+                {toClipTypeLabel(clip.job_type)}
               </span>
               <span className="rounded-full border border-white/15 bg-white/5 px-2 py-1 text-white/70">{clip.source_filename}</span>
             </div>

--- a/frontend/src/app/app/page.tsx
+++ b/frontend/src/app/app/page.tsx
@@ -112,6 +112,11 @@ function isFailedStatus(status: string) {
   return normalized === "failed" || normalized === "error";
 }
 
+function isReframeClip(clip: UserClipItem) {
+  const normalized = clip.job_type.toLowerCase();
+  return normalized === "reframe";
+}
+
 function isAudioFile(file: File) {
   if (file.type.toLowerCase().startsWith("audio/")) {
     return true;
@@ -170,10 +175,11 @@ export default function AppHomePage() {
   const hasVideo = Boolean(uploadedVideo);
   const hasAudio = Boolean(uploadedAudio);
   const visibleClips = useMemo(() => {
+    const reframeFallbackClips = fallbackClips.filter(isReframeClip);
     if (createdJobs.length > 0) {
-      return mapJobsToClips(createdJobs, jobStatusMap, fallbackClips);
+      return mapJobsToClips(createdJobs, jobStatusMap, reframeFallbackClips);
     }
-    return mapUserClipsToCards(fallbackClips);
+    return mapUserClipsToCards(reframeFallbackClips);
   }, [createdJobs, jobStatusMap, fallbackClips]);
 
   const clipProgress = useMemo(() => {
@@ -502,7 +508,7 @@ export default function AppHomePage() {
           return;
         }
 
-        const related = data.clips.filter((clip) => clip.video_id === uploadedVideo.video_id);
+        const related = data.clips.filter((clip) => clip.video_id === uploadedVideo.video_id && isReframeClip(clip));
         setFallbackClips(related);
         setAutoJobCount((prev) => (prev > 0 ? prev : related.length));
 

--- a/frontend/src/app/app/share/[clipId]/page.tsx
+++ b/frontend/src/app/app/share/[clipId]/page.tsx
@@ -3,9 +3,15 @@
 import { Button } from "@/src/components/ui/Button";
 import { Panel } from "@/src/components/ui/Panel";
 import { authApi } from "@/src/services/authApi";
-import { videoApi, type UserClipItem, type YoutubeConnectionStatus, VideoApiError } from "@/src/services/videoApi";
+import {
+  videoApi,
+  type UserClipItem,
+  type YoutubeConnectionStatus,
+  type YoutubeMetadataSuggestionTone,
+  VideoApiError
+} from "@/src/services/videoApi";
 import { useAuthStore } from "@/src/store/useAuthStore";
-import { Facebook, Instagram, MessageCircle, Music2, Share2, Youtube } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Facebook, Instagram, MessageCircle, Music2, Share2, Sparkles, Youtube } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { type ComponentType, useEffect, useState } from "react";
@@ -23,6 +29,12 @@ const socialTargets: SocialTarget[] = [
   { id: "youtube", label: "YouTube", icon: Youtube },
   { id: "x", label: "X", icon: Share2 },
   { id: "whatsapp", label: "WhatsApp", icon: MessageCircle }
+];
+
+const metadataToneOptions: Array<{ value: YoutubeMetadataSuggestionTone; label: string }> = [
+  { value: "neutral", label: "Neutral" },
+  { value: "energetic", label: "Energetico" },
+  { value: "informative", label: "Informativo" }
 ];
 
 function normalizeVideoError(error: unknown, fallbackMessage: string) {
@@ -54,6 +66,14 @@ export default function ShareClipPage() {
   const [youtubeTitle, setYoutubeTitle] = useState("");
   const [youtubeDescription, setYoutubeDescription] = useState("");
   const [youtubePrivacy, setYoutubePrivacy] = useState<"public" | "private" | "unlisted">("private");
+  const [metadataTone, setMetadataTone] = useState<YoutubeMetadataSuggestionTone>("neutral");
+  const [isSuggestingMetadata, setIsSuggestingMetadata] = useState(false);
+  const [youtubeHashtags, setYoutubeHashtags] = useState<string[]>([]);
+  const [youtubeTags, setYoutubeTags] = useState<string[]>([]);
+  const [youtubeMetadataProvider, setYoutubeMetadataProvider] = useState<string | null>(null);
+  const [youtubePublishStatus, setYoutubePublishStatus] = useState<"idle" | "success" | "error">("idle");
+  const [youtubePublishMessage, setYoutubePublishMessage] = useState<string | null>(null);
+  const [youtubePublishedUrl, setYoutubePublishedUrl] = useState<string | null>(null);
   const canPublishClip = clip ? ["done", "completed"].includes(clip.status.toLowerCase()) : false;
 
   useEffect(() => {
@@ -124,6 +144,12 @@ export default function ShareClipPage() {
 
     setYoutubeTitle(`Clip ${clip.job_id.slice(0, 8)} - Hacelo Corto`);
     setYoutubeDescription(`Clip generado desde ${clip.source_filename}`);
+    setYoutubeHashtags([]);
+    setYoutubeTags([]);
+    setYoutubeMetadataProvider(null);
+    setYoutubePublishStatus("idle");
+    setYoutubePublishMessage(null);
+    setYoutubePublishedUrl(null);
   }, [clip]);
 
   const handleConnectYoutube = async () => {
@@ -146,6 +172,9 @@ export default function ShareClipPage() {
     setIsPublishingYoutube(true);
     setError(null);
     setInfo(null);
+    setYoutubePublishStatus("idle");
+    setYoutubePublishMessage(null);
+    setYoutubePublishedUrl(null);
 
     try {
       const response = await videoApi.publishToYoutube(clip.job_id, token, {
@@ -155,10 +184,39 @@ export default function ShareClipPage() {
       });
 
       setInfo(`Publicado en YouTube: ${response.youtube_url}`);
+      setYoutubePublishStatus("success");
+      setYoutubePublishedUrl(response.youtube_url);
+      setYoutubePublishMessage("Publicacion completada correctamente.");
     } catch (publishError) {
-      setError(normalizeVideoError(publishError, "No pudimos publicar el clip en YouTube."));
+      setYoutubePublishStatus("error");
+      setYoutubePublishMessage(normalizeVideoError(publishError, "No pudimos publicar el clip en YouTube."));
     } finally {
       setIsPublishingYoutube(false);
+    }
+  };
+
+  const handleSuggestYoutubeMetadata = async () => {
+    if (!token || !clip) {
+      setError("No hay sesion activa o clip seleccionado para generar metadata.");
+      return;
+    }
+
+    setIsSuggestingMetadata(true);
+    setError(null);
+    setInfo(null);
+
+    try {
+      const suggestion = await videoApi.suggestYoutubeMetadata(clip.job_id, token, metadataTone);
+      setYoutubeTitle(suggestion.title);
+      setYoutubeDescription(suggestion.description);
+      setYoutubeHashtags(suggestion.hashtags);
+      setYoutubeTags(suggestion.tags);
+      setYoutubeMetadataProvider(suggestion.provider);
+      setInfo(`Metadata sugerida aplicada (${suggestion.generated_with_ai ? "IA" : "template"}).`);
+    } catch (suggestError) {
+      setError(normalizeVideoError(suggestError, "No pudimos generar metadata sugerida para YouTube."));
+    } finally {
+      setIsSuggestingMetadata(false);
     }
   };
 
@@ -260,12 +318,71 @@ export default function ShareClipPage() {
                       </div>
                     </div>
 
+                    {isYoutube && youtubePublishStatus !== "idle" ? (
+                      <div
+                        className={[
+                          "mt-3 rounded-lg border px-3 py-2 text-xs",
+                          youtubePublishStatus === "success"
+                            ? "border-emerald-300/45 bg-emerald-300/10 text-emerald-100"
+                            : "border-rose-300/45 bg-rose-300/10 text-rose-100"
+                        ].join(" ")}
+                      >
+                        <p className="inline-flex items-center gap-1.5 font-semibold uppercase tracking-[0.12em]">
+                          {youtubePublishStatus === "success" ? <CheckCircle2 size={14} /> : <AlertTriangle size={14} />}
+                          {youtubePublishStatus === "success" ? "Publicado" : "Fallo la publicacion"}
+                        </p>
+                        {youtubePublishMessage ? <p className="mt-1">{youtubePublishMessage}</p> : null}
+                        {youtubePublishStatus === "success" && youtubePublishedUrl ? (
+                          <a
+                            href={youtubePublishedUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="mt-2 inline-flex items-center gap-1 rounded-md border border-emerald-200/35 bg-emerald-200/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-emerald-100 transition hover:bg-emerald-200/20"
+                          >
+                            Ver en YouTube
+                          </a>
+                        ) : null}
+                      </div>
+                    ) : null}
+
                     {isYoutube && !canPublishClip ? (
                       <p className="mt-2 text-xs text-amber-200">Este clip debe estar en estado DONE para poder publicarse en YouTube.</p>
                     ) : null}
 
                     {isYoutube ? (
                       <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                        <div className="sm:col-span-2 rounded-lg border border-neon-cyan/25 bg-gradient-to-r from-neon-cyan/8 to-neon-violet/8 p-3">
+                          <p className="text-[11px] uppercase tracking-[0.16em] text-neon-cyan/85">Asistente IA</p>
+                          <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                            <label className="text-xs text-white/75">
+                              Tono IA
+                              <select
+                                value={metadataTone}
+                                onChange={(event) => setMetadataTone(event.target.value as YoutubeMetadataSuggestionTone)}
+                                className="mt-1 w-full rounded-lg border border-white/20 bg-night-900/80 px-3 py-2 text-xs text-white outline-none focus:border-neon-cyan/50"
+                              >
+                                {metadataToneOptions.map((option) => (
+                                  <option key={option.value} value={option.value}>
+                                    {option.label}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <div className="flex items-end">
+                              <Button
+                                className="h-9 w-full px-3 py-2 text-xs"
+                                variant="cyan"
+                                disabled={!isYoutubeConnected || isSuggestingMetadata || !canPublishClip}
+                                onClick={() => void handleSuggestYoutubeMetadata()}
+                              >
+                                <Sparkles size={14} />
+                                {isSuggestingMetadata ? "Generando..." : "Generar datos con IA"}
+                              </Button>
+                            </div>
+                          </div>
+                          <p className="mt-2 text-[11px] text-white/60">Completa titulo y descripcion sugeridos para acelerar la publicacion.</p>
+                        </div>
+
                         <label className="text-xs text-white/75 sm:col-span-2">
                           Titulo
                           <input
@@ -297,6 +414,44 @@ export default function ShareClipPage() {
                             <option value="public">public</option>
                           </select>
                         </label>
+
+                        {(youtubeHashtags.length > 0 || youtubeTags.length > 0) ? (
+                          <div className="sm:col-span-2 rounded-lg border border-white/12 bg-night-900/60 p-3 text-xs text-white/75">
+                            {youtubeMetadataProvider ? (
+                              <p className="text-[11px] uppercase tracking-[0.15em] text-neon-cyan/80">Provider: {youtubeMetadataProvider}</p>
+                            ) : null}
+                            {youtubeHashtags.length > 0 ? (
+                              <div className="mt-2">
+                                <p className="text-[11px] uppercase tracking-[0.12em] text-white/60">Hashtags sugeridos</p>
+                                <div className="mt-1 flex flex-wrap gap-1.5">
+                                  {youtubeHashtags.map((hashtag) => (
+                                    <span
+                                      key={hashtag}
+                                      className="rounded-full border border-neon-cyan/35 bg-neon-cyan/10 px-2 py-0.5 text-[11px] text-neon-cyan"
+                                    >
+                                      {hashtag}
+                                    </span>
+                                  ))}
+                                </div>
+                              </div>
+                            ) : null}
+                            {youtubeTags.length > 0 ? (
+                              <div className="mt-2">
+                                <p className="text-[11px] uppercase tracking-[0.12em] text-white/60">Tags sugeridos</p>
+                                <div className="mt-1 flex flex-wrap gap-1.5">
+                                  {youtubeTags.map((tag) => (
+                                    <span
+                                      key={tag}
+                                      className="rounded-full border border-neon-violet/35 bg-neon-violet/10 px-2 py-0.5 text-[11px] text-neon-violet"
+                                    >
+                                      {tag}
+                                    </span>
+                                  ))}
+                                </div>
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : null}
                       </div>
                     ) : null}
                   </div>

--- a/frontend/src/components/home/ProjectStatusPanel.tsx
+++ b/frontend/src/components/home/ProjectStatusPanel.tsx
@@ -51,6 +51,8 @@ export function ProjectStatusPanel({
       : hasVideo
         ? 10
         : 0;
+  const generationCountLabel =
+    jobsCreated > 0 ? `${clipsPending}/${jobsCreated} en proceso` : isCreatingJobs ? "Calculando cantidad..." : "";
 
   return (
     <section>
@@ -78,7 +80,10 @@ export function ProjectStatusPanel({
 
         <div className="mt-4 flex items-center justify-between text-sm">
           <span className="text-white/80">Generacion de clips</span>
-          <span className="text-white">{generationProgress}%</span>
+          <div className="text-right">
+            <p className="text-white">{generationProgress}%</p>
+            {generationCountLabel ? <p className="text-[11px] text-white/60">{generationCountLabel}</p> : null}
+          </div>
         </div>
         <div className="mt-2 h-2 overflow-hidden rounded-full bg-night-950/90">
           <div

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -55,6 +55,17 @@ export type YoutubeConnectionStatus = {
   is_expired: boolean | null;
 };
 
+export type YoutubeMetadataSuggestionTone = "neutral" | "energetic" | "informative";
+
+export type YoutubeMetadataSuggestion = {
+  title: string;
+  description: string;
+  hashtags: string[];
+  tags: string[];
+  provider: string;
+  generated_with_ai: boolean;
+};
+
 export type AudioUploadResponse = {
   audio_id: string;
   bucket: string;
@@ -459,6 +470,18 @@ export const videoApi = {
     });
 
     return parseResponse<YoutubePublishResponse>(response);
+  },
+
+  async suggestYoutubeMetadata(jobId: string, token: string, tone: YoutubeMetadataSuggestionTone = "neutral") {
+    const params = new URLSearchParams({ tone });
+    const response = await fetch(`${apiBaseUrl}/api/v1/youtube/metadata/${jobId}?${params.toString()}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return parseResponse<YoutubeMetadataSuggestion>(response);
   },
 
   async createAutoReframeJobs(

--- a/frontend/src/services/videoApi.ts
+++ b/frontend/src/services/videoApi.ts
@@ -160,6 +160,7 @@ type RawJobStatusResponse = {
 export type UserClipItem = {
   job_id: string;
   video_id: string;
+  job_type: string;
   status: string;
   output_path: string | null;
   source_filename: string;
@@ -169,6 +170,7 @@ export type UserClipItem = {
 type RawUserClipItem = {
   job_id: string;
   video_id: string;
+  job_type: string;
   status: string;
   output_path: RawOutputPath;
   source_filename: string;


### PR DESCRIPTION
# Backend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feature/audio-mix-library-youtube-share-ai`

### Objetivo

Hacer que los resultados de mezcla de audio (`ADD_AUDIO`) aparezcan en Biblioteca como clips del usuario, igual que los `REFRAME`.

### Contexto y por que se hizo

- Antes de este ajuste, el endpoint `GET /api/v1/jobs/my-clips` filtraba solo `JobType.REFRAME`.
- El flujo de Audio Editor genera jobs `JobType.ADD_AUDIO`, por lo que esos resultados quedaban fuera de la consulta de biblioteca aunque el archivo final existiera en MinIO y el `output_path` estuviera guardado.
- Efecto visible en frontend: el usuario ve que la mezcla termina y existe en storage, pero no aparece en `Biblioteca > Clips`.
- Tambien habia inconsistencia funcional: aunque un job `ADD_AUDIO` se mostrara por otras vias, `GET /api/v1/jobs/{job_id}` y `DELETE /api/v1/jobs/{job_id}` estaban restringidos a `REFRAME`, dejando acciones incompletas para ese tipo.
- Agregar `job_type` al schema de salida permite a frontend etiquetar correctamente el origen del clip y evita tratar un mix de audio como si fuera un reframe comun.

### Cambios implementados en curso

- Se actualizo `backend/api/app/services/job_service.py` para que `GET /api/v1/jobs/my-clips` incluya jobs `REFRAME` y `ADD_AUDIO` cuando tienen `output_path`.
- Se ajusto `GET /api/v1/jobs/{job_id}` y `DELETE /api/v1/jobs/{job_id}` para aceptar ambos tipos (`REFRAME` y `ADD_AUDIO`) manteniendo ownership checks.
- Se agrego `job_type` en `UserClipItem` (`backend/api/app/schemas/job.py`) para que frontend pueda diferenciar visualmente el origen del clip.
- En la iteracion de `Share > YouTube + IA` no se requirieron cambios adicionales de API: frontend consume el endpoint ya disponible `GET /api/v1/youtube/metadata/{job_id}` y solo se reforzo documentacion para explicar el motivo de los ajustes previos.

### Commits de esta rama (backend)

- `feat(backend): include add-audio jobs in user clips endpoints`

### Validaciones locales

- `docker exec fastapi python -m compileall app` -> OK

***

# Frontend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feature/audio-mix-library-youtube-share-ai`

### Objetivo

Mejorar visibilidad del progreso en Home y estabilizar Audio Editor/Biblioteca para que el flujo de mezcla no pierda contexto y muestre los resultados generados.

### Cambios implementados en curso

- Se mejoro `frontend/src/components/home/ProjectStatusPanel.tsx` para mostrar cantidad de clips en proceso junto al porcentaje (`pendientes/total`).
- Se extendio `frontend/src/services/videoApi.ts` con `job_type` en `UserClipItem` para distinguir `REFRAME` vs `ADD_AUDIO`.
- Se ajusto `frontend/src/app/app/library/page.tsx` para etiquetar los clips por tipo (`Auto Reframe` / `Audio Mix`).
- Se reforzo `frontend/src/app/app/page.tsx` para que Home use solo clips `REFRAME` al calcular progreso/listado y no mezclar jobs de audio.
- Se implemento persistencia de sesion en `frontend/src/app/app/audio_editor/page.tsx` usando `localStorage` por `videoId` (audio elegido, offsets, volumen, job, mensajes y preview).
- Se agrego barra de progreso de mezcla en Audio Editor (estados `En cola`, `Procesando`, `Mezcla lista`, `Mezcla con error`) y label explicita cuando el preview corresponde al resultado mezclado.
- Se integro en `frontend/src/app/app/share/[clipId]/page.tsx` la generacion de metadata de YouTube con IA (`GET /api/v1/youtube/metadata/{job_id}`), incluyendo selector de tono (`neutral`, `energetic`, `informative`) y aplicacion directa de titulo/descripcion sugeridos.
- Se extendio el formulario de publicacion con visualizacion de `hashtags`, `tags` y `provider` devueltos por backend para dejar trazabilidad del origen (IA/template).
- Se mejoro la UX de publicacion en `frontend/src/app/app/share/[clipId]/page.tsx` con estado explicito de resultado (`Publicado` / `Fallo la publicacion`) y acceso directo al link de YouTube cuando la subida fue exitosa.
- Se rediseño la presentacion de metadata sugerida para mostrar `hashtags` y `tags` como chips visuales, mejorando lectura y edicion previa a publicar.

### Commits de esta rama (frontend)

- `feat(frontend): persist audio editor session and expose mix progress`
- `fix(frontend): surface audio-mix clips in library while keeping home scoped to reframe`
- `feat(frontend): add ai metadata suggestions to youtube share flow`

### Validaciones locales

- `npm run lint` -> OK
- `npm run build` -> OK
