### PR TITLE
Feat/frontend light latte seo hardening

### DIFF
--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -2,7 +2,7 @@
 
 ## Seguimiento activo (rama actual)
 
-Rama de trabajo actual: `feat/frontend-landing-prod-refresh`
+Rama de trabajo actual: `feat/frontend-light-latte-seo-hardening`
 
 ### Objetivo
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -25,9 +25,13 @@ Actualizar la landing para reflejar el alcance real actual de la app web, mostra
 - Se ajustaron FAQ y CTA para incluir integracion YouTube + metadata IA, audio editor y biblioteca de audios.
 - Se cambio la variante `light` a paleta Catppuccin Macchiato en `frontend/src/app/globals.css`, ajustando tokens base (`night`, `neon`, texto, bordes, sombras y logo) para evaluar un look mas consistente con el resto del dashboard.
 - Se limpiaron overrides globales agresivos del modo light (`text-white/*`, `bg-night-*`, placeholders y variantes rose) que estaban forzando colores fuera de la paleta y generaban contraste irregular.
+- Se descarto el experimento Macchiato para light y se restauro Catppuccin Latte en `frontend/src/app/globals.css`, manteniendo el modo claro realmente claro.
+- Se reforzaron overrides de contraste para light (`text-white*`, `border-white*`, `bg-white*`, placeholders y `logout-btn`) para evitar texto blanco sobre fondos claros en auth y dashboard.
 - Se reforzo SEO tecnico base en `frontend/src/app/layout.tsx` con `metadataBase`, canonical, Open Graph, Twitter cards y robots global.
 - Se agregaron `frontend/src/app/robots.ts` y `frontend/src/app/sitemap.ts` para exponer reglas de rastreo e indice XML.
 - Se agrego control de indexacion para secciones privadas (`/app` y `/auth`) mediante `head.tsx` dedicados con `noindex,nofollow`.
+- Se agrego metadata especifica de Home en `frontend/src/app/page.tsx` para alinear title/description/OG con el objetivo SEO principal de la landing.
+- Se reemplazo la imagen social generica por endpoints dedicados `frontend/src/app/opengraph-image.tsx` y `frontend/src/app/twitter-image.tsx` (1200x630) para previews consistentes al compartir.
 
 ### Commits de esta rama (frontend)
 
@@ -36,6 +40,9 @@ Actualizar la landing para reflejar el alcance real actual de la app web, mostra
 - `style(frontend): switch light theme to catppuccin macchiato and simplify overrides`
 - `feat(frontend): add metadata, robots and sitemap for seo baseline`
 - `docs(frontend): log macchiato light theme and seo baseline updates`
+- `fix(frontend): restore latte light theme and enforce readable contrast`
+- `feat(frontend): harden home seo metadata and social preview images`
+- `docs(frontend): log latte light pass and seo image hardening updates`
 
 ### Validaciones locales
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -23,11 +23,19 @@ Actualizar la landing para reflejar el alcance real actual de la app web, mostra
 - Se ajusto paleta del `HaceloCortoLogo` para modo light usando variables CSS dedicadas, mejorando contraste del isotipo y gradientes en navbar/landing.
 - QA final light mode: se reforzaron variantes `rose-300/rose-400` (texto/borde/fondo) y placeholders para evitar combinaciones de bajo contraste en auth, alerts y acciones destructivas.
 - Se ajustaron FAQ y CTA para incluir integracion YouTube + metadata IA, audio editor y biblioteca de audios.
+- Se cambio la variante `light` a paleta Catppuccin Macchiato en `frontend/src/app/globals.css`, ajustando tokens base (`night`, `neon`, texto, bordes, sombras y logo) para evaluar un look mas consistente con el resto del dashboard.
+- Se limpiaron overrides globales agresivos del modo light (`text-white/*`, `bg-night-*`, placeholders y variantes rose) que estaban forzando colores fuera de la paleta y generaban contraste irregular.
+- Se reforzo SEO tecnico base en `frontend/src/app/layout.tsx` con `metadataBase`, canonical, Open Graph, Twitter cards y robots global.
+- Se agregaron `frontend/src/app/robots.ts` y `frontend/src/app/sitemap.ts` para exponer reglas de rastreo e indice XML.
+- Se agrego control de indexacion para secciones privadas (`/app` y `/auth`) mediante `head.tsx` dedicados con `noindex,nofollow`.
 
 ### Commits de esta rama (frontend)
 
 - `feat(frontend): refresh landing to reflect full production workflow`
 - `docs(frontend): log landing production refresh updates`
