### PR TITLE
Feature/i18n multidioma

### DIFF
--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -29,6 +29,7 @@ Incorporar infraestructura de internacionalizacion en Next.js (es/en) y aplicar 
 - Se agrego limpieza de borradores de sesion al logout en `frontend/src/store/useAuthStore.ts` (Home, Timeline, Audio editor, Share metadata y estado OAuth temporal).
 - Se resolvio fallo de CI en `npm ci` sincronizando lockfile y fijando `@swc/helpers@0.5.19` en `frontend/package.json` + `frontend/package-lock.json`.
 - Se ajusto `frontend/src/components/home/videoEditAudioTimeLine/AudioTimeLine.tsx` para que la region sea realmente redimensionable y visible: `resize: true`, longitudes min/max coherentes con duracion de audio/video y cleanup correcto de `WaveSurfer`.
+- Se refactorizo `AudioTimeLine` para un look mas profesional y consistente con dark/light (altura mas contenida, barra mas limpia, resumen de tramo seleccionado y CTA de play compacto), corrigiendo ademas `AbortError` en cleanup (`ws.destroy`) con manejo seguro.
 
 ### Commits de esta rama (frontend)
 
@@ -40,6 +41,7 @@ Incorporar infraestructura de internacionalizacion en Next.js (es/en) y aplicar 
 - `fix(frontend): persist share metadata drafts and clear session artifacts on logout`
 - `fix(frontend): pin swc helpers and sync lockfile for ci`
 - `fix(frontend): make audio timeline region resizable and stable`
+- `fix(frontend): polish audio timeline ui and guard wavesurfer abort cleanup`
 - `docs(frontend): log i18n rollout for landing auth and shell`
 - `docs(frontend): update i18n worklog with app view translation batch`
 - `docs(frontend): log sidebar label localization adjustment`
@@ -49,6 +51,7 @@ Incorporar infraestructura de internacionalizacion en Next.js (es/en) y aplicar 
 - `docs(frontend): add smoke checklist for i18n share metadata flow`
 - `docs(frontend): log ci lockfile sync fix`
 - `docs(frontend): log audio timeline resize behavior fix`
+- `docs(frontend): log audio timeline ui polish and aborterror fix`
 
 ### Validaciones locales
 

--- a/docs/frontend-pr-log.md
+++ b/docs/frontend-pr-log.md
@@ -30,6 +30,7 @@ Incorporar infraestructura de internacionalizacion en Next.js (es/en) y aplicar 
 - Se resolvio fallo de CI en `npm ci` sincronizando lockfile y fijando `@swc/helpers@0.5.19` en `frontend/package.json` + `frontend/package-lock.json`.
 - Se ajusto `frontend/src/components/home/videoEditAudioTimeLine/AudioTimeLine.tsx` para que la region sea realmente redimensionable y visible: `resize: true`, longitudes min/max coherentes con duracion de audio/video y cleanup correcto de `WaveSurfer`.
 - Se refactorizo `AudioTimeLine` para un look mas profesional y consistente con dark/light (altura mas contenida, barra mas limpia, resumen de tramo seleccionado y CTA de play compacto), corrigiendo ademas `AbortError` en cleanup (`ws.destroy`) con manejo seguro.
+- Se reforzo el guard de cleanup en `AudioTimeLine` para no abortar render por errores de desmontaje de `WaveSurfer` (deteccion flexible de `AbortError` y warning no bloqueante para otros casos).
 
 ### Commits de esta rama (frontend)
 
@@ -42,6 +43,7 @@ Incorporar infraestructura de internacionalizacion en Next.js (es/en) y aplicar 
 - `fix(frontend): pin swc helpers and sync lockfile for ci`
 - `fix(frontend): make audio timeline region resizable and stable`
 - `fix(frontend): polish audio timeline ui and guard wavesurfer abort cleanup`
+- `fix(frontend): prevent audio timeline cleanup abort from crashing ui`
 - `docs(frontend): log i18n rollout for landing auth and shell`
 - `docs(frontend): update i18n worklog with app view translation batch`
 - `docs(frontend): log sidebar label localization adjustment`
@@ -52,6 +54,7 @@ Incorporar infraestructura de internacionalizacion en Next.js (es/en) y aplicar 
 - `docs(frontend): log ci lockfile sync fix`
 - `docs(frontend): log audio timeline resize behavior fix`
 - `docs(frontend): log audio timeline ui polish and aborterror fix`