+- `style(frontend): switch light theme to catppuccin macchiato and simplify overrides`
+- `feat(frontend): add metadata, robots and sitemap for seo baseline`
+- `docs(frontend): log macchiato light theme and seo baseline updates`
 
 ### Validaciones locales
 

--- a/frontend/src/app/app/head.tsx
+++ b/frontend/src/app/app/head.tsx
@@ -1,0 +1,8 @@
+export default function Head() {
+  return (
+    <>
+      <meta name="robots" content="noindex,nofollow" />
+      <meta name="googlebot" content="noindex,nofollow" />
+    </>
+  );
+}

--- a/frontend/src/app/auth/head.tsx
+++ b/frontend/src/app/auth/head.tsx
@@ -1,0 +1,8 @@
+export default function Head() {
+  return (
+    <>
+      <meta name="robots" content="noindex,nofollow" />
+      <meta name="googlebot" content="noindex,nofollow" />
+    </>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -80,30 +80,30 @@
 }
 
 html.light {
-  --hc-night-950: #eff1f5;
-  --hc-night-900: #e6e9ef;
-  --hc-night-800: #dce0e8;
-  --hc-night-700: #ccd0da;
+  --hc-night-950: #181926;
+  --hc-night-900: #1e2030;
+  --hc-night-800: #24273a;
+  --hc-night-700: #363a4f;
 
-  --hc-neon-cyan: #04a5e5;
-  --hc-neon-magenta: #ea76cb;
-  --hc-neon-violet: #8839ef;
-  --hc-neon-mint: #40a02b;
+  --hc-neon-cyan: #91d7e3;
+  --hc-neon-magenta: #f5bde6;
+  --hc-neon-violet: #c6a0f6;
+  --hc-neon-mint: #a6da95;
 
-  --hc-text-strong: #4c4f69;
-  --hc-text-soft: #5c5f77;
-  --hc-border-soft: rgba(76, 79, 105, 0.25);
-  --hc-panel-veil: rgba(220, 224, 232, 0.72);
-  --hc-shadow-glow: 0 10px 35px rgba(4, 165, 229, 0.24);
-  --hc-shadow-panel: 0 22px 55px rgba(140, 143, 161, 0.3);
+  --hc-text-strong: #cad3f5;
+  --hc-text-soft: #b8c0e0;
+  --hc-border-soft: rgba(184, 192, 224, 0.28);
+  --hc-panel-veil: rgba(24, 25, 38, 0.7);
+  --hc-shadow-glow: 0 10px 35px rgba(145, 215, 227, 0.24);
+  --hc-shadow-panel: 0 22px 55px rgba(24, 25, 38, 0.52);
 
-  --hc-logo-a-start: #1e66f5;
-  --hc-logo-a-mid: #04a5e5;
-  --hc-logo-a-end: #8839ef;
-  --hc-logo-b-start: #d20f39;
-  --hc-logo-b-mid: #04a5e5;
-  --hc-logo-b-end: #40a02b;
-  --hc-logo-node: #eff1f5;
+  --hc-logo-a-start: #8aadf4;
+  --hc-logo-a-mid: #91d7e3;
+  --hc-logo-a-end: #c6a0f6;
+  --hc-logo-b-start: #ed8796;
+  --hc-logo-b-mid: #91d7e3;
+  --hc-logo-b-end: #a6da95;
+  --hc-logo-node: #24273a;
 }
 
 * {
@@ -135,95 +135,4 @@ body {
     radial-gradient(circle at 50% 90%, color-mix(in srgb, var(--hc-neon-cyan) 24%, transparent), transparent 48%),
     var(--hc-night-950);
   color: var(--hc-text-strong);
-}
-
-html.light .text-white {
-  color: rgb(76 79 105 / 1);
-}
-
-html.light .text-white\/90 {
-  color: rgb(76 79 105 / 0.9);
-}
-
-html.light .text-white\/85,
-html.light .text-white\/80,
-html.light .text-white\/78,
-html.light .text-white\/75,
-html.light .text-white\/72,
-html.light .text-white\/70,
-html.light .text-white\/65,
-html.light .text-white\/60,
-html.light .text-white\/55 {
-  color: rgb(92 95 119 / 0.95);
-}
-
-html.light .border-white\/20,
-html.light .border-white\/15,
-html.light .border-white\/12,
-html.light .border-white\/10 {
-  border-color: var(--hc-border-soft);
-}
-
-html.light .bg-white\/10,
-html.light .bg-white\/5 {
-  background-color: rgb(76 79 105 / 0.08);
-}
-
-html.light .bg-night-900\/90,
-html.light .bg-night-900\/70,
-html.light .bg-night-900\/60,
-html.light .bg-night-900\/55,
-html.light .bg-night-900\/50,
-html.light .bg-night-900\/45,
-html.light .bg-night-800\/80,
-html.light .bg-night-800\/70,
-html.light .bg-night-800\/65,
-html.light .bg-night-800\/55,
-html.light .bg-night-800\/45 {
-  background-color: color-mix(in srgb, var(--hc-night-800) 75%, transparent);
-}
-
-html.light .shadow-panel {
-  box-shadow: var(--hc-shadow-panel);
-}
-
-html.light .text-rose-200,
-html.light .text-rose-300 {
-  color: rgb(159 18 57 / 0.95);
-}
-
-html.light .border-rose-400\/35 {
-  border-color: rgb(244 63 94 / 0.45);
-}
-
-html.light .border-rose-300\/45 {
-  border-color: rgb(244 114 182 / 0.45);
-}
-
-html.light .bg-rose-400\/10 {
-  background-color: rgb(251 113 133 / 0.16);
-}
-
-html.light .bg-rose-300\/10 {
-  background-color: rgb(249 168 212 / 0.2);
-}
-
-html.light .logout-btn {
-  color: rgb(159 18 57 / 0.95);
-  border-color: rgb(244 63 94 / 0.45);
-  background-color: rgb(251 113 133 / 0.16);
-}
-
-html.light .logout-btn:hover {
-  background-color: rgb(251 113 133 / 0.24);
-}
-
-html.light input::placeholder,
-html.light textarea::placeholder {
-  color: rgb(92 95 119 / 0.55);
-}
-
-html.light input[class*="placeholder:text-white/35"]::placeholder,
-html.light textarea[class*="placeholder:text-white/35"]::placeholder {
-  color: rgb(92 95 119 / 0.55);
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -80,30 +80,30 @@
 }
 
 html.light {
-  --hc-night-950: #181926;
-  --hc-night-900: #1e2030;
-  --hc-night-800: #24273a;
-  --hc-night-700: #363a4f;
+  --hc-night-950: #eff1f5;
+  --hc-night-900: #e6e9ef;
+  --hc-night-800: #dce0e8;
+  --hc-night-700: #ccd0da;
 
-  --hc-neon-cyan: #91d7e3;
-  --hc-neon-magenta: #f5bde6;
-  --hc-neon-violet: #c6a0f6;
-  --hc-neon-mint: #a6da95;
+  --hc-neon-cyan: #04a5e5;
+  --hc-neon-magenta: #ea76cb;
+  --hc-neon-violet: #8839ef;
+  --hc-neon-mint: #40a02b;
 
-  --hc-text-strong: #cad3f5;
-  --hc-text-soft: #b8c0e0;
-  --hc-border-soft: rgba(184, 192, 224, 0.28);
-  --hc-panel-veil: rgba(24, 25, 38, 0.7);
-  --hc-shadow-glow: 0 10px 35px rgba(145, 215, 227, 0.24);
-  --hc-shadow-panel: 0 22px 55px rgba(24, 25, 38, 0.52);
+  --hc-text-strong: #4c4f69;
+  --hc-text-soft: #5c5f77;
+  --hc-border-soft: rgba(76, 79, 105, 0.25);
+  --hc-panel-veil: rgba(220, 224, 232, 0.72);
+  --hc-shadow-glow: 0 10px 35px rgba(4, 165, 229, 0.24);
+  --hc-shadow-panel: 0 22px 55px rgba(140, 143, 161, 0.3);
 
-  --hc-logo-a-start: #8aadf4;
-  --hc-logo-a-mid: #91d7e3;
-  --hc-logo-a-end: #c6a0f6;
-  --hc-logo-b-start: #ed8796;
-  --hc-logo-b-mid: #91d7e3;
-  --hc-logo-b-end: #a6da95;
-  --hc-logo-node: #24273a;
+  --hc-logo-a-start: #1e66f5;
+  --hc-logo-a-mid: #04a5e5;
+  --hc-logo-a-end: #8839ef;
+  --hc-logo-b-start: #d20f39;
+  --hc-logo-b-mid: #04a5e5;
+  --hc-logo-b-end: #40a02b;
+  --hc-logo-node: #eff1f5;
 }
 
 * {
@@ -135,4 +135,77 @@ body {
     radial-gradient(circle at 50% 90%, color-mix(in srgb, var(--hc-neon-cyan) 24%, transparent), transparent 48%),
     var(--hc-night-950);
   color: var(--hc-text-strong);
+}
+
+html.light .text-white,
+html.light [class~="text-white"],
+html.light [class*="text-white/"] {
+  color: rgb(76 79 105 / 0.94) !important;
+}
+
+html.light [class*="text-white/55"],
+html.light [class*="text-white/50"],
+html.light [class*="text-white/45"] {
+  color: rgb(92 95 119 / 0.9) !important;
+}
+
+html.light .border-white\/20,
+html.light .border-white\/15,
+html.light .border-white\/12,
+html.light .border-white\/10 {
+  border-color: var(--hc-border-soft) !important;
+}
+
+html.light .bg-white\/10,
+html.light .bg-white\/5 {
+  background-color: rgb(76 79 105 / 0.08) !important;
+}
+
+html.light .bg-night-900\/90,
+html.light .bg-night-900\/80,
+html.light .bg-night-900\/70,
+html.light .bg-night-900\/60,
+html.light .bg-night-900\/55,
+html.light .bg-night-900\/50,
+html.light .bg-night-900\/45,
+html.light .bg-night-800\/80,
+html.light .bg-night-800\/70,
+html.light .bg-night-800\/65,
+html.light .bg-night-800\/55,
+html.light .bg-night-800\/45 {
+  background-color: color-mix(in srgb, var(--hc-night-800) 76%, transparent);
+}
+
+html.light .shadow-panel {
+  box-shadow: var(--hc-shadow-panel);
+}
+
+html.light .text-rose-200,
+html.light .text-rose-300 {
+  color: rgb(159 18 57 / 0.95);
+}
+
+html.light .border-rose-400\/35 {
+  border-color: rgb(244 63 94 / 0.45);
+}
+
+html.light .bg-rose-400\/10 {
+  background-color: rgb(251 113 133 / 0.16);
+}
+
+html.light .logout-btn {
+  color: rgb(159 18 57 / 0.95);
+  border-color: rgb(244 63 94 / 0.45);
+  background-color: rgb(251 113 133 / 0.16);
+}
+
+html.light .logout-btn:hover {
+  background-color: rgb(251 113 133 / 0.24);
+}
+
+html.light input::placeholder,
+html.light textarea::placeholder,
+html.light input[class*="placeholder:text-white/35"]::placeholder,
+html.light textarea[class*="placeholder:text-white/35"]::placeholder {
+  color: rgb(92 95 119 / 0.68);
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,9 +5,62 @@ import { ThemeProvider } from "@/src/components/theme/ThemeProvider";
 import { ThemeToggle } from "@/src/components/theme/ThemeToggle";
 import "./globals.css";
 
+function resolveMetadataBase() {
+  const fallbackUrl = "http://localhost:3000";
+  const configuredUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+
+  if (!configuredUrl) {
+    return new URL(fallbackUrl);
+  }
+
+  try {
+    return new URL(configuredUrl);
+  } catch {
+    return new URL(fallbackUrl);
+  }
+}
+
+const metadataBase = resolveMetadataBase();
+
 export const metadata: Metadata = {
-  title: "Hacelo Corto",
-  description: "Landing publica del equipo frontend",
+  metadataBase,
+  title: {
+    default: "Hacelo Corto | Convierte videos largos en shorts",
+    template: "%s | Hacelo Corto"
+  },
+  description:
+    "Convierte videos largos en shorts listos para publicar: upload, recorte en timeline, edicion de audio, biblioteca y exportacion desde una sola app.",
+  alternates: {
+    canonical: "/"
+  },
+  robots: {
+    index: true,
+    follow: true
+  },
+  openGraph: {
+    type: "website",
+    locale: "es_AR",
+    url: "/",
+    siteName: "Hacelo Corto",
+    title: "Hacelo Corto | Convierte videos largos en shorts",
+    description:
+      "Plataforma web para crear shorts desde videos largos con recorte inteligente, timeline manual, audio editor y exportacion.",
+    images: [
+      {
+        url: "/icon.svg",
+        width: 512,
+        height: 512,
+        alt: "Logo de Hacelo Corto"
+      }
+    ]
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Hacelo Corto | Convierte videos largos en shorts",
+    description:
+      "Upload, recorte, audio y exportacion en una sola app para creadores que publican shorts.",
+    images: ["/icon.svg"]
+  },
   icons: {
     icon: "/icon.svg"
   }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -47,10 +47,10 @@ export const metadata: Metadata = {
       "Plataforma web para crear shorts desde videos largos con recorte inteligente, timeline manual, audio editor y exportacion.",
     images: [
       {
-        url: "/icon.svg",
-        width: 512,
-        height: 512,
-        alt: "Logo de Hacelo Corto"
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Hacelo Corto - Convierte videos largos en shorts"
       }
     ]
   },
@@ -59,7 +59,7 @@ export const metadata: Metadata = {
     title: "Hacelo Corto | Convierte videos largos en shorts",
     description:
       "Upload, recorte, audio y exportacion en una sola app para creadores que publican shorts.",
-    images: ["/icon.svg"]
+    images: ["/twitter-image"]
   },
   icons: {
     icon: "/icon.svg"

--- a/frontend/src/app/opengraph-image.tsx
+++ b/frontend/src/app/opengraph-image.tsx
@@ -1,0 +1,53 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 1200,
+  height: 630
+};
+
+export const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "56px",
+          background:
+            "radial-gradient(circle at 15% 20%, rgba(4,165,229,0.35), transparent 35%), radial-gradient(circle at 85% 15%, rgba(234,118,203,0.3), transparent 32%), linear-gradient(135deg, #eff1f5 0%, #dce0e8 100%)",
+          color: "#4c4f69",
+          fontFamily: "Segoe UI"
+        }}
+      >
+        <div
+          style={{
+            border: "1px solid rgba(76,79,105,0.22)",
+            borderRadius: "999px",
+            padding: "10px 18px",
+            fontSize: 24,
+            fontWeight: 600
+          }}
+        >
+          Hacelo Corto
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "18px", maxWidth: "920px" }}>
+          <div style={{ fontSize: 70, fontWeight: 700, lineHeight: 1.05 }}>
+            Convierte videos largos en shorts listos para publicar
+          </div>
+          <div style={{ fontSize: 34, color: "#5c5f77", lineHeight: 1.25 }}>
+            Upload, recorte en timeline, audio editor, biblioteca y exportacion en una sola app web.
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size
+    }
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,35 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { HaceloCortoLogo } from "@/src/components/branding/HaceloCortoLogo";
+
+export const metadata: Metadata = {
+  title: "Convierte videos largos en shorts listos para publicar",
+  description:
+    "Transforma videos largos en shorts para redes: recorte automatico, timeline manual, editor de audio, biblioteca y exportacion desde una sola app web.",
+  alternates: {
+    canonical: "/"
+  },
+  openGraph: {
+    title: "Hacelo Corto | Convierte videos largos en shorts",
+    description:
+      "Recorta, edita y exporta clips para redes sociales en minutos con un flujo web completo.",
+    url: "/",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Hacelo Corto - App web para crear shorts"
+      }
+    ]
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Hacelo Corto | Convierte videos largos en shorts",
+    description: "App web para crear shorts con upload, timeline, audio y exportacion.",
+    images: ["/twitter-image"]
+  }
+};
 
 export default function HomePage() {
   const snapshot = [

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next";
+
+function resolveSiteOrigin() {
+  const fallbackUrl = "http://localhost:3000";
+  const configuredUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+
+  if (!configuredUrl) {
+    return new URL(fallbackUrl).origin;
+  }
+
+  try {
+    return new URL(configuredUrl).origin;
+  } catch {
+    return new URL(fallbackUrl).origin;
+  }
+}
+
+export default function robots(): MetadataRoute.Robots {
+  const siteOrigin = resolveSiteOrigin();
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/app", "/app/", "/auth", "/auth/"]
+      }
+    ],
+    sitemap: [`${siteOrigin}/sitemap.xml`],
+    host: siteOrigin
+  };
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next";
+
+function resolveSiteOrigin() {
+  const fallbackUrl = "http://localhost:3000";
+  const configuredUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+
+  if (!configuredUrl) {
+    return new URL(fallbackUrl).origin;
+  }
+
+  try {
+    return new URL(configuredUrl).origin;
+  } catch {
+    return new URL(fallbackUrl).origin;
+  }
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const siteOrigin = resolveSiteOrigin();
+
+  return [
+    {
+      url: `${siteOrigin}/`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1
+    }
+  ];
+}