+- `docs(frontend): log resilient cleanup guard for audio timeline`
 
 ### Validaciones locales
 

--- a/frontend/src/components/home/videoEditAudioTimeLine/AudioTimeLine.tsx
+++ b/frontend/src/components/home/videoEditAudioTimeLine/AudioTimeLine.tsx
@@ -36,6 +36,18 @@ function toRgbaFromHex(color: string, alpha: number) {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+function isAbortLikeError(error: unknown) {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+
+  if (error instanceof Error && error.name.toLowerCase() === "aborterror") {
+    return true;
+  }
+
+  return false;
+}
+
 export function AudioTimeLine({ videoDurationSec, selectedAudioUrl, regionChange }: PropTimeLine) {
   const wsRef = useRef<WaveSurfer | null>(null);
   const regionsRef = useRef<InstanceType<typeof RegionsPlugin> | null>(null);
@@ -82,8 +94,8 @@ export function AudioTimeLine({ videoDurationSec, selectedAudioUrl, regionChange
       try {
         ws.destroy();
       } catch (error) {
-        if (!(error instanceof DOMException && error.name === "AbortError")) {
-          throw error;
+        if (!isAbortLikeError(error)) {
+          console.warn("AudioTimeLine cleanup warning", error);
         }
       } finally {
         wsRef.current = null;

--- a/frontend/src/components/home/videoEditAudioTimeLine/AudioTimeLine.tsx
+++ b/frontend/src/components/home/videoEditAudioTimeLine/AudioTimeLine.tsx
@@ -1,128 +1,197 @@
-import { Pause, Play } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
-import WaveSurfer from "wavesurfer.js"
-import RegionsPlugin from "wavesurfer.js/dist/plugins/regions.esm.js"
+"use client";
+
+import { Pause, Play } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import WaveSurfer from "wavesurfer.js";
+import RegionsPlugin from "wavesurfer.js/dist/plugins/regions.esm.js";
 
 type PropTimeLine = {
-  videoDurationSec: number,
-  selectedAudioUrl: string | null,
-regionChange?: (start: number, end: number) => void
+  videoDurationSec: number;
+  selectedAudioUrl: string | null;
+  regionChange?: (start: number, end: number) => void;
+};
 
+function secondsToLabel(value: number) {
+  const safe = Math.max(0, Math.floor(value));
+  const minutes = Math.floor(safe / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = Math.floor(safe % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${minutes}:${seconds}`;
 }
-export function AudioTimeLine({
-  videoDurationSec,
-  selectedAudioUrl,
-  regionChange
-}: PropTimeLine) {
-  const wsRef = useRef<WaveSurfer | null>(null)
-  const regionsRef = useRef<InstanceType<typeof RegionsPlugin> | null>(null)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-    const [isPlaying, setIsPlaying] = useState(false);
-  
-const regionRef = useRef<ReturnType<
-  InstanceType<typeof RegionsPlugin>["addRegion"]
-> | null>(null)
-  // ✅ 1️⃣ Crear instancia SOLO una vez
+
+function toRgbaFromHex(color: string, alpha: number) {
+  const hex = color.trim();
+  const normalized = hex.startsWith("#") ? hex.slice(1) : hex;
+  const valid = normalized.length === 6;
+  if (!valid) {
+    return `rgba(137, 220, 235, ${alpha})`;
+  }
+
+  const r = Number.parseInt(normalized.slice(0, 2), 16);
+  const g = Number.parseInt(normalized.slice(2, 4), 16);
+  const b = Number.parseInt(normalized.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function AudioTimeLine({ videoDurationSec, selectedAudioUrl, regionChange }: PropTimeLine) {
+  const wsRef = useRef<WaveSurfer | null>(null);
+  const regionsRef = useRef<InstanceType<typeof RegionsPlugin> | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const regionRef = useRef<ReturnType<InstanceType<typeof RegionsPlugin>["addRegion"]> | null>(null);
+
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [selection, setSelection] = useState({ start: 0, end: 0 });
+
   useEffect(() => {
-    if (!containerRef.current) return
+    if (!containerRef.current) {
+      return;
+    }
 
-    // 🔥 limpiar contenedor SIEMPRE
-    containerRef.current.innerHTML = ""
+    containerRef.current.innerHTML = "";
+    const styles = getComputedStyle(document.documentElement);
+    const neonCyan = styles.getPropertyValue("--hc-neon-cyan") || "#89dceb";
+    const neonMagenta = styles.getPropertyValue("--hc-neon-magenta") || "#f5c2e7";
+    const neonViolet = styles.getPropertyValue("--hc-neon-violet") || "#cba6f7";
 
-    const regions = RegionsPlugin.create()
-
+    const regions = RegionsPlugin.create();
     const ws = WaveSurfer.create({
       container: containerRef.current,
-      waveColor: "rgb(200, 0, 200)",
-      progressColor: "rgb(100, 0, 100)",
-      plugins: [regions],
-    })
+      height: 72,
+      barWidth: 3,
+      barGap: 2,
+      barRadius: 999,
+      cursorWidth: 2,
+      normalize: true,
+      waveColor: toRgbaFromHex(neonCyan, 0.4),
+      progressColor: toRgbaFromHex(neonMagenta, 0.7),
+      cursorColor: toRgbaFromHex(neonViolet, 0.95),
+      plugins: [regions]
+    });
 
-    wsRef.current = ws
-    regionsRef.current = regions
+    ws.on("play", () => setIsPlaying(true));
+    ws.on("pause", () => setIsPlaying(false));
+    ws.on("finish", () => setIsPlaying(false));
+
+    wsRef.current = ws;
+    regionsRef.current = regions;
 
     return () => {
-      ws.destroy()
-      wsRef.current = null
-      regionsRef.current = null
-    }
-  }, []) // 👈 solo una vez
+      try {
+        ws.destroy();
+      } catch (error) {
+        if (!(error instanceof DOMException && error.name === "AbortError")) {
+          throw error;
+        }
+      } finally {
+        wsRef.current = null;
+        regionsRef.current = null;
+        regionRef.current = null;
+      }
+    };
+  }, []);
 
-  // ✅ 2️⃣ Cargar audio cuando cambia
   useEffect(() => {
-    if (!wsRef.current) return
-    if (!selectedAudioUrl) return
+    const ws = wsRef.current;
+    const regions = regionsRef.current;
 
-    const ws = wsRef.current
+    if (!ws || !regions || !selectedAudioUrl) {
+      return;
+    }
 
-    ws.load(selectedAudioUrl)
+    let cancelled = false;
+    ws.stop();
+    setIsPlaying(false);
+    ws.load(selectedAudioUrl);
 
     ws.once("ready", () => {
-      const audioDuration = ws.getDuration()
-      if (!Number.isFinite(audioDuration) || audioDuration <= 0) {
-        return
+      if (cancelled) {
+        return;
       }
 
-      regionsRef.current?.clearRegions()
+      const audioDuration = ws.getDuration();
+      if (!Number.isFinite(audioDuration) || audioDuration <= 0) {
+        return;
+      }
 
-      const maxRegionLength = Math.max(Math.min(videoDurationSec, audioDuration), 0.5)
-      const minRegionLength = Math.min(5, maxRegionLength)
+      regions.clearRegions();
+      const maxRegionLength = Math.max(Math.min(videoDurationSec, audioDuration), 0.5);
+      const minRegionLength = Math.min(5, maxRegionLength);
 
-      const region =regionsRef.current?.addRegion({
+      const region = regions.addRegion({
         start: 0,
         end: maxRegionLength,
         minLength: minRegionLength,
         maxLength: maxRegionLength,
-        content: "Selecciona tramo",
-        color: "rgba(180, 120, 255, 0.25)",
+        color: "rgba(203, 166, 247, 0.25)",
         drag: true,
-        resize: true,
-      })
-      if(region){
-        regionRef.current = region
+        resize: true
+      });
 
-      }
-      // 🔥 Escuchar cuando el usuario termina de mover
-      region?.on("update-end", () => {
-        const { start, end } = region
-        regionChange?.(Math.floor(start),Math.floor( end))
-      })
+      regionRef.current = region;
+      const nextStart = Math.floor(region.start);
+      const nextEnd = Math.floor(region.end);
+      setSelection({ start: nextStart, end: nextEnd });
+      regionChange?.(nextStart, nextEnd);
 
-      regionChange?.(0, Math.floor(maxRegionLength))
-    })
-  }, [selectedAudioUrl,videoDurationSec,regionChange]) 
- const playRegion = () => {
-    // const regions = regionsRef.current?.getRegions()
-    // const firstRegion = regions ? Object.values(regions)[0] : null
-  const ws = wsRef.current
+      region.on("update-end", () => {
+        if (cancelled) {
+          return;
+        }
+        const start = Math.floor(region.start);
+        const end = Math.floor(region.end);
+        setSelection({ start, end });
+        regionChange?.(start, end);
+      });
+    });
 
-    if (ws?.isPlaying()) {
-        setIsPlaying(false)
-    ws.pause()
-  } else {
-    setIsPlaying(true)
-    ws?.play(
-      regionRef.current?.start,
-      regionRef.current?.end
-    )
-  }
-  }
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAudioUrl, videoDurationSec, regionChange]);
+
+  const playRegion = () => {
+    const ws = wsRef.current;
+    const region = regionRef.current;
+
+    if (!ws || !region) {
+      return;
+    }
+
+    if (ws.isPlaying()) {
+      ws.pause();
+      return;
+    }
+
+    ws.play(region.start, region.end);
+  };
 
   return (
-    <div>
+    <div className="mt-4 rounded-xl border border-white/12 bg-white/5 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11px] uppercase tracking-[0.14em] text-neon-violet/90">Seleccion de audio</p>
+        <p className="text-[11px] text-white/70">
+          {secondsToLabel(selection.start)} - {secondsToLabel(selection.end)}
+        </p>
+      </div>
+
+      <div className="mt-2 overflow-hidden rounded-lg border border-white/10 bg-night-900/70 px-2 py-2">
         <div ref={containerRef} />
-      
-            {/* <button onClick={playRegion}>Play selección</button> */}
-            
+      </div>
+
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <p className="text-[11px] text-white/60">Arrastra y redimensiona la region para elegir el tramo.</p>
         <button
           type="button"
-         onClick={playRegion}
-          className="inline-flex h-10 w-10 items-center justify-center self-center rounded-full border border-neon-violet/45 bg-neon-violet/15 text-neon-violet transition hover:bg-neon-violet/25"
+          onClick={playRegion}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-neon-violet/45 bg-neon-violet/15 text-neon-violet transition hover:bg-neon-violet/25"
           aria-label={isPlaying ? "Pausar audio" : "Reproducir audio"}
         >
-          {isPlaying ? <Pause size={16} /> : <Play size={16} className="ml-0.5" />}
+          {isPlaying ? <Pause size={15} /> : <Play size={15} className="ml-0.5" />}
         </button>
-        
+      </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
# Frontend PR Worklog

## Seguimiento activo (rama actual)

Rama de trabajo actual: `feature/i18n-multidioma`

## Cambios implementados en curso
- Se resolvio fallo de CI en `npm ci` sincronizando lockfile y fijando `@swc/helpers@0.5.19` en `frontend/package.json` + `frontend/package-lock.json`.
- Se ajusto `frontend/src/components/home/videoEditAudioTimeLine/AudioTimeLine.tsx` para que la region sea realmente redimensionable y visible: `resize: true`, longitudes min/max coherentes con duracion de audio/video y cleanup correcto de `WaveSurfer`.
- Se refactorizo `AudioTimeLine` para un look mas profesional y consistente con dark/light (altura mas contenida, barra mas limpia, resumen de tramo seleccionado y CTA de play compacto), corrigiendo ademas `AbortError` en cleanup (`ws.destroy`) con manejo seguro.
- Se reforzo el guard de cleanup en `AudioTimeLine` para no abortar render por errores de desmontaje de `WaveSurfer` (deteccion flexible de `AbortError` y warning no bloqueante para otros casos).

## Commits de esta rama (frontend)
- `docs(frontend): log ci lockfile sync fix`
- `docs(frontend): log audio timeline resize behavior fix`
- `docs(frontend): log audio timeline ui polish and aborterror fix`
- `docs(frontend): log resilient cleanup guard for audio timeline`

### Validaciones locales

- `npm run lint` -> OK
- `npm run test` -> OK
- `npm run build` -> OK