--- a/frontend/src/app/twitter-image.tsx
+++ b/frontend/src/app/twitter-image.tsx
@@ -1,0 +1,41 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 1200,
+  height: 630
+};
+
+export const contentType = "image/png";
+
+export default function TwitterImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          gap: "20px",
+          padding: "64px",
+          background:
+            "radial-gradient(circle at 80% 15%, rgba(136,57,239,0.24), transparent 35%), linear-gradient(160deg, #eff1f5 0%, #e6e9ef 100%)",
+          color: "#4c4f69",
+          fontFamily: "Segoe UI"
+        }}
+      >
+        <div style={{ fontSize: 28, fontWeight: 600, color: "#1e66f5" }}>Hacelo Corto</div>
+        <div style={{ fontSize: 72, fontWeight: 700, lineHeight: 1.05, maxWidth: "960px" }}>
+          Crea shorts desde videos largos en minutos
+        </div>
+        <div style={{ fontSize: 34, color: "#5c5f77", maxWidth: "860px" }}>
+          Flujo completo: upload, timeline, audio y exportacion.
+        </div>
+      </div>
+    ),
+    {
+      ...size
+    }
+  );
+}


### PR DESCRIPTION
# Frontend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feat/frontend-light-latte-seo-hardening`

### Objetivo

Actualizar la landing para reflejar el alcance real actual de la app web, mostrar demos/capturas nuevas del flujo productivo y alinear el discurso a estado operativo (sin mensajes de preproduccion).

### Cambios implementados en curso

- Se refactorizo `frontend/src/app/page.tsx` para reposicionar la propuesta de valor: flujo completo `upload -> jobs -> timeline -> audio editor -> biblioteca -> exportacion -> compartir`.
- Se removieron textos de etapa temprana (ej. "Estado real", "produccion interna", "preparacion") para dejar una narrativa alineada al uso actual del producto.
- Se corrigio la tarjeta de demo 02 para que represente `Entrevista` (antes figuraba como Deportes con archivo de entrevista).
- Se ampliaron demos de landing con assets reales en `frontend/public/landing-demos/`: `video4_generando_texto_hastag_IA.mp4`, `video5_subida_audio.mp4`, `video6_añade_audio_a_video.mp4`, `home_desktop.png`, `home_movile.png`.
- Se actualizo `DemoSlot` para renderizar tanto videos como imagenes (capturas) dentro de la misma grilla responsive.
- Se removieron las capturas `home_desktop.png` y `home_movile.png` de la grilla de landing por ruido visual.
- Se separaron `Timeline` y `Audio Editor` en una seccion destacada con layout en dos columnas y reproduccion automatica (`autoplay + muted + loop`) para mostrar ambos flujos lado a lado.
- Se incorporo base de theming claro/oscuro en todo el frontend con `ThemeProvider` + toggle global persistido en `localStorage` (`hc-theme`).
- Se migraron tokens globales de `frontend/src/app/globals.css` a variables CSS para soportar Catppuccin Mocha (dark) y Latte (light) sin romper la paleta principal del producto.
- Se ajusto contraste del modo light en acciones criticas (ej. boton `Cerrar sesion`) y mensajes de error en tonos rose para mejorar legibilidad sobre fondos claros.
- Se ajusto paleta del `HaceloCortoLogo` para modo light usando variables CSS dedicadas, mejorando contraste del isotipo y gradientes en navbar/landing.
- QA final light mode: se reforzaron variantes `rose-300/rose-400` (texto/borde/fondo) y placeholders para evitar combinaciones de bajo contraste en auth, alerts y acciones destructivas.
- Se ajustaron FAQ y CTA para incluir integracion YouTube + metadata IA, audio editor y biblioteca de audios.
- Se cambio la variante `light` a paleta Catppuccin Macchiato en `frontend/src/app/globals.css`, ajustando tokens base (`night`, `neon`, texto, bordes, sombras y logo) para evaluar un look mas consistente con el resto del dashboard.
- Se limpiaron overrides globales agresivos del modo light (`text-white/*`, `bg-night-*`, placeholders y variantes rose) que estaban forzando colores fuera de la paleta y generaban contraste irregular.
- Se descarto el experimento Macchiato para light y se restauro Catppuccin Latte en `frontend/src/app/globals.css`, manteniendo el modo claro realmente claro.
- Se reforzaron overrides de contraste para light (`text-white*`, `border-white*`, `bg-white*`, placeholders y `logout-btn`) para evitar texto blanco sobre fondos claros en auth y dashboard.
- Se reforzo SEO tecnico base en `frontend/src/app/layout.tsx` con `metadataBase`, canonical, Open Graph, Twitter cards y robots global.
- Se agregaron `frontend/src/app/robots.ts` y `frontend/src/app/sitemap.ts` para exponer reglas de rastreo e indice XML.
- Se agrego control de indexacion para secciones privadas (`/app` y `/auth`) mediante `head.tsx` dedicados con `noindex,nofollow`.
- Se agrego metadata especifica de Home en `frontend/src/app/page.tsx` para alinear title/description/OG con el objetivo SEO principal de la landing.
- Se reemplazo la imagen social generica por endpoints dedicados `frontend/src/app/opengraph-image.tsx` y `frontend/src/app/twitter-image.tsx` (1200x630) para previews consistentes al compartir.
- Se actualizo este worklog para dejar `feat/frontend-light-latte-seo-hardening` como rama activa vigente y mantener trazabilidad de los ultimos ajustes.

### Commits de esta rama (frontend)

- `feat(frontend): refresh landing to reflect full production workflow`
- `docs(frontend): log landing production refresh updates`
- `style(frontend): switch light theme to catppuccin macchiato and simplify overrides`
- `feat(frontend): add metadata, robots and sitemap for seo baseline`
- `docs(frontend): log macchiato light theme and seo baseline updates`
- `fix(frontend): restore latte light theme and enforce readable contrast`
- `feat(frontend): harden home seo metadata and social preview images`
- `docs(frontend): log latte light pass and seo image hardening updates`
- `docs(frontend): update active branch name in worklog`
- `feat: skills`

### Validaciones locales

- `npm run lint` -> OK
- `npm run build` -> OK